### PR TITLE
Fixed reading and writing the creditor's bank name ...

### DIFF
--- a/ZUGFeRD-Test/Application.cs
+++ b/ZUGFeRD-Test/Application.cs
@@ -67,6 +67,7 @@ namespace ZUGFeRD_Test
 
             Assert.AreEqual(desc.Profile, Profile.Comfort);
             Assert.AreEqual(desc.Type, InvoiceType.Invoice);
+            Assert.AreEqual(desc.CreditorBankAccounts[0].BankName, "Hausbank München");
         } // !_loadZUGFeRDComfortRabatteInvoice()
 
 

--- a/ZUGFeRD/InvoiceDescriptorReader.cs
+++ b/ZUGFeRD/InvoiceDescriptorReader.cs
@@ -127,7 +127,7 @@ namespace s2industries.ZUGFeRD
                         IBAN = _nodeAsString(creditorFinancialAccountNodes[0], ".//ram:IBANID", nsmgr),
                         BIC = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:BICID", nsmgr),
                         Bankleitzahl = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:GermanBankleitzahlID", nsmgr),
-                        BankName = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:AccountName", nsmgr),
+                        BankName = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:Name", nsmgr),
                     };
 
                     retval.CreditorBankAccounts.Add(_account);

--- a/ZUGFeRD/InvoiceDescriptorWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptorWriter.cs
@@ -210,7 +210,7 @@ namespace s2industries.ZUGFeRD
 
                     if (!String.IsNullOrEmpty(account.BankName))
                     {
-                        Writer.WriteElementString("ram:AccountName", account.BankName);
+                        Writer.WriteElementString("ram:Name", account.BankName);
                     }
                     Writer.WriteEndElement(); // !PayeeSpecifiedCreditorFinancialInstitution
                 }


### PR DESCRIPTION
(tag PayeeSpecifiedCreditorFinancialInstitution of type CreditorFinancialInstitutionType)

Extended the assertions in _loadZUGFeRDComfortRabatteInvoice to compare the expected name of the creditor's bank with the actual one. This reveals a bug in InvoiceDescriptorReader (it also exists in InvoiceDescriptorWriter). While for "PayerSpecifiedDebtorFinancialInstitution" the name would be correctly read from the "Name" tag, "PayeeSpecifiedCreditorFinancialInstitution" incorrectly uses the "AccountName" (which by the way would be a valid but obviously unimportant tag for PayeePartyCreditorFinancialAccount). Fixed the InvoiceDescriptorReader and also the InvoiceDescriptorWriter (when the creditor's bank name was set, the generated XML was not valid according to the specification!).