### PR TITLE
Feature/settable line id for trade line item

### DIFF
--- a/ZUGFeRD/AssociatedDocument.cs
+++ b/ZUGFeRD/AssociatedDocument.cs
@@ -37,14 +37,14 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// identifier of the invoice line item
         /// </summary>
-        public int? LineID { get; set; }
+        public string LineID { get; set; }
 
 
         /// <summary>
         /// Initializes a new associated document object, optionally passing a certain lineID
         /// </summary>
         /// <param name="lineID"></param>
-        public AssociatedDocument(int? lineID = null)
+        public AssociatedDocument(string lineID)
         {
             this.LineID = lineID;
         }

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -550,11 +550,18 @@ namespace s2industries.ZUGFeRD
         } // !Save()
 
 
-        public void AddTradeLineCommentItem(string comment,string lineID = "")
+        public void AddTradeLineCommentItem(string comment)
+        {
+            AddTradeLineCommentItem(GetNextLineId(), comment);
+
+        } // !AddTradeLineCommentItem()
+
+
+        public void AddTradeLineCommentItem(string lineID, string comment)
         {
             if(String.IsNullOrEmpty(lineID))
             {
-                lineID = GetNextLineId();
+                throw new ArgumentException("LineID cannot be Null or Empty");
             }
             else
             {
@@ -583,7 +590,7 @@ namespace s2industries.ZUGFeRD
         } // !AddTradeLineCommentItem()
 
 
-        // TODO Rabatt ergänzen:
+
         // <ram:AppliedTradeAllowanceCharge>
         //     <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
         //     <ram:CalculationPercent>2.00</ram:CalculationPercent>
@@ -605,8 +612,54 @@ namespace s2industries.ZUGFeRD
                                      GlobalID id = null,
                                      string sellerAssignedID = "", string buyerAssignedID = "",
                                      string deliveryNoteID = "", DateTime? deliveryNoteDate = null,
-                                     string buyerOrderID = "", DateTime? buyerOrderDate = null,
-                                     string lineID = ""
+                                     string buyerOrderID = "", DateTime? buyerOrderDate = null)
+        {
+            return AddTradeLineItem(lineID: GetNextLineId(),
+                             name: name,
+                             description: description,
+                             unitCode: unitCode,
+                             unitQuantity: unitQuantity,
+                             grossUnitPrice: grossUnitPrice,
+                             netUnitPrice: netUnitPrice,
+                             billedQuantity: billedQuantity,
+                             taxType: taxType,
+                             categoryCode: categoryCode,
+                             taxPercent: taxPercent,
+                             comment: comment,
+                             id: id,
+                             sellerAssignedID: sellerAssignedID,
+                             deliveryNoteID: deliveryNoteID,
+                             buyerOrderID: buyerOrderID);
+
+        } // !AddTradeLineItem()
+
+
+
+
+        // TODO Rabatt ergänzen:
+        // <ram:AppliedTradeAllowanceCharge>
+        //     <ram:ChargeIndicator><udt:Indicator>false</udt:Indicator></ram:ChargeIndicator>
+        //     <ram:CalculationPercent>2.00</ram:CalculationPercent>
+        //     <ram:BasisAmount currencyID = "EUR" > 1.5000 </ram:BasisAmount>
+        //     <ram:ActualAmount currencyID = "EUR" > 0.0300 </ram:ActualAmount>
+        //     <ram:Reason>Artikelrabatt 1</ram:Reason>
+        // </ram:AppliedTradeAllowanceCharge>
+        public TradeLineItem AddTradeLineItem(string lineID,
+                                     string name,
+                                     string description = null,
+                                     QuantityCodes unitCode = QuantityCodes.Unknown,
+                                     decimal? unitQuantity = null,
+                                     decimal grossUnitPrice = Decimal.MinValue,
+                                     decimal netUnitPrice = Decimal.MinValue,
+                                     decimal billedQuantity = Decimal.MinValue,
+                                     TaxTypes taxType = TaxTypes.Unknown,
+                                     TaxCategoryCodes categoryCode = TaxCategoryCodes.Unknown,
+                                     decimal taxPercent = Decimal.MinValue,
+                                     string comment = null,
+                                     GlobalID id = null,
+                                     string sellerAssignedID = "", string buyerAssignedID = "",
+                                     string deliveryNoteID = "", DateTime? deliveryNoteDate = null,
+                                     string buyerOrderID = "", DateTime? buyerOrderDate = null
                                      )
         {
             TradeLineItem newItem = new TradeLineItem()
@@ -629,7 +682,7 @@ namespace s2industries.ZUGFeRD
 
             if (String.IsNullOrEmpty(lineID))
             {
-                lineID = GetNextLineId();
+                throw new ArgumentException("LineID cannot be Null or Empty");
             }
             else
             {

--- a/ZUGFeRD/InvoiceDescriptor1Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Reader.cs
@@ -312,10 +312,7 @@ namespace s2industries.ZUGFeRD
 
             if (tradeLineItem.SelectSingleNode(".//ram:AssociatedDocumentLineDocument", nsmgr) != null)
             {
-                item.AssociatedDocument = new AssociatedDocument()
-                {
-                    LineID = _nodeAsInt(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr, Int32.MaxValue)
-                };
+                item.AssociatedDocument = new AssociatedDocument(_nodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr));
 
                 XmlNodeList noteNodes = tradeLineItem.SelectNodes(".//ram:AssociatedDocumentLineDocument/ram:IncludedNote", nsmgr);
                 foreach(XmlNode noteNode in noteNodes)
@@ -325,11 +322,6 @@ namespace s2industries.ZUGFeRD
                                 subjectCode: default(SubjectCodes).FromString(_nodeAsString(noteNode, ".//ram:SubjectCode", nsmgr)),
                                 contentCode: ContentCodes.Unknown
                     ));
-                }
-
-                if (item.AssociatedDocument.LineID == Int32.MaxValue) // a bit dirty, but works for now
-                {
-                    item.AssociatedDocument.LineID = null;
                 }
             }
 

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -412,9 +412,9 @@ namespace s2industries.ZUGFeRD
                 if (tradeLineItem.AssociatedDocument != null)
                 {
                     Writer.WriteStartElement("ram:AssociatedDocumentLineDocument");
-                    if (tradeLineItem.AssociatedDocument.LineID.HasValue)
+                    if (!String.IsNullOrEmpty(tradeLineItem.AssociatedDocument.LineID))
                     {
-                        Writer.WriteElementString("ram:LineID", String.Format("{0}", tradeLineItem.AssociatedDocument.LineID));
+                        Writer.WriteElementString("ram:LineID", tradeLineItem.AssociatedDocument.LineID);
                     }
                     _writeNotes(Writer, tradeLineItem.AssociatedDocument.Notes);
                     Writer.WriteEndElement(); // ram:AssociatedDocumentLineDocument

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -323,10 +323,7 @@ namespace s2industries.ZUGFeRD
 
             if (tradeLineItem.SelectSingleNode(".//ram:AssociatedDocumentLineDocument", nsmgr) != null)
             {
-                item.AssociatedDocument = new AssociatedDocument()
-                {
-                    LineID = _nodeAsInt(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr, Int32.MaxValue)
-                };
+                item.AssociatedDocument = new AssociatedDocument(_nodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr));
 
                 XmlNodeList noteNodes = tradeLineItem.SelectNodes(".//ram:AssociatedDocumentLineDocument/ram:IncludedNote", nsmgr);
                 foreach (XmlNode noteNode in noteNodes)
@@ -338,10 +335,6 @@ namespace s2industries.ZUGFeRD
                     ));
                 }
 
-                if (item.AssociatedDocument.LineID == Int32.MaxValue) // a bit dirty, but works for now
-                {
-                    item.AssociatedDocument.LineID = null;
-                }
             }
 
             XmlNodeList appliedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge", nsmgr);

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -104,9 +104,9 @@ namespace s2industries.ZUGFeRD
                 if (tradeLineItem.AssociatedDocument != null)
                 {
                     Writer.WriteStartElement("ram:AssociatedDocumentLineDocument");
-                    if (tradeLineItem.AssociatedDocument.LineID.HasValue)
+                    if (!String.IsNullOrEmpty(tradeLineItem.AssociatedDocument.LineID))
                     {
-                        Writer.WriteElementString("ram:LineID", String.Format("{0}", tradeLineItem.AssociatedDocument.LineID));
+                        Writer.WriteElementString("ram:LineID", tradeLineItem.AssociatedDocument.LineID);
                     }
                     _writeNotes(Writer, tradeLineItem.AssociatedDocument.Notes);
                     Writer.WriteEndElement(); // ram:AssociatedDocumentLineDocument

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -353,11 +353,8 @@ namespace s2industries.ZUGFeRD
 
 
             if (tradeLineItem.SelectSingleNode(".//ram:AssociatedDocumentLineDocument", nsmgr) != null)
-            {              
-                item.AssociatedDocument = new AssociatedDocument()
-                {
-                    LineID = _nodeAsInt(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr, Int32.MaxValue)
-                };
+            {
+                item.AssociatedDocument = new AssociatedDocument(_nodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr));
 
                 XmlNodeList noteNodes = tradeLineItem.SelectNodes(".//ram:AssociatedDocumentLineDocument/ram:IncludedNote", nsmgr);
                 foreach (XmlNode noteNode in noteNodes)
@@ -369,10 +366,6 @@ namespace s2industries.ZUGFeRD
                     ));
                 }
 
-                if (item.AssociatedDocument.LineID == Int32.MaxValue) // a bit dirty, but works for now
-                {
-                    item.AssociatedDocument.LineID = null;
-                }
             }
 
             XmlNodeList appliedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge", nsmgr);

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -121,9 +121,9 @@ namespace s2industries.ZUGFeRD
                 if (tradeLineItem.AssociatedDocument != null)
                 {
                     Writer.WriteStartElement("ram:AssociatedDocumentLineDocument", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung);
-                    if (tradeLineItem.AssociatedDocument.LineID.HasValue)
+                    if (!String.IsNullOrEmpty(tradeLineItem.AssociatedDocument.LineID))
                     {
-                        Writer.WriteElementString("ram:LineID", String.Format("{0}", tradeLineItem.AssociatedDocument.LineID));
+                        Writer.WriteElementString("ram:LineID", tradeLineItem.AssociatedDocument.LineID);
                     }
                     _writeNotes(Writer, tradeLineItem.AssociatedDocument.Notes);
                     Writer.WriteEndElement(); // ram:AssociatedDocumentLineDocument(Basic|Comfort|Extended|XRechnung)


### PR DESCRIPTION
I implemented it the way, that it is also possible to not specify the LineId, and then it is internaly generated and incremented like before. But now you have the ability to set it, because it is needed in some situations. Specially for the Deutsche Bahn who requires XRechnungen starting from 27.11.2020 on, and want to see their own given LineIDs, not following the schema 1,2,3.
For users who dont want to specify the LineID nothing changes with this implementaion, because of the still existing auto generating as a fallback.