### PR TITLE
Bugfix: TradeAllowanceCharges

### DIFF
--- a/ZUGFeRD/InvoiceDescriptorWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptorWriter.cs
@@ -220,7 +220,12 @@ namespace s2industries.ZUGFeRD
                     Writer.WriteAttributeString("currencyID", tradeAllowanceCharge.Currency.EnumToString());
                     Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount));
                     Writer.WriteEndElement();
-                    Writer.WriteElementString("ram:ActualAmount", _formatDecimal(tradeAllowanceCharge.Amount));
+                    
+                    Writer.WriteStartElement("ram:ActualAmount");
+                    Writer.WriteAttributeString("currencyID", tradeAllowanceCharge.Currency.EnumToString());
+                    Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 4));
+                    Writer.WriteEndElement();
+
 
                     _writeOptionalElementString(Writer, "ram:Reason", tradeAllowanceCharge.Reason);
 

--- a/ZUGFeRD/InvoiceDescriptorWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptorWriter.cs
@@ -212,7 +212,9 @@ namespace s2industries.ZUGFeRD
                 foreach (TradeAllowanceCharge tradeAllowanceCharge in this.Descriptor.TradeAllowanceCharges)
                 {
                     Writer.WriteStartElement("ram:SpecifiedTradeAllowanceCharge");
-                    Writer.WriteElementString("ram:ChargeIndicator", tradeAllowanceCharge.ChargeIndicator ? "true" : "false");
+                    Writer.WriteStartElement("ram:ChargeIndicator");
+                    Writer.WriteElementString("udt:Indicator", tradeAllowanceCharge.ChargeIndicator ? "true" : "false");
+                    Writer.WriteEndElement(); // !ram:ChargeIndicator
 
                     Writer.WriteStartElement("ram:BasisAmount");
                     Writer.WriteAttributeString("currencyID", tradeAllowanceCharge.Currency.EnumToString());


### PR DESCRIPTION
Ich bin auf ein paar kleine Fehler gestoßen.
Zum einen war ein Indicator noch im alten Format und zum anderen fehlte die Currency bei einem Amount Feld welches mit zu wenig Nachkommastellen geliefert wurde.