### PR TITLE
added QuantityCode KMT to be Rec20r13 compatible

### DIFF
--- a/ZUGFeRD/QuantityCodes.cs
+++ b/ZUGFeRD/QuantityCodes.cs
@@ -73,7 +73,13 @@ namespace s2industries.ZUGFeRD
 
         /// <summary>
         /// Kilometer
-        /// Abkürzung: km
+        /// Abkürzung: km (Rec20r13)
+        /// </summary>
+        KMT,
+
+        /// <summary>
+        /// Kilometer
+        /// Abkürzung: km (Rec20r16)
         /// </summary>
         KTM,
 

--- a/ZUGFeRD/QuantityCodes.cs
+++ b/ZUGFeRD/QuantityCodes.cs
@@ -73,7 +73,7 @@ namespace s2industries.ZUGFeRD
 
         /// <summary>
         /// Kilometer
-        /// Abkürzung: km (Rec20r13)
+        /// Abkürzung: km (Rec20r13) für XRechnung
         /// </summary>
         KMT,
 


### PR DESCRIPTION
One of our clients complaint about the wrong Quantity Code KTM for kilometers, this is because KTM is Rec20r16 compatible, but XRechnung needs Rec20r13 compatible QuantityCode for Kilometer, which is KMT. So i added the missing QuantityCode. Following Rec20r16 both KTM and KMT are valid so it should be no problem to have both available. I also marked them clearly in the comment which one is compatible with which codelist.