### PR TITLE
ReceivableSpecifiedTradeAccountingAccount

### DIFF
--- a/ZUGFeRD/AccountingAccountTypeCodes.cs
+++ b/ZUGFeRD/AccountingAccountTypeCodes.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace s2industries.ZUGFeRD
+{
+    //based on https://www.unece.org/fileadmin/DAM/uncefact/codelist/standard/EDIFICASEU_AccountingAccountType_D11A.xsd
+
+    /// <summary>Account Types (EDIFICAS-EU Code List)</summary>
+    public enum AccountingAccountTypeCodes
+    {
+        /// <summary>
+        /// TypeCode not set
+        /// </summary>
+        Unspecified = 0,
+        /// <summary>
+        /// The code indicates a financial account
+        /// </summary>
+        Financial = 1,
+        /// <summary>
+        /// The code indicates a subsidiary account
+        /// </summary>
+        Subsidiary = 2,
+        /// <summary>
+        /// The code indicates a budget account
+        /// </summary>
+        Budget = 3,
+        /// <summary>
+        /// The code indicates a cost accounting account
+        /// </summary>
+        Cost_Accounting = 4,
+        /// <summary>
+        /// The code indicates a receivable account
+        /// </summary>
+        Receivable = 5,
+        /// <summary>
+        /// The code indicates a payable account
+        /// </summary>
+        Payable = 6,
+        /// <summary>
+        /// The code indicates a job cost accounting
+        /// </summary>
+        Job_Cost_Accounting = 7
+    }
+}

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -134,7 +134,7 @@ namespace s2industries.ZUGFeRD
         public List<TradeAllowanceCharge> TradeAllowanceCharges { get; set; } = new List<TradeAllowanceCharge>();
         public PaymentTerms PaymentTerms { get; set; }        
         public InvoiceReferencedDocument InvoiceReferencedDocument { get; set; }
-        public List<ReceivableSpecifiedTradeAccountingAccount> ReceivableSpecifiedTradeAccountingAccounts { get; set; } = new List<ReceivableSpecifiedTradeAccountingAccount>();
+        public List<ReceivableSpecifiedTradeAccountingAccount> ReceivableSpecifiedTradeAccountingAccounts { get; internal set; } = new List<ReceivableSpecifiedTradeAccountingAccount>();
         public List<BankAccount> CreditorBankAccounts { get; set; } = new List<BankAccount>();
         public List<BankAccount> DebitorBankAccounts { get; set; } = new List<BankAccount>();
         public PaymentMeans PaymentMeans { get; set; }

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -134,6 +134,7 @@ namespace s2industries.ZUGFeRD
         public List<TradeAllowanceCharge> TradeAllowanceCharges { get; set; } = new List<TradeAllowanceCharge>();
         public PaymentTerms PaymentTerms { get; set; }        
         public InvoiceReferencedDocument InvoiceReferencedDocument { get; set; }
+        public List<ReceivableSpecifiedTradeAccountingAccount> ReceivableSpecifiedTradeAccountingAccounts { get; set; } = new List<ReceivableSpecifiedTradeAccountingAccount>();
         public List<BankAccount> CreditorBankAccounts { get; set; } = new List<BankAccount>();
         public List<BankAccount> DebitorBankAccounts { get; set; } = new List<BankAccount>();
         public PaymentMeans PaymentMeans { get; set; }
@@ -781,6 +782,18 @@ namespace s2industries.ZUGFeRD
             });
         } // !AddDebitorFinancialAccount()
 
+        public void AddReceivableSpecifiedTradeAccountingAccount(string AccountID)
+        {
+            AddReceivableSpecifiedTradeAccountingAccount(AccountID, AccountingAccountTypeCodes.Unspecified);
+        }
+        public void AddReceivableSpecifiedTradeAccountingAccount(string AccountID, AccountingAccountTypeCodes AccountTypeCode)
+        {
+            this.ReceivableSpecifiedTradeAccountingAccounts.Add(new ReceivableSpecifiedTradeAccountingAccount()
+            {
+                TradeAccountID = AccountID,
+                TradeAccountTypeCode = AccountTypeCode
+            });
+        }
 
         private string _getNextLineId()
         {

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -419,10 +419,11 @@ namespace s2industries.ZUGFeRD
                             //TODO
                             break;
                         case "ram:ReceivableSpecifiedTradeAccountingAccount":
-                            ReceivableSpecifiedTradeAccountingAccount RSTAA = new ReceivableSpecifiedTradeAccountingAccount();
-                            RSTAA.TradeAccountID = _nodeAsString(LineTradeSettlementNode, "./ram:ID", nsmgr);
-                            RSTAA.TradeAccountTypeCode = (AccountingAccountTypeCodes)_nodeAsInt(LineTradeSettlementNode, ".//ram:TypeCode", nsmgr);
-                            item.ReceivableSpecifiedTradeAccountingAccounts.Add(RSTAA);
+                            item.ReceivableSpecifiedTradeAccountingAccounts.Add(new ReceivableSpecifiedTradeAccountingAccount()
+                            {
+                                TradeAccountID = _nodeAsString(LineTradeSettlementNode, "./ram:ID", nsmgr),
+                                TradeAccountTypeCode = (AccountingAccountTypeCodes)_nodeAsInt(LineTradeSettlementNode, ".//ram:TypeCode", nsmgr)
+                            });
                             break;
                     }
                 }

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -119,7 +119,7 @@ namespace s2industries.ZUGFeRD
 
             if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument", nsmgr) != null)
             {
-                string _issuerAssignedID = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:IssuerAssignedID", nsmgr);                
+                string _issuerAssignedID = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:IssuerAssignedID", nsmgr);
                 string _typeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:TypeCode", nsmgr);
                 string _referenceTypeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:ReferenceTypeCode", nsmgr);
                 string _name = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:Name", nsmgr);
@@ -185,13 +185,13 @@ namespace s2industries.ZUGFeRD
                 SEPAMandateReference = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ID/@schemeAgencyID", nsmgr)
             };
             retval.PaymentMeans = _tempPaymentMeans;
-            
+
             retval.BillingPeriodStart = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime", nsmgr);
             retval.BillingPeriodEnd = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:BillingSpecifiedPeriod/ram:EndDateTime", nsmgr);
 
             XmlNodeList creditorFinancialAccountNodes = doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeePartyCreditorFinancialAccount", nsmgr);
             XmlNodeList creditorFinancialInstitutions = doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution", nsmgr);
-            
+
             if (creditorFinancialAccountNodes.Count == creditorFinancialInstitutions.Count)
             {
                 for (int i = 0; i < creditorFinancialAccountNodes.Count; i++)
@@ -282,6 +282,15 @@ namespace s2industries.ZUGFeRD
             retval.GrandTotalAmount = _nodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:GrandTotalAmount", nsmgr, 0).Value;
             retval.TotalPrepaidAmount = _nodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TotalPrepaidAmount", nsmgr, null);
             retval.DuePayableAmount = _nodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:DuePayableAmount", nsmgr, 0).Value;            
+
+            foreach (XmlNode node in doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:ReceivableSpecifiedTradeAccountingAccount", nsmgr))
+            {
+                retval.ReceivableSpecifiedTradeAccountingAccounts.Add(new ReceivableSpecifiedTradeAccountingAccount()
+                {
+                    TradeAccountID = _nodeAsString(node, ".//ram:ID", nsmgr),
+                    TradeAccountTypeCode = (AccountingAccountTypeCodes)_nodeAsInt(node, ".//ram:TypeCode", nsmgr),
+                });
+            }
 
             retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/udt:DateTimeString", nsmgr);
             if (!retval.OrderDate.HasValue)
@@ -387,6 +396,37 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeSettlement", nsmgr) != null)
+            {
+                XmlNodeList LineTradeSettlementNodes = tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeSettlement", nsmgr).ChildNodes;
+                foreach (XmlNode LineTradeSettlementNode in LineTradeSettlementNodes)
+                {
+                    switch (LineTradeSettlementNode.Name)
+                    {
+                        case "ram:ApplicableTradeTax":
+                            //TODO
+                            break;
+                        case "ram:BillingSpecifiedPeriod":
+                            //TODO
+                            break;
+                        case "ram:SpecifiedTradeAllowanceCharge":
+                            //TODO
+                            break;
+                        case "ram:SpecifiedTradeSettlementLineMonetarySummation":
+                            //TODO
+                            break;
+                        case "ram:AdditionalReferencedDocument":
+                            //TODO
+                            break;
+                        case "ram:ReceivableSpecifiedTradeAccountingAccount":
+                            ReceivableSpecifiedTradeAccountingAccount RSTAA = new ReceivableSpecifiedTradeAccountingAccount();
+                            RSTAA.TradeAccountID = _nodeAsString(LineTradeSettlementNode, "./ram:ID", nsmgr);
+                            RSTAA.TradeAccountTypeCode = (AccountingAccountTypeCodes)_nodeAsInt(LineTradeSettlementNode, ".//ram:TypeCode", nsmgr);
+                            item.ReceivableSpecifiedTradeAccountingAccounts.Add(RSTAA);
+                            break;
+                    }
+                }
+            }
 
             if (tradeLineItem.SelectSingleNode(".//ram:AssociatedDocumentLineDocument", nsmgr) != null)
             {

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -407,7 +407,40 @@ namespace s2industries.ZUGFeRD
 
                 #region ReceivableSpecifiedTradeAccountingAccount
                 //Detailinformationen zur Buchungsreferenz
-                //ToDo: ReceivableSpecifiedTradeAccountingAccount
+                if (descriptor.Profile == Profile.XRechnung1 || descriptor.Profile == Profile.XRechnung && tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts.Count > 0)
+                {
+                    //only one ReceivableSpecifiedTradeAccountingAccount (BT-133) is allowed in Profile XRechnung
+                    Writer.WriteStartElement("ram:ReceivableSpecifiedTradeAccountingAccount", Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+                    {
+                        Writer.WriteStartElement("ram:ID");
+                        Writer.WriteValue(tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts[0].TradeAccountID);  //BT-133
+                        Writer.WriteEndElement(); // !ram:ID
+                    }
+                    Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
+                }
+                else
+                {
+                    //multiple ReceivableSpecifiedTradeAccountingAccounts are allowed in other profiles
+                    foreach (ReceivableSpecifiedTradeAccountingAccount RSTA in tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts)
+                    {
+                        Writer.WriteStartElement("ram:ReceivableSpecifiedTradeAccountingAccount", Profile.Comfort | Profile.Extended);
+
+                        {
+                            Writer.WriteStartElement("ram:ID");
+                            Writer.WriteValue(RSTA.TradeAccountID);
+                            Writer.WriteEndElement(); // !ram:ID
+                        }
+
+                        if (RSTA.TradeAccountTypeCode != AccountingAccountTypeCodes.Unspecified)
+                        {
+                            Writer.WriteStartElement("ram:TypeCode", Profile.Extended);
+                            Writer.WriteValue(((int)RSTA.TradeAccountTypeCode).ToString());
+                            Writer.WriteEndElement(); // !ram:TypeCode
+                        }
+
+                        Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
+                    }
+                }
                 #endregion
 
                 Writer.WriteEndElement(); // !ram:SpecifiedLineTradeSettlement
@@ -810,6 +843,48 @@ namespace s2industries.ZUGFeRD
             }
             #endregion
 
+            #region ReceivableSpecifiedTradeAccountingAccount
+            if (this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts != null && this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts.Count > 0)
+            {
+                if (descriptor.Profile == Profile.XRechnung1 || descriptor.Profile == Profile.XRechnung)
+                {
+                    if (!string.IsNullOrEmpty(this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts[0].TradeAccountID))
+                    {
+                        Writer.WriteStartElement("ram:ReceivableSpecifiedTradeAccountingAccount");
+                        {
+                            //BT-19
+                            Writer.WriteStartElement("ram:ID");
+                            Writer.WriteValue(this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts[0].TradeAccountID);
+                            Writer.WriteEndElement(); // !ram:ID
+                        }
+                        Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
+                    }
+                }
+                else
+                {
+                    foreach (ReceivableSpecifiedTradeAccountingAccount RSTAA in this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts)
+                    {
+                        Writer.WriteStartElement("ram:ReceivableSpecifiedTradeAccountingAccount", Profile.BasicWL | Profile.Basic | Profile.Comfort | Profile.Extended);
+                        
+                        {   
+                            //BT-19
+                            Writer.WriteStartElement("ram:ID", Profile.BasicWL | Profile.Basic | Profile.Comfort | Profile.Extended);
+                            Writer.WriteValue(RSTAA.TradeAccountID);
+                            Writer.WriteEndElement(); // !ram:ID
+                        }
+
+                        if (RSTAA.TradeAccountTypeCode != AccountingAccountTypeCodes.Unspecified)
+                        {
+                            Writer.WriteStartElement("ram:TypeCode", Profile.Extended);
+                            Writer.WriteValue(((int)RSTAA.TradeAccountTypeCode).ToString());
+                            Writer.WriteEndElement(); // !ram:TypeCode
+                        }
+
+                        Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
+                    }
+                }
+            }
+            #endregion
             Writer.WriteEndElement(); // !ram:ApplicableHeaderTradeSettlement
 
             #endregion

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -1060,10 +1060,10 @@ namespace s2industries.ZUGFeRD
                 {
                     _writeOptionalContact(writer, "ram:DefinedTradeContact", contact, Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
                 }
-                else if ( ((profile & Profile.XRechnung) == Profile.XRechnung) || ((profile & Profile.XRechnung1) == Profile.XRechnung1) )
-                {
-                    _writeOptionalContact(writer, "ram:DefinedTradeContact", new Contact(), Profile.XRechnung1 | Profile.XRechnung);
-                }
+                //else if ( ((profile & Profile.XRechnung) == Profile.XRechnung) || ((profile & Profile.XRechnung1) == Profile.XRechnung1) )
+                //{
+                //    _writeOptionalContact(writer, "ram:DefinedTradeContact", new Contact(), Profile.XRechnung1 | Profile.XRechnung);
+                //}
 
                 writer.WriteStartElement("ram:PostalTradeAddress");
                 writer.WriteElementString("ram:PostcodeCode", party.Postcode);

--- a/ZUGFeRD/MimeTypeMapper.cs
+++ b/ZUGFeRD/MimeTypeMapper.cs
@@ -48,7 +48,7 @@ namespace s2industries.ZUGFeRD
             if (!String.IsNullOrEmpty(filename))
             {
                 string extension = System.IO.Path.GetExtension(filename);                
-                if (!String.IsNullOrEmpty(extension) && _MimeTypes.TryGetValue(extension, out string mimeType))
+                if (!String.IsNullOrEmpty(extension) && _MimeTypes.TryGetValue(extension.ToLower(), out string mimeType))
                 {
                     return mimeType;
                 }                    

--- a/ZUGFeRD/ReceivableSpecifiedTradeAccountingAccount.cs
+++ b/ZUGFeRD/ReceivableSpecifiedTradeAccountingAccount.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace s2industries.ZUGFeRD
+{
+    /// <summary>Detailinformationen zur Buchungsreferenz</summary>
+    public class ReceivableSpecifiedTradeAccountingAccount
+    {
+        /// <summary>
+        /// Ein Textwert, der angibt, an welcher Stelle die betreffenden Daten in den Finanzkonten des Käufers zu verbuchen sind
+        /// </summary>
+        public string TradeAccountID { get; set; }
+
+        /// <summary>
+        /// EDIFICAS-EU Type Codes: https://www.unece.org/fileadmin/DAM/uncefact/codelist/standard/EDIFICASEU_AccountingAccountType_D11A.xsd
+        /// </summary>
+        public AccountingAccountTypeCodes TradeAccountTypeCode { get; set; }
+    }
+}

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -97,7 +97,8 @@ namespace s2industries.ZUGFeRD
         public ContractReferencedDocument ContractReferencedDocument { get; set; }
         public List<AdditionalReferencedDocument> AdditionalReferencedDocuments { get; set; }
         public List<TradeAllowanceCharge> TradeAllowanceCharges { get; set; }
-        
+        public List<ReceivableSpecifiedTradeAccountingAccount> ReceivableSpecifiedTradeAccountingAccounts { get; set; }
+
 
         /// <summary>
         /// Initializes a new/ empty trade line item
@@ -109,6 +110,7 @@ namespace s2industries.ZUGFeRD
             this.GlobalID = new GlobalID();
             this.TradeAllowanceCharges = new List<TradeAllowanceCharge>();
             this.AdditionalReferencedDocuments = new List<AdditionalReferencedDocument>();
+            this.ReceivableSpecifiedTradeAccountingAccounts = new List<ReceivableSpecifiedTradeAccountingAccount>();
         }
 
 
@@ -171,5 +173,18 @@ namespace s2industries.ZUGFeRD
                 IssueDateTime = contractReferencedDate
             };
         } // !SetContractReferencedDocument()
+
+        public void AddReceivableSpecifiedTradeAccountingAccount(string AccountID)
+        {
+            AddReceivableSpecifiedTradeAccountingAccount(AccountID, AccountingAccountTypeCodes.Unspecified);
+        }
+        public void AddReceivableSpecifiedTradeAccountingAccount(string AccountID, AccountingAccountTypeCodes AccountTypeCode)
+        {
+            this.ReceivableSpecifiedTradeAccountingAccounts.Add(new ReceivableSpecifiedTradeAccountingAccount()
+            {
+                TradeAccountID = AccountID,
+                TradeAccountTypeCode = AccountTypeCode
+            });
+        }
     }
 }


### PR DESCRIPTION
Hello Stephan,

here are mainly my additions for the ReceivableSpecifiedTradeAccountingAccount structures (invoice-header and also tradelines) which I already use in production for XRechnung invoices.

One more commit makes the file extensions to choose the corresponding mimetypes case-insensitive.

And last but not least one commit which may solve issue #121. At least for XRechnung it solves validation errors but I am still not sure if it causes new (already solved problems) in ZUGFeRD-Profiles.

Regards, Stefan