### PR TITLE
Add optional parties ShipTo, ShipFrom, Invoicee, Payee

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -45,6 +45,10 @@ namespace s2industries.ZUGFeRD
         public Party Seller { get; set; }
         public Contact SellerContact { get; set; }
         public List<TaxRegistration> SellerTaxRegistration { get; set; }
+        public Party Invoicee { get; set; }
+        public Party ShipTo { get; set; }
+        public Party Payee { get; set; }
+        public Party ShipFrom { get; set; }
         public List<Note> Notes { get; set; }
 
         public bool IsTest { get; set; }

--- a/ZUGFeRD/InvoiceDescriptor1Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Reader.cs
@@ -103,6 +103,8 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
+            retval.ShipTo = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ShipToTradeParty", nsmgr);
+            retval.ShipFrom = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ShipFromTradeParty", nsmgr);
             retval.ActualDeliveryDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
 
             string _deliveryNoteNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID", nsmgr);
@@ -121,6 +123,9 @@ namespace s2industries.ZUGFeRD
                     IssueDateTime = _deliveryNoteDate
                 };
             }
+
+            retval.Invoicee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceeTradeParty", nsmgr);
+            retval.Payee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:PayeeTradeParty", nsmgr);
 
             retval.InvoiceNoAsReference = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:PaymentReference", nsmgr);
             retval.Currency = default(CurrencyCodes).FromString(_nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceCurrencyCode", nsmgr));

--- a/ZUGFeRD/InvoiceDescriptor1Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Reader.cs
@@ -578,6 +578,11 @@ namespace s2industries.ZUGFeRD
             }
 
             XmlNode node = baseNode.SelectSingleNode(xpath, nsmgr);
+            if (node == null)
+            {
+                return null;
+            }
+
             Party retval = new Party()
             {
                 ID = _nodeAsString(node, "ram:ID", nsmgr),

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -136,6 +136,13 @@ namespace s2industries.ZUGFeRD
             Writer.WriteEndElement(); // !ApplicableSupplyChainTradeAgreement
 
             Writer.WriteStartElement("ram:ApplicableSupplyChainTradeDelivery"); // Pflichteintrag
+
+            if (Descriptor.Profile == Profile.Extended)
+            {
+                _writeOptionalParty(Writer, "ram:ShipToTradeParty", this.Descriptor.ShipTo);
+                _writeOptionalParty(Writer, "ram:ShipFromTradeParty", this.Descriptor.ShipFrom);
+            }
+
             if (this.Descriptor.ActualDeliveryDate.HasValue)
             {
                 Writer.WriteStartElement("ram:ActualDeliverySupplyChainEvent");
@@ -166,6 +173,16 @@ namespace s2industries.ZUGFeRD
             Writer.WriteEndElement(); // !ApplicableSupplyChainTradeDelivery
 
             Writer.WriteStartElement("ram:ApplicableSupplyChainTradeSettlement");
+
+            if (Descriptor.Profile != Profile.Basic)
+            {
+                _writeOptionalParty(Writer, "ram:InvoiceeTradeParty", this.Descriptor.Invoicee);
+            }
+            if (Descriptor.Profile == Profile.Extended)
+            {
+                _writeOptionalParty(Writer, "ram:PayeeTradeParty", this.Descriptor.Payee);
+            }
+
             if (!String.IsNullOrEmpty(this.Descriptor.InvoiceNoAsReference))
             {
                 _writeOptionalElementString(Writer, "ram:PaymentReference", this.Descriptor.InvoiceNoAsReference);

--- a/ZUGFeRD/InvoiceDescriptor2Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor2Reader.cs
@@ -103,6 +103,8 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
+            retval.ShipTo = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ShipToTradeParty", nsmgr);
+            retval.ShipFrom = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ShipFromTradeParty", nsmgr);
             retval.ActualDeliveryDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
 
             string _deliveryNoteNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID", nsmgr);
@@ -121,6 +123,9 @@ namespace s2industries.ZUGFeRD
                     IssueDateTime = _deliveryNoteDate
                 };
             }
+
+            retval.Invoicee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceeTradeParty", nsmgr);
+            retval.Payee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:PayeeTradeParty", nsmgr);
 
             retval.InvoiceNoAsReference = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:PaymentReference", nsmgr);
             retval.Currency = default(CurrencyCodes).FromString(_nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceCurrencyCode", nsmgr));

--- a/ZUGFeRD/InvoiceDescriptor2Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor2Reader.cs
@@ -578,6 +578,11 @@ namespace s2industries.ZUGFeRD
             }
 
             XmlNode node = baseNode.SelectSingleNode(xpath, nsmgr);
+            if (node == null)
+            {
+                return null;
+            }
+
             Party retval = new Party()
             {
                 ID = _nodeAsString(node, "ram:ID", nsmgr),

--- a/ZUGFeRD/InvoiceDescriptor2Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor2Writer.cs
@@ -142,6 +142,13 @@ namespace s2industries.ZUGFeRD
             Writer.WriteEndElement(); // !ApplicableSupplyChainTradeAgreement
 
             Writer.WriteStartElement("ram:ApplicableSupplyChainTradeDelivery"); // Pflichteintrag
+
+            if (Descriptor.Profile == Profile.Extended)
+            {
+                _writeOptionalParty(Writer, "ram:ShipToTradeParty", this.Descriptor.ShipTo);
+                _writeOptionalParty(Writer, "ram:ShipFromTradeParty", this.Descriptor.ShipFrom);
+            }
+
             if (this.Descriptor.ActualDeliveryDate.HasValue)
             {
                 Writer.WriteStartElement("ram:ActualDeliverySupplyChainEvent");
@@ -172,6 +179,16 @@ namespace s2industries.ZUGFeRD
             Writer.WriteEndElement(); // !ApplicableSupplyChainTradeDelivery
 
             Writer.WriteStartElement("ram:ApplicableSupplyChainTradeSettlement");
+
+            if (Descriptor.Profile == Profile.Extended)
+            {
+                _writeOptionalParty(Writer, "ram:InvoiceeTradeParty", this.Descriptor.Invoicee);
+            }
+            if (Descriptor.Profile != Profile.Minimum)
+            {
+                _writeOptionalParty(Writer, "ram:PayeeTradeParty", this.Descriptor.Payee);
+            }
+
             if (!String.IsNullOrEmpty(this.Descriptor.InvoiceNoAsReference))
             {
                 _writeOptionalElementString(Writer, "ram:PaymentReference", this.Descriptor.InvoiceNoAsReference);


### PR DESCRIPTION
The profiling for ram:InvoiceeTradeParty and ram:PayeeTradeParty seems to be swapped for ZUGFeRD 2.0 compared to 1.0. Please confirm before merging.