### PR TITLE
ActualDeliveryDate in TradeLineItems hinzugefügt

### DIFF
--- a/ZUGFeRD/InvoiceDescriptorReader.cs
+++ b/ZUGFeRD/InvoiceDescriptorReader.cs
@@ -285,6 +285,11 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime", nsmgr) != null)
+            {
+                item.ActualDeliveryDate = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
+            }
+
             if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:ID", nsmgr) != null)
             {
                 item.ContractReferencedDocument = new ContractReferencedDocument()

--- a/ZUGFeRD/InvoiceDescriptorWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptorWriter.cs
@@ -465,6 +465,18 @@ namespace s2industries.ZUGFeRD
                     Writer.WriteEndElement(); // !ram:DeliveryNoteReferencedDocument
                 }
 
+                if (tradeLineItem.ActualDeliveryDate.HasValue)
+                {
+                    Writer.WriteStartElement("ram:ActualDeliverySupplyChainEvent");
+                    Writer.WriteStartElement("ram:OccurrenceDateTime");
+                    Writer.WriteStartElement("udt:DateTimeString");
+                    Writer.WriteAttributeString("format", "102");
+                    Writer.WriteValue(_formatDate(tradeLineItem.ActualDeliveryDate.Value));
+                    Writer.WriteEndElement(); // "udt:DateTimeString
+                    Writer.WriteEndElement(); // !OccurrenceDateTime()
+                    Writer.WriteEndElement(); // !ActualDeliverySupplyChainEvent
+                }
+
                 Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeDelivery
 
                 Writer.WriteStartElement("ram:SpecifiedSupplyChainTradeSettlement");

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -40,6 +40,7 @@ namespace s2industries.ZUGFeRD
         public decimal GrossUnitPrice { get; set; }
         public QuantityCodes UnitCode { get; set; }
         public AssociatedDocument AssociatedDocument { get; set; }
+        public DateTime? ActualDeliveryDate { get; set; }
         public BuyerOrderReferencedDocument BuyerOrderReferencedDocument { get; set; }
         public DeliveryNoteReferencedDocument DeliveryNoteReferencedDocument { get; set; }
         public ContractReferencedDocument ContractReferencedDocument { get; set; }


### PR DESCRIPTION
Bei den TradeLineItems hat noch das ActualDeliverySupplyChainEvent gefehlt.