### PR TITLE
Improve ZUGFeRD 2.0 writer

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -97,8 +97,8 @@ namespace s2industries.ZUGFeRD
              */
 
             #region SpecifiedSupplyChainTradeTransaction
-            Writer.WriteStartElement("rsm:SpecifiedSupplyChainTradeTransaction");
-            Writer.WriteStartElement("ram:ApplicableSupplyChainTradeAgreement");
+            Writer.WriteStartElement("rsm:SupplyChainTradeTransaction");
+            Writer.WriteStartElement("ram:ApplicableHeaderTradeAgreement");
             if (!String.IsNullOrEmpty(this.Descriptor.ReferenceOrderNo))
             {
                 Writer.WriteElementString("ram:BuyerReference", this.Descriptor.ReferenceOrderNo);
@@ -110,15 +110,6 @@ namespace s2industries.ZUGFeRD
             if (this.Descriptor.OrderDate.HasValue || ((this.Descriptor.OrderNo != null) && (this.Descriptor.OrderNo.Length > 0)))
             {
                 Writer.WriteStartElement("ram:BuyerOrderReferencedDocument");
-                if (this.Descriptor.OrderDate.HasValue)
-                {
-                    Writer.WriteStartElement("ram:FormattedIssueDateTime");
-                    Writer.WriteStartElement("udt:DateTimeString");
-                    Writer.WriteValue(_formatDate(this.Descriptor.OrderDate.Value, false));
-                    Writer.WriteEndElement(); // !udt:DateTimeString
-                    Writer.WriteEndElement(); // !FormattedIssueDateTime
-                }
-
                 Writer.WriteElementString("ram:IssuerAssignedID", this.Descriptor.OrderNo);
                 Writer.WriteEndElement(); // !BuyerOrderReferencedDocument
             }
@@ -148,7 +139,7 @@ namespace s2industries.ZUGFeRD
                 } // !foreach(document)
             }
 
-            Writer.WriteEndElement(); // !ApplicableSupplyChainTradeAgreement
+            Writer.WriteEndElement(); // !ApplicableHeaderTradeAgreement
 
             Writer.WriteStartElement("ram:ApplicableSupplyChainTradeDelivery"); // Pflichteintrag
 
@@ -471,11 +462,11 @@ namespace s2industries.ZUGFeRD
 
                     if (tradeLineItem.ContractReferencedDocument != null)
                     {
-                        Writer.WriteStartElement("ram:ContractReferencedDocument");
+                        Writer.WriteStartElement("ram:InvoiceReferencedDocument");
                         if (tradeLineItem.ContractReferencedDocument.IssueDateTime.HasValue)
                         {
                             Writer.WriteStartElement("ram:FormattedIssueDateTime");
-                            Writer.WriteValue(_formatDate(tradeLineItem.ContractReferencedDocument.IssueDateTime.Value, false));
+                            Writer.WriteValue(_formatDate(tradeLineItem.ContractReferencedDocument.IssueDateTime.Value, true));
                             Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
                         }
                         if (!String.IsNullOrEmpty(tradeLineItem.ContractReferencedDocument.ID))
@@ -483,7 +474,7 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteElementString("ram:IssuerAssignedID", tradeLineItem.ContractReferencedDocument.ID);
                         }
 
-                        Writer.WriteEndElement(); // !ram:ContractReferencedDocument
+                        Writer.WriteEndElement(); // !ram:InvoiceReferencedDocument
                     }
 
                     if (tradeLineItem.AdditionalReferencedDocuments != null)
@@ -659,7 +650,7 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteEndElement(); // !ram:IncludedSupplyChainTradeLineItem
             } // !foreach(tradeLineItem)
 
-            Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeTransaction
+            Writer.WriteEndElement(); // !ram:SupplyChainTradeTransaction
             #endregion
 
             Writer.WriteEndElement(); // !ram:Invoice

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -139,7 +139,7 @@ namespace s2industries.ZUGFeRD
 
             Writer.WriteEndElement(); // !ApplicableHeaderTradeAgreement
 
-            Writer.WriteStartElement("ram:ApplicableSupplyChainTradeDelivery"); // Pflichteintrag
+            Writer.WriteStartElement("ram:ApplicableHeaderTradeDelivery"); // Pflichteintrag
 
             if (Descriptor.Profile == Profile.Extended)
             {
@@ -174,9 +174,9 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteEndElement(); // !DeliveryNoteReferencedDocument
             }
 
-            Writer.WriteEndElement(); // !ApplicableSupplyChainTradeDelivery
+            Writer.WriteEndElement(); // !ApplicableHeaderTradeDelivery
 
-            Writer.WriteStartElement("ram:ApplicableSupplyChainTradeSettlement");
+            Writer.WriteStartElement("ram:ApplicableHeaderTradeSettlement");
 
             if (Descriptor.Profile == Profile.Extended)
             {
@@ -255,10 +255,6 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteElementString("ram:GermanBankleitzahlID", account.Bankleitzahl);
                     }
 
-                    if (!String.IsNullOrEmpty(account.BankName))
-                    {
-                        Writer.WriteElementString("ram:Name", account.BankName);
-                    }
                     Writer.WriteEndElement(); // !PayeeSpecifiedCreditorFinancialInstitution
                     Writer.WriteEndElement(); // !SpecifiedTradeSettlementPaymentMeans
                 }
@@ -352,7 +348,7 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteElementString("ram:TypeCode", tradeAllowanceCharge.Tax.TypeCode.EnumToString());
                         if (tradeAllowanceCharge.Tax.CategoryCode.HasValue)
                             Writer.WriteElementString("ram:CategoryCode", tradeAllowanceCharge.Tax.CategoryCode?.EnumToString());
-                        Writer.WriteElementString("ram:ApplicablePercent", _formatDecimal(tradeAllowanceCharge.Tax.Percent));
+                        Writer.WriteElementString("ram:RateApplicablePercent", _formatDecimal(tradeAllowanceCharge.Tax.Percent));
                         Writer.WriteEndElement();
                     }
                     Writer.WriteEndElement();
@@ -375,7 +371,7 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteElementString("ram:TypeCode", serviceCharge.Tax.TypeCode.EnumToString());
                         if (serviceCharge.Tax.CategoryCode.HasValue)
                             Writer.WriteElementString("ram:CategoryCode", serviceCharge.Tax.CategoryCode?.EnumToString());
-                        Writer.WriteElementString("ram:ApplicablePercent", _formatDecimal(serviceCharge.Tax.Percent));
+                        Writer.WriteElementString("ram:RateApplicablePercent", _formatDecimal(serviceCharge.Tax.Percent));
                         Writer.WriteEndElement();
                     }
                     Writer.WriteEndElement();
@@ -409,9 +405,9 @@ namespace s2industries.ZUGFeRD
             }
 
             _writeOptionalAmount(Writer, "ram:DuePayableAmount", this.Descriptor.DuePayableAmount);
-            Writer.WriteEndElement(); // !ram:SpecifiedTradeSettlementMonetarySummation
+            Writer.WriteEndElement(); // !ram:SpecifiedTradeSettlementHeaderMonetarySummation
 
-            Writer.WriteEndElement(); // !ram:ApplicableSupplyChainTradeSettlement
+            Writer.WriteEndElement(); // !ram:ApplicableHeaderTradeSettlement
 
             foreach (TradeLineItem tradeLineItem in this.Descriptor.TradeLineItems)
             {
@@ -437,7 +433,7 @@ namespace s2industries.ZUGFeRD
 
                 if (Descriptor.Profile != Profile.Basic)
                 {
-                    Writer.WriteStartElement("ram:SpecifiedSupplyChainTradeAgreement");
+                    Writer.WriteStartElement("ram:SpecifiedLineTradeAgreement");
 
                     if (tradeLineItem.BuyerOrderReferencedDocument != null)
                     {
@@ -536,12 +532,12 @@ namespace s2industries.ZUGFeRD
                     }
                     Writer.WriteEndElement(); // ram:NetPriceProductTradePrice
 
-                    Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeAgreement
+                    Writer.WriteEndElement(); // !ram:SpecifiedLineTradeAgreement
                 }
 
                 if (Descriptor.Profile != Profile.Basic)
                 {
-                    Writer.WriteStartElement("ram:SpecifiedSupplyChainTradeDelivery");
+                    Writer.WriteStartElement("ram:SpecifiedLineTradeDelivery");
                     _writeElementWithAttribute(Writer, "ram:BilledQuantity", "unitCode", tradeLineItem.UnitCode.EnumToString(), _formatDecimal(tradeLineItem.BilledQuantity, 4));
 
                     if (tradeLineItem.DeliveryNoteReferencedDocument != null)
@@ -573,23 +569,23 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteEndElement(); // !ActualDeliverySupplyChainEvent
                     }
 
-                    Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeDelivery
+                    Writer.WriteEndElement(); // !ram:SpecifiedLineTradeDelivery
                 }
                 else
                 {
-                    Writer.WriteStartElement("ram:SpecifiedSupplyChainTradeDelivery");
+                    Writer.WriteStartElement("ram:SpecifiedLineTradeDelivery");
                     _writeElementWithAttribute(Writer, "ram:BilledQuantity", "unitCode", tradeLineItem.UnitCode.EnumToString(), _formatDecimal(tradeLineItem.BilledQuantity, 4));
-                    Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeDelivery
+                    Writer.WriteEndElement(); // !ram:SpecifiedLineTradeDelivery
                 }
 
-                Writer.WriteStartElement("ram:SpecifiedSupplyChainTradeSettlement");
+                Writer.WriteStartElement("ram:SpecifiedLineTradeSettlement");
 
                 if (Descriptor.Profile != Profile.Basic)
                 {
                     Writer.WriteStartElement("ram:ApplicableTradeTax");
                     Writer.WriteElementString("ram:TypeCode", tradeLineItem.TaxType.EnumToString());
                     Writer.WriteElementString("ram:CategoryCode", tradeLineItem.TaxCategoryCode.EnumToString());
-                    Writer.WriteElementString("ram:ApplicablePercent", _formatDecimal(tradeLineItem.TaxPercent));
+                    Writer.WriteElementString("ram:RateApplicablePercent", _formatDecimal(tradeLineItem.TaxPercent));
                     Writer.WriteEndElement(); // !ram:ApplicableTradeTax
                 }
 
@@ -612,7 +608,7 @@ namespace s2industries.ZUGFeRD
                     Writer.WriteEndElement(); // !BillingSpecifiedPeriod
                 }
 
-                Writer.WriteStartElement("ram:SpecifiedTradeSettlementMonetarySummation");
+                Writer.WriteStartElement("ram:SpecifiedTradeSettlementLineMonetarySummation");
 
                 decimal _total = 0m;
 
@@ -628,8 +624,8 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteStartElement("ram:LineTotalAmount");
                 Writer.WriteValue(_formatDecimal(_total));
                 Writer.WriteEndElement(); // ram:LineTotalAmount
-                Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementMonetarySummation
-                Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeSettlement
+                Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementLineMonetarySummation
+                Writer.WriteEndElement(); // !ram:SpecifiedLineTradeSettlement
 
                 Writer.WriteStartElement("ram:SpecifiedTradeProduct");
                 if ((tradeLineItem.GlobalID != null) && !String.IsNullOrEmpty(tradeLineItem.GlobalID.SchemeID) && !String.IsNullOrEmpty(tradeLineItem.GlobalID.ID))
@@ -657,11 +653,15 @@ namespace s2industries.ZUGFeRD
         } // !Save()
 
 
-        private void _writeOptionalAmount(ProfileAwareXmlTextWriter writer, string tagName, decimal? value, int numDecimals = 2)
+        private void _writeOptionalAmount(ProfileAwareXmlTextWriter writer, string tagName, decimal? value, int numDecimals = 2, bool forceCurrency = false)
         {
             if (value.HasValue && (value.Value != decimal.MinValue))
             {
                 writer.WriteStartElement(tagName);
+                if (forceCurrency)
+                {
+                    writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
+                }
                 writer.WriteValue(_formatDecimal(value.Value, numDecimals));
                 writer.WriteEndElement(); // !tagName
             }
@@ -704,7 +704,7 @@ namespace s2industries.ZUGFeRD
                 {
                     writer.WriteElementString("ram:CategoryCode", tax.CategoryCode?.EnumToString());
                 }
-                writer.WriteElementString("ram:ApplicablePercent", _formatDecimal(tax.Percent));
+                writer.WriteElementString("ram:RateApplicablePercent", _formatDecimal(tax.Percent));
                 writer.WriteEndElement(); // !ApplicableTradeTax
             }
         } // !_writeOptionalTaxes()

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -343,6 +343,14 @@ namespace s2industries.ZUGFeRD
             if (this.Descriptor.OrderDate.HasValue || ((this.Descriptor.OrderNo != null) && (this.Descriptor.OrderNo.Length > 0)))
             {
                 Writer.WriteStartElement("ram:BuyerOrderReferencedDocument");
+                if (this.Descriptor.OrderDate.HasValue)
+                {
+                    Writer.WriteStartElement("ram:FormattedIssueDateTime");
+                    Writer.WriteStartElement("udt:DateTimeString");
+                    Writer.WriteValue(_formatDate(this.Descriptor.OrderDate.Value, false));
+                    Writer.WriteEndElement(); // !udt:DateTimeString	
+                    Writer.WriteEndElement(); // !FormattedIssueDateTime	
+                }
                 Writer.WriteElementString("ram:IssuerAssignedID", this.Descriptor.OrderNo);
                 Writer.WriteEndElement(); // !BuyerOrderReferencedDocument
             }

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -211,9 +211,11 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteEndElement(); // !ram:ChargeIndicator
 
                         Writer.WriteStartElement("ram:BasisAmount");
+                        Writer.WriteAttributeString("currencyID", tradeAllowanceCharge.Currency.EnumToString());
                         Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount, 4));
                         Writer.WriteEndElement();
                         Writer.WriteStartElement("ram:ActualAmount");
+                        Writer.WriteAttributeString("currencyID", tradeAllowanceCharge.Currency.EnumToString());
                         Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 4));
                         Writer.WriteEndElement();
 
@@ -322,9 +324,7 @@ namespace s2industries.ZUGFeRD
                     _total = tradeLineItem.NetUnitPrice * tradeLineItem.BilledQuantity;
                 }
 
-                Writer.WriteStartElement("ram:LineTotalAmount");
-                Writer.WriteValue(_formatDecimal(_total));
-                Writer.WriteEndElement(); // ram:LineTotalAmount
+                _writeElementWithAttribute(Writer, "ram:LineTotalAmount", "currencyID", this.Descriptor.Currency.EnumToString(), _formatDecimal(_total));
                 Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementLineMonetarySummation
                 Writer.WriteEndElement(); // !ram:SpecifiedLineTradeSettlement
 
@@ -567,11 +567,13 @@ namespace s2industries.ZUGFeRD
                     Writer.WriteEndElement(); // !ram:ChargeIndicator
 
                     Writer.WriteStartElement("ram:BasisAmount");
+                    Writer.WriteAttributeString("currencyID", tradeAllowanceCharge.Currency.EnumToString());
                     Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount));
                     Writer.WriteEndElement();
 
                     Writer.WriteStartElement("ram:ActualAmount");
-                    Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 2));
+                    Writer.WriteAttributeString("currencyID", tradeAllowanceCharge.Currency.EnumToString());
+                    Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount));
                     Writer.WriteEndElement();
 
 
@@ -627,19 +629,19 @@ namespace s2industries.ZUGFeRD
             }
 
             Writer.WriteStartElement("ram:SpecifiedTradeSettlementHeaderMonetarySummation");
-            _writeOptionalAmount(Writer, "ram:LineTotalAmount", this.Descriptor.LineTotalAmount, forceCurrency: true);
-            _writeOptionalAmount(Writer, "ram:ChargeTotalAmount", this.Descriptor.ChargeTotalAmount, forceCurrency: true);
-            _writeOptionalAmount(Writer, "ram:AllowanceTotalAmount", this.Descriptor.AllowanceTotalAmount, forceCurrency: true);
-            _writeOptionalAmount(Writer, "ram:TaxBasisTotalAmount", this.Descriptor.TaxBasisAmount, forceCurrency: true);
-            _writeOptionalAmount(Writer, "ram:TaxTotalAmount", this.Descriptor.TaxTotalAmount, forceCurrency: true);
-            _writeOptionalAmount(Writer, "ram:GrandTotalAmount", this.Descriptor.GrandTotalAmount, forceCurrency: true);
+            _writeOptionalAmount(Writer, "ram:LineTotalAmount", this.Descriptor.LineTotalAmount);
+            _writeOptionalAmount(Writer, "ram:ChargeTotalAmount", this.Descriptor.ChargeTotalAmount);
+            _writeOptionalAmount(Writer, "ram:AllowanceTotalAmount", this.Descriptor.AllowanceTotalAmount);
+            _writeOptionalAmount(Writer, "ram:TaxBasisTotalAmount", this.Descriptor.TaxBasisAmount);
+            _writeOptionalAmount(Writer, "ram:TaxTotalAmount", this.Descriptor.TaxTotalAmount);
+            _writeOptionalAmount(Writer, "ram:GrandTotalAmount", this.Descriptor.GrandTotalAmount);
 
             if (this.Descriptor.TotalPrepaidAmount.HasValue)
             {
-                _writeOptionalAmount(Writer, "ram:TotalPrepaidAmount", this.Descriptor.TotalPrepaidAmount.Value, forceCurrency: true);
+                _writeOptionalAmount(Writer, "ram:TotalPrepaidAmount", this.Descriptor.TotalPrepaidAmount.Value);
             }
 
-            _writeOptionalAmount(Writer, "ram:DuePayableAmount", this.Descriptor.DuePayableAmount, forceCurrency: true);
+            _writeOptionalAmount(Writer, "ram:DuePayableAmount", this.Descriptor.DuePayableAmount);
             Writer.WriteEndElement(); // !ram:SpecifiedTradeSettlementHeaderMonetarySummation
 
             Writer.WriteEndElement(); // !ram:ApplicableHeaderTradeSettlement
@@ -655,15 +657,12 @@ namespace s2industries.ZUGFeRD
         } // !Save()
 
 
-        private void _writeOptionalAmount(ProfileAwareXmlTextWriter writer, string tagName, decimal? value, int numDecimals = 2, bool forceCurrency = false)
+        private void _writeOptionalAmount(ProfileAwareXmlTextWriter writer, string tagName, decimal? value, int numDecimals = 2)
         {
             if (value.HasValue && (value.Value != decimal.MinValue))
             {
                 writer.WriteStartElement(tagName);
-                if (forceCurrency)
-                {
-                    writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
-                }
+                writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
                 writer.WriteValue(_formatDecimal(value.Value, numDecimals));
                 writer.WriteEndElement(); // !tagName
             }
@@ -686,18 +685,21 @@ namespace s2industries.ZUGFeRD
                 writer.WriteStartElement("ram:ApplicableTradeTax");
 
                 writer.WriteStartElement("ram:CalculatedAmount");
+                writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
                 writer.WriteValue(_formatDecimal(tax.TaxAmount));
                 writer.WriteEndElement(); // !CalculatedAmount
 
                 writer.WriteElementString("ram:TypeCode", tax.TypeCode.EnumToString());
 
                 writer.WriteStartElement("ram:BasisAmount");
+                writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
                 writer.WriteValue(_formatDecimal(tax.BasisAmount));
                 writer.WriteEndElement(); // !BasisAmount
 
                 if (tax.AllowanceChargeBasisAmount != 0)
                 {
                     writer.WriteStartElement("ram:AllowanceChargeBasisAmount");
+                    writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
                     writer.WriteValue(_formatDecimal(tax.AllowanceChargeBasisAmount));
                     writer.WriteEndElement(); // !AllowanceChargeBasisAmount
                 }

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -196,7 +196,7 @@ namespace s2industries.ZUGFeRD
                     }
 
                     Writer.WriteStartElement("ram:GrossPriceProductTradePrice");
-                    _writeOptionalAmount(Writer, "ram:ChargeAmount", tradeLineItem.GrossUnitPrice, 4, true);
+                    _writeOptionalAmount(Writer, "ram:ChargeAmount", tradeLineItem.GrossUnitPrice, 4);
                     if (tradeLineItem.UnitQuantity.HasValue)
                     {
                         _writeElementWithAttribute(Writer, "ram:BasisQuantity", "unitCode", tradeLineItem.UnitCode.EnumToString(), _formatDecimal(tradeLineItem.UnitQuantity.Value, 4));


### PR DESCRIPTION
- Renamed tags to use the ZUGFeRD 2.0 equivalents
- Removed BankName as it is not used anymore
- Changed order of elements to pass ZUV validation
- Reverted changes from #99 as ZUV requires `@currencyID`