### PR TITLE
ZUGFeRD 2 SEPA Direct Debit

### DIFF
--- a/ZUGFeRD-Test/ZUGFeRD-Test.csproj
+++ b/ZUGFeRD-Test/ZUGFeRD-Test.csproj
@@ -49,6 +49,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicTests.cs" />

--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -20,6 +20,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using s2industries.ZUGFeRD;
 using System;
 using System.IO;
+using System.Xml;
 
 namespace ZUGFeRD_Test
 {
@@ -109,5 +110,177 @@ namespace ZUGFeRD_Test
 
             Assert.IsTrue(invoiceDescriptor.TradeLineItems.TrueForAll(x => x.ApplicableProductCharacteristics.Count == 0));
         } // !TestMissingPropertListsEmpty()
+
+        [TestMethod]
+        public void TestSepaPreNotification_Load()
+        {
+            string path = @"..\..\..\demodata\zugferd20\zugferd_2p0_EN16931_SEPA_Prenotification.xml";
+            var invoiceDescriptor = InvoiceDescriptor.Load(path);
+            Assert.AreEqual(Profile.Comfort, invoiceDescriptor.Profile);
+            Assert.AreEqual(InvoiceType.Invoice, invoiceDescriptor.Type);
+            Assert.AreEqual("471102", invoiceDescriptor.InvoiceNo);
+            Assert.AreEqual(2, invoiceDescriptor.TradeLineItems.Count);
+            Assert.AreEqual(new DateTime(2018, 3, 5), invoiceDescriptor.InvoiceDate);
+
+            Assert.AreEqual("1", invoiceDescriptor.TradeLineItems[0].LineID);
+            Assert.AreEqual("4012345001235", invoiceDescriptor.TradeLineItems[0].GlobalID.ID);
+            Assert.AreEqual("0160", invoiceDescriptor.TradeLineItems[0].GlobalID.SchemeID);
+            Assert.AreEqual("TB100A4", invoiceDescriptor.TradeLineItems[0].SellerAssignedID);
+            Assert.AreEqual("Trennblätter A4", invoiceDescriptor.TradeLineItems[0].Name);
+            Assert.AreEqual(20m, invoiceDescriptor.TradeLineItems[0].BilledQuantity);
+            Assert.AreEqual(9.9m, invoiceDescriptor.TradeLineItems[0].NetUnitPrice);
+            Assert.AreEqual(9.9m, invoiceDescriptor.TradeLineItems[0].GrossUnitPrice);
+            Assert.AreEqual(TaxCategoryCodes.S, invoiceDescriptor.TradeLineItems[0].TaxCategoryCode);
+            Assert.AreEqual(19.0m, invoiceDescriptor.TradeLineItems[0].TaxPercent);
+            Assert.AreEqual(TaxTypes.VAT, invoiceDescriptor.TradeLineItems[0].TaxType);
+            Assert.AreEqual(198.00m, invoiceDescriptor.TradeLineItems[0].LineTotalAmount);
+
+            Assert.AreEqual("2", invoiceDescriptor.TradeLineItems[1].LineID);
+            Assert.AreEqual("4000050986428", invoiceDescriptor.TradeLineItems[1].GlobalID.ID);
+            Assert.AreEqual("0160", invoiceDescriptor.TradeLineItems[1].GlobalID.SchemeID);
+            Assert.AreEqual("ARNR2", invoiceDescriptor.TradeLineItems[1].SellerAssignedID);
+            Assert.AreEqual("Joghurt Banane", invoiceDescriptor.TradeLineItems[1].Name);
+            Assert.AreEqual(50m, invoiceDescriptor.TradeLineItems[1].BilledQuantity);
+            Assert.AreEqual(5.5m, invoiceDescriptor.TradeLineItems[1].NetUnitPrice);
+            Assert.AreEqual(5.5m, invoiceDescriptor.TradeLineItems[1].GrossUnitPrice);
+            Assert.AreEqual(TaxCategoryCodes.S, invoiceDescriptor.TradeLineItems[1].TaxCategoryCode);
+            Assert.AreEqual(7.0m, invoiceDescriptor.TradeLineItems[1].TaxPercent);
+            Assert.AreEqual(TaxTypes.VAT, invoiceDescriptor.TradeLineItems[1].TaxType);
+            Assert.AreEqual(275.00m, invoiceDescriptor.TradeLineItems[1].LineTotalAmount);
+
+            Assert.AreEqual("0088", invoiceDescriptor.Seller.GlobalID.SchemeID);
+            Assert.AreEqual("4000001123452", invoiceDescriptor.Seller.GlobalID.ID);
+            Assert.AreEqual("Lieferant GmbH", invoiceDescriptor.Seller.Name);
+            Assert.AreEqual("80333", invoiceDescriptor.Seller.Postcode);
+            Assert.AreEqual("Lieferantenstraße 20", invoiceDescriptor.Seller.Street);
+            Assert.AreEqual("München", invoiceDescriptor.Seller.City);
+            Assert.AreEqual(CountryCodes.DE, invoiceDescriptor.Seller.Country);
+
+            Assert.AreEqual("GE2020211", invoiceDescriptor.Buyer.ID);
+            Assert.AreEqual("0088", invoiceDescriptor.Buyer.GlobalID.SchemeID);
+            Assert.AreEqual("4000001987658", invoiceDescriptor.Buyer.GlobalID.ID);
+            Assert.AreEqual("Kunden AG Mitte", invoiceDescriptor.Buyer.Name);
+            Assert.AreEqual("69876", invoiceDescriptor.Buyer.Postcode);
+            Assert.AreEqual("Kundenstraße 15", invoiceDescriptor.Buyer.Street);
+            Assert.AreEqual("Frankfurt", invoiceDescriptor.Buyer.City);
+            Assert.AreEqual(CountryCodes.DE, invoiceDescriptor.Buyer.Country);
+
+            Assert.AreEqual("DE98ZZZ09999999999", invoiceDescriptor.PaymentMeans.SEPACreditorIdentifier);
+            Assert.AreEqual("REF A-123", invoiceDescriptor.PaymentMeans.SEPAMandateReference);
+            Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
+            Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
+
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.Description);
+
+            Assert.AreEqual(CurrencyCodes.EUR, invoiceDescriptor.Currency);
+            Assert.AreEqual(473.00m, invoiceDescriptor.LineTotalAmount);
+            Assert.AreEqual(0.00m, invoiceDescriptor.ChargeTotalAmount);
+            Assert.AreEqual(0.00m, invoiceDescriptor.AllowanceTotalAmount);
+            Assert.AreEqual(473.00m, invoiceDescriptor.TaxBasisAmount);
+            Assert.AreEqual(56.87m, invoiceDescriptor.TaxTotalAmount);
+            Assert.AreEqual(529.87m, invoiceDescriptor.GrandTotalAmount);
+            Assert.AreEqual(0.00m, invoiceDescriptor.TotalPrepaidAmount);
+            Assert.AreEqual(529.87m, invoiceDescriptor.DuePayableAmount);
+        } // !TestSepaPreNotification_Load()
+
+        [TestMethod]
+        public void TestSepaPreNotification_Write()
+        {
+            var d = new InvoiceDescriptor();
+            d.Type = InvoiceType.Invoice;
+            d.InvoiceNo = "471102";
+            d.Currency = CurrencyCodes.EUR;
+            d.InvoiceDate = new DateTime(2018, 3, 5);
+            d.AddTradeLineItem(
+                lineID: "1",
+                id: new GlobalID("0160", "4012345001235"),
+                sellerAssignedID: "TB100A4",
+                name: "Trennblätter A4",
+                billedQuantity: 20m,
+                unitCode: QuantityCodes.C62,
+                netUnitPrice: 9.9m,
+                grossUnitPrice: 9.9m,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 19.0m,
+                taxType: TaxTypes.VAT);
+            d.AddTradeLineItem(
+                lineID: "2",
+                id: new GlobalID("0160", "4000050986428"),
+                sellerAssignedID: "ARNR2",
+                name: "Joghurt Banane",
+                billedQuantity: 50m,
+                unitCode: QuantityCodes.C62,
+                netUnitPrice: 5.5m,
+                grossUnitPrice: 5.5m,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 7.0m,
+                taxType: TaxTypes.VAT);
+            d.SetSeller(
+                id: null,
+                globalID: new GlobalID("0088", "4000001123452"),
+                name: "Lieferant GmbH",
+                postcode: "80333",
+                city: "München",
+                street: "Lieferantenstraße 20",
+                country: CountryCodes.DE);
+            d.SetBuyer(
+                id: "GE2020211",
+                globalID: new GlobalID("0088", "4000001987658"),
+                name: "Kunden AG Mitte",
+                postcode: "69876",
+                city: "Frankfurt",
+                street: "Kundenstraße 15",
+                country: CountryCodes.DE);
+            d.SetPaymentMeansSepaDirectDebit(
+                "DE98ZZZ09999999999",
+                "REF A-123");
+            d.AddDebitorFinancialAccount(
+                "DE21860000000086001055", 
+                null);
+            d.SetTradePaymentTerms(
+                "Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.");
+            d.SetTotals(
+                473.00m,
+                0.00m,
+                0.00m,
+                473.00m,
+                56.87m,
+                529.87m,
+                0.00m,
+                529.87m);
+            d.SellerTaxRegistration.Add(new TaxRegistration
+            {
+                SchemeID = TaxRegistrationSchemeID.FC,
+                No = "201/113/40209"
+            });
+            d.SellerTaxRegistration.Add(new TaxRegistration
+            {
+                SchemeID = TaxRegistrationSchemeID.VA,
+                No = "DE123456789"
+            });
+            d.AddApplicableTradeTax(
+                275.00m,
+                7.00m,
+                TaxTypes.VAT,
+                TaxCategoryCodes.S);
+            d.AddApplicableTradeTax(
+                198.00m,
+                19.00m,
+                TaxTypes.VAT,
+                TaxCategoryCodes.S);
+
+            using (var stream = new MemoryStream())
+            {
+                d.Save(stream, ZUGFeRDVersion.Version20, Profile.Comfort);
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                var d2 = InvoiceDescriptor.Load(stream);
+                Assert.AreEqual("DE98ZZZ09999999999", d2.PaymentMeans.SEPACreditorIdentifier);
+                Assert.AreEqual("REF A-123", d2.PaymentMeans.SEPAMandateReference);
+                Assert.AreEqual(1, d2.DebitorBankAccounts.Count);
+                Assert.AreEqual("DE21860000000086001055", d2.DebitorBankAccounts[0].IBAN);
+            }
+        }
     }
 }

--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -128,6 +128,7 @@ namespace ZUGFeRD_Test
             Assert.AreEqual("TB100A4", invoiceDescriptor.TradeLineItems[0].SellerAssignedID);
             Assert.AreEqual("Trennblätter A4", invoiceDescriptor.TradeLineItems[0].Name);
             Assert.AreEqual(20m, invoiceDescriptor.TradeLineItems[0].BilledQuantity);
+            Assert.AreEqual(QuantityCodes.C62, invoiceDescriptor.TradeLineItems[0].UnitCode);
             Assert.AreEqual(9.9m, invoiceDescriptor.TradeLineItems[0].NetUnitPrice);
             Assert.AreEqual(9.9m, invoiceDescriptor.TradeLineItems[0].GrossUnitPrice);
             Assert.AreEqual(TaxCategoryCodes.S, invoiceDescriptor.TradeLineItems[0].TaxCategoryCode);
@@ -141,6 +142,7 @@ namespace ZUGFeRD_Test
             Assert.AreEqual("ARNR2", invoiceDescriptor.TradeLineItems[1].SellerAssignedID);
             Assert.AreEqual("Joghurt Banane", invoiceDescriptor.TradeLineItems[1].Name);
             Assert.AreEqual(50m, invoiceDescriptor.TradeLineItems[1].BilledQuantity);
+            Assert.AreEqual(QuantityCodes.C62, invoiceDescriptor.TradeLineItems[0].UnitCode);
             Assert.AreEqual(5.5m, invoiceDescriptor.TradeLineItems[1].NetUnitPrice);
             Assert.AreEqual(5.5m, invoiceDescriptor.TradeLineItems[1].GrossUnitPrice);
             Assert.AreEqual(TaxCategoryCodes.S, invoiceDescriptor.TradeLineItems[1].TaxCategoryCode);
@@ -170,7 +172,7 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
             Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
 
-            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.Description);
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.Description.Trim());
 
             Assert.AreEqual(CurrencyCodes.EUR, invoiceDescriptor.Currency);
             Assert.AreEqual(473.00m, invoiceDescriptor.LineTotalAmount);

--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -416,39 +416,41 @@ namespace ZUGFeRD_Test
             fileStream.Close();
 
             // Modifiy trade line settlement data
-            originalInvoiceDescriptor.TradeLineItems.Add(new TradeLineItem()
-            {
-                ApplicableProductCharacteristics = new ApplicableProductCharacteristic[]
+            originalInvoiceDescriptor.TradeLineItems.Add(
+                new TradeLineItem()
                 {
-                    new ApplicableProductCharacteristic()
+                    ApplicableProductCharacteristics = new ApplicableProductCharacteristic[]
                     {
-                        Description = "Description_1_1",
-                        Value = "Value_1_1"
-                    },
-                    new ApplicableProductCharacteristic()
-                    {
-                        Description = "Description_1_2",
-                        Value = "Value_1_2"
-                    },
-                }.ToList(),
-            });
+                        new ApplicableProductCharacteristic()
+                        {
+                            Description = "Description_1_1",
+                            Value = "Value_1_1"
+                        },
+                        new ApplicableProductCharacteristic()
+                        {
+                            Description = "Description_1_2",
+                            Value = "Value_1_2"
+                        },
+                    }.ToList(),
+                });
 
-            originalInvoiceDescriptor.TradeLineItems.Add(new TradeLineItem()
-            {
-                ApplicableProductCharacteristics = new ApplicableProductCharacteristic[]
+            originalInvoiceDescriptor.TradeLineItems.Add(
+                new TradeLineItem()
                 {
-                    new ApplicableProductCharacteristic()
+                    ApplicableProductCharacteristics = new ApplicableProductCharacteristic[]
                     {
-                        Description = "Description_2_1",
-                        Value = "Value_2_1"
-                    },
-                    new ApplicableProductCharacteristic()
-                    {
-                        Description = "Description_2_2",
-                        Value = "Value_2_2"
-                    },
-                }.ToList()
-            });
+                        new ApplicableProductCharacteristic()
+                        {
+                            Description = "Description_2_1",
+                            Value = "Value_2_1"
+                        },
+                        new ApplicableProductCharacteristic()
+                        {
+                            Description = "Description_2_2",
+                            Value = "Value_2_2"
+                        },
+                    }.ToList()
+                });
 
             originalInvoiceDescriptor.IsTest = false;
 
@@ -485,17 +487,19 @@ namespace ZUGFeRD_Test
             s.Close();
 
             // Modifiy trade line settlement data
-            originalInvoiceDescriptor.TradeLineItems.Add(new TradeLineItem()
-            {
-                BillingPeriodStart = new DateTime(2020, 1, 1),
-                BillingPeriodEnd = new DateTime(2021, 1, 1),
-            });
+            originalInvoiceDescriptor.TradeLineItems.Add(
+                new TradeLineItem()
+                {
+                    BillingPeriodStart = new DateTime(2020, 1, 1),
+                    BillingPeriodEnd = new DateTime(2021, 1, 1),
+                });
 
-            originalInvoiceDescriptor.TradeLineItems.Add(new TradeLineItem()
-            {
-                BillingPeriodStart = new DateTime(2021, 1, 1),
-                BillingPeriodEnd = new DateTime(2022, 1, 1)
-            });
+            originalInvoiceDescriptor.TradeLineItems.Add(
+                new TradeLineItem()
+                {
+                    BillingPeriodStart = new DateTime(2021, 1, 1),
+                    BillingPeriodEnd = new DateTime(2022, 1, 1)
+                });
 
             originalInvoiceDescriptor.IsTest = false;
 
@@ -528,11 +532,12 @@ namespace ZUGFeRD_Test
             fileStream.Close();
 
             // Modifiy trade line settlement data
-            originalInvoiceDescriptor.TradeLineItems.Add(new TradeLineItem()
-            {
-                BilledQuantity = 10,
-                NetUnitPrice = 1
-            });
+            originalInvoiceDescriptor.TradeLineItems.Add(
+                new TradeLineItem()
+                {
+                    BilledQuantity = 10,
+                    NetUnitPrice = 1
+                });
 
             originalInvoiceDescriptor.IsTest = false;
 
@@ -558,10 +563,11 @@ namespace ZUGFeRD_Test
             fileStream.Close();
 
             // Modifiy trade line settlement data
-            originalInvoiceDescriptor.TradeLineItems.Add(new TradeLineItem()
-            {
-                NetUnitPrice = 25
-            });
+            originalInvoiceDescriptor.TradeLineItems.Add(
+                new TradeLineItem()
+                {
+                    NetUnitPrice = 25
+                });
 
             originalInvoiceDescriptor.IsTest = false;
 
@@ -606,6 +612,180 @@ namespace ZUGFeRD_Test
 
                 var secondTradeLineItem = invoiceDescriptor.TradeLineItems[1];
                 Assert.AreEqual("3", secondTradeLineItem.LineID);
+            }
+        }
+
+        [TestMethod]
+        public void TestSepaPreNotification_Load()
+        {
+            string path = @"..\..\..\demodata\zugferd21\zugferd_2p1_EN16931_SEPA_Prenotification.xml";
+            var invoiceDescriptor = InvoiceDescriptor.Load(path);
+            Assert.AreEqual(Profile.Comfort, invoiceDescriptor.Profile);
+            Assert.AreEqual(InvoiceType.Invoice, invoiceDescriptor.Type);
+            Assert.AreEqual("471102", invoiceDescriptor.InvoiceNo);
+            Assert.AreEqual(2, invoiceDescriptor.TradeLineItems.Count);
+            Assert.AreEqual(new DateTime(2018, 3, 5), invoiceDescriptor.InvoiceDate);
+
+            Assert.AreEqual("1", invoiceDescriptor.TradeLineItems[0].LineID);
+            Assert.AreEqual("4012345001235", invoiceDescriptor.TradeLineItems[0].GlobalID.ID);
+            Assert.AreEqual("0160", invoiceDescriptor.TradeLineItems[0].GlobalID.SchemeID);
+            Assert.AreEqual("TB100A4", invoiceDescriptor.TradeLineItems[0].SellerAssignedID);
+            Assert.AreEqual("Trennblätter A4", invoiceDescriptor.TradeLineItems[0].Name);
+            Assert.AreEqual(20m, invoiceDescriptor.TradeLineItems[0].BilledQuantity);
+            Assert.AreEqual(QuantityCodes.H87, invoiceDescriptor.TradeLineItems[0].UnitCode);
+            Assert.AreEqual(9.9m, invoiceDescriptor.TradeLineItems[0].NetUnitPrice);
+            Assert.AreEqual(9.9m, invoiceDescriptor.TradeLineItems[0].GrossUnitPrice);
+            Assert.AreEqual(TaxCategoryCodes.S, invoiceDescriptor.TradeLineItems[0].TaxCategoryCode);
+            Assert.AreEqual(19.0m, invoiceDescriptor.TradeLineItems[0].TaxPercent);
+            Assert.AreEqual(TaxTypes.VAT, invoiceDescriptor.TradeLineItems[0].TaxType);
+            Assert.AreEqual(198.00m, invoiceDescriptor.TradeLineItems[0].LineTotalAmount);
+
+            Assert.AreEqual("2", invoiceDescriptor.TradeLineItems[1].LineID);
+            Assert.AreEqual("4000050986428", invoiceDescriptor.TradeLineItems[1].GlobalID.ID);
+            Assert.AreEqual("0160", invoiceDescriptor.TradeLineItems[1].GlobalID.SchemeID);
+            Assert.AreEqual("ARNR2", invoiceDescriptor.TradeLineItems[1].SellerAssignedID);
+            Assert.AreEqual("Joghurt Banane", invoiceDescriptor.TradeLineItems[1].Name);
+            Assert.AreEqual(50m, invoiceDescriptor.TradeLineItems[1].BilledQuantity);
+            Assert.AreEqual(QuantityCodes.H87, invoiceDescriptor.TradeLineItems[1].UnitCode);
+            Assert.AreEqual(5.5m, invoiceDescriptor.TradeLineItems[1].NetUnitPrice);
+            Assert.AreEqual(5.5m, invoiceDescriptor.TradeLineItems[1].GrossUnitPrice);
+            Assert.AreEqual(TaxCategoryCodes.S, invoiceDescriptor.TradeLineItems[1].TaxCategoryCode);
+            Assert.AreEqual(7.0m, invoiceDescriptor.TradeLineItems[1].TaxPercent);
+            Assert.AreEqual(TaxTypes.VAT, invoiceDescriptor.TradeLineItems[1].TaxType);
+            Assert.AreEqual(275.00m, invoiceDescriptor.TradeLineItems[1].LineTotalAmount);
+
+            Assert.AreEqual("0088", invoiceDescriptor.Seller.GlobalID.SchemeID);
+            Assert.AreEqual("4000001123452", invoiceDescriptor.Seller.GlobalID.ID);
+            Assert.AreEqual("Lieferant GmbH", invoiceDescriptor.Seller.Name);
+            Assert.AreEqual("80333", invoiceDescriptor.Seller.Postcode);
+            Assert.AreEqual("Lieferantenstraße 20", invoiceDescriptor.Seller.Street);
+            Assert.AreEqual("München", invoiceDescriptor.Seller.City);
+            Assert.AreEqual(CountryCodes.DE, invoiceDescriptor.Seller.Country);
+
+            Assert.AreEqual("GE2020211", invoiceDescriptor.Buyer.ID);
+            Assert.AreEqual("Kunden AG Mitte", invoiceDescriptor.Buyer.Name);
+            Assert.AreEqual("69876", invoiceDescriptor.Buyer.Postcode);
+            Assert.AreEqual("Kundenstraße 15", invoiceDescriptor.Buyer.Street);
+            Assert.AreEqual("Frankfurt", invoiceDescriptor.Buyer.City);
+            Assert.AreEqual(CountryCodes.DE, invoiceDescriptor.Buyer.Country);
+
+            Assert.AreEqual("DE98ZZZ09999999999", invoiceDescriptor.PaymentMeans.SEPACreditorIdentifier);
+            Assert.AreEqual("REF A-123", invoiceDescriptor.PaymentMeans.SEPAMandateReference);
+            Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
+            Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
+
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.Description.Trim());
+
+            Assert.AreEqual(CurrencyCodes.EUR, invoiceDescriptor.Currency);
+            Assert.AreEqual(473.00m, invoiceDescriptor.LineTotalAmount);
+            Assert.AreEqual(0.00m, invoiceDescriptor.ChargeTotalAmount);
+            Assert.AreEqual(0.00m, invoiceDescriptor.AllowanceTotalAmount);
+            Assert.AreEqual(473.00m, invoiceDescriptor.TaxBasisAmount);
+            Assert.AreEqual(56.87m, invoiceDescriptor.TaxTotalAmount);
+            Assert.AreEqual(529.87m, invoiceDescriptor.GrandTotalAmount);
+            Assert.AreEqual(0.00m, invoiceDescriptor.TotalPrepaidAmount);
+            Assert.AreEqual(529.87m, invoiceDescriptor.DuePayableAmount);
+        } // !TestSepaPreNotification_Load()
+
+        [TestMethod]
+        public void TestSepaPreNotification_Write()
+        {
+            var d = new InvoiceDescriptor();
+            d.Type = InvoiceType.Invoice;
+            d.InvoiceNo = "471102";
+            d.Currency = CurrencyCodes.EUR;
+            d.InvoiceDate = new DateTime(2018, 3, 5);
+            d.AddTradeLineItem(
+                lineID: "1",
+                id: new GlobalID("0160", "4012345001235"),
+                sellerAssignedID: "TB100A4",
+                name: "Trennblätter A4",
+                billedQuantity: 20m,
+                unitCode: QuantityCodes.H87,
+                netUnitPrice: 9.9m,
+                grossUnitPrice: 9.9m,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 19.0m,
+                taxType: TaxTypes.VAT);
+            d.AddTradeLineItem(
+                lineID: "2",
+                id: new GlobalID("0160", "4000050986428"),
+                sellerAssignedID: "ARNR2",
+                name: "Joghurt Banane",
+                billedQuantity: 50m,
+                unitCode: QuantityCodes.H87,
+                netUnitPrice: 5.5m,
+                grossUnitPrice: 5.5m,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 7.0m,
+                taxType: TaxTypes.VAT);
+            d.SetSeller(
+                id: null,
+                globalID: new GlobalID("0088", "4000001123452"),
+                name: "Lieferant GmbH",
+                postcode: "80333",
+                city: "München",
+                street: "Lieferantenstraße 20",
+                country: CountryCodes.DE);
+            d.SetBuyer(
+                id: "GE2020211",
+                globalID: new GlobalID("0088", "4000001987658"),
+                name: "Kunden AG Mitte",
+                postcode: "69876",
+                city: "Frankfurt",
+                street: "Kundenstraße 15",
+                country: CountryCodes.DE);
+            d.SetPaymentMeansSepaDirectDebit(
+                "DE98ZZZ09999999999",
+                "REF A-123");
+            d.AddDebitorFinancialAccount(
+                "DE21860000000086001055",
+                null);
+            d.SetTradePaymentTerms(
+                "Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.");
+            d.SetTotals(
+                473.00m,
+                0.00m,
+                0.00m,
+                473.00m,
+                56.87m,
+                529.87m,
+                0.00m,
+                529.87m);
+            d.SellerTaxRegistration.Add(
+                new TaxRegistration
+                {
+                    SchemeID = TaxRegistrationSchemeID.FC,
+                    No = "201/113/40209"
+                });
+            d.SellerTaxRegistration.Add(
+                new TaxRegistration
+                {
+                    SchemeID = TaxRegistrationSchemeID.VA,
+                    No = "DE123456789"
+                });
+            d.AddApplicableTradeTax(
+                275.00m,
+                7.00m,
+                TaxTypes.VAT,
+                TaxCategoryCodes.S);
+            d.AddApplicableTradeTax(
+                198.00m,
+                19.00m,
+                TaxTypes.VAT,
+                TaxCategoryCodes.S);
+
+            using (var stream = new MemoryStream())
+            {
+                d.Save(stream, ZUGFeRDVersion.Version21, Profile.Comfort);
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                var d2 = InvoiceDescriptor.Load(stream);
+                Assert.AreEqual("DE98ZZZ09999999999", d2.PaymentMeans.SEPACreditorIdentifier);
+                Assert.AreEqual("REF A-123", d2.PaymentMeans.SEPAMandateReference);
+                Assert.AreEqual(1, d2.DebitorBankAccounts.Count);
+                Assert.AreEqual("DE21860000000086001055", d2.DebitorBankAccounts[0].IBAN);
             }
         }
     }

--- a/ZUGFeRD/FinancialCard.cs
+++ b/ZUGFeRD/FinancialCard.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace s2industries.ZUGFeRD
+{
+    /// <summary>
+    ///     Payment card information.
+    /// </summary>
+    public class FinancialCard
+    {
+        /// <summary>
+        ///     Payment card primary account number.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        ///     Payment card holder name.
+        /// </summary>
+        public string CardholderName { get; set; }
+    }
+}

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -314,13 +314,13 @@ namespace s2industries.ZUGFeRD
                 return reader.Load(stream);
             }
 
-            reader = new InvoiceDescriptor20Reader();
+            reader = new InvoiceDescriptor21Reader();
             if (reader.IsReadableByThisReaderVersion(stream))
             {
                 return reader.Load(stream);
             }
 
-            reader = new InvoiceDescriptor21Reader();
+            reader = new InvoiceDescriptor20Reader();
             if (reader.IsReadableByThisReaderVersion(stream))
             {
                 return reader.Load(stream);
@@ -347,13 +347,13 @@ namespace s2industries.ZUGFeRD
                 return reader.Load(filename);
             }
 
-            reader = new InvoiceDescriptor20Reader();
+            reader = new InvoiceDescriptor21Reader();
             if (reader.IsReadableByThisReaderVersion(filename))
             {
                 return reader.Load(filename);
             }
 
-            reader = new InvoiceDescriptor21Reader();
+            reader = new InvoiceDescriptor20Reader();
             if (reader.IsReadableByThisReaderVersion(filename))
             {
                 return reader.Load(filename);

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -922,6 +922,37 @@ namespace s2industries.ZUGFeRD
             };
         } // !SetPaymentMeans()
 
+        /// <summary>
+        ///     Sets up the payment means for SEPA direct debit.
+        /// </summary>
+        public void SetPaymentMeansSepaDirectDebit(string sepaCreditorIdentifier, string sepaMandateReference, string information = "")
+        {
+            this.PaymentMeans = new PaymentMeans
+            {
+                TypeCode = PaymentMeansTypeCodes.SEPADirectDebit,
+                Information = information,
+                SEPACreditorIdentifier = sepaCreditorIdentifier,
+                SEPAMandateReference = sepaMandateReference
+            };
+        } // !SetPaymentMeans()
+
+        /// <summary>
+        ///     Sets up the payment means for payment via financial card.
+        /// </summary>
+        public void SetPaymentMeansFinancialCard(string financialCardId, string financialCardCardholder, string information = "")
+        {
+            this.PaymentMeans = new PaymentMeans
+            {
+                TypeCode = PaymentMeansTypeCodes.SEPADirectDebit,
+                Information = information,
+                FinancialCard = new FinancialCard
+                {
+                    Id = financialCardId,
+                    CardholderName = financialCardCardholder
+                }
+            };
+        } // !SetPaymentMeans()
+
 
         public void AddCreditorFinancialAccount(string iban, string bic, string id = null, string bankleitzahl = null, string bankName = null, string name = null)
         {

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -145,7 +145,7 @@ namespace s2industries.ZUGFeRD
             PaymentMeans _tempPaymentMeans = new PaymentMeans()
             {
                 TypeCode = default(PaymentMeansTypeCodes).FromString(_nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:TypeCode", nsmgr)),
-                Information = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:Information", nsmgr),
+                Information = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:Information", nsmgr),
                 SEPACreditorIdentifier = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:CreditorReferenceID", nsmgr),
                 SEPAMandateReference = _nodeAsString(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID", nsmgr),
             };
@@ -267,7 +267,7 @@ namespace s2industries.ZUGFeRD
 
             retval.PaymentTerms = new PaymentTerms()
             {
-                Description = _nodeAsString(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:Description", nsmgr).Trim(),
+                Description = _nodeAsString(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:Description", nsmgr),
                 DueDate = _nodeAsDateTime(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime", nsmgr)
             };
 

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -661,6 +661,11 @@ namespace s2industries.ZUGFeRD
             //  18. ReceivableSpecifiedTradeAccountingAccount (optional)
             //  19. SpecifiedAdvancePayment (optional)
 
+            //   1. CreditorReferenceID (optional)
+            if (!String.IsNullOrEmpty(this.Descriptor.PaymentMeans?.SEPACreditorIdentifier))
+            {
+                _writeOptionalElementString(Writer, "ram:CreditorReferenceID", Descriptor.PaymentMeans?.SEPACreditorIdentifier, Profile.BasicWL | Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung | Profile.XRechnung1);
+            }
 
             //   2. PaymentReference (optional)
             if (!String.IsNullOrEmpty(this.Descriptor.PaymentReference))
@@ -691,12 +696,12 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteElementString("ram:TypeCode", this.Descriptor.PaymentMeans.TypeCode.EnumToString());
                         Writer.WriteElementString("ram:Information", this.Descriptor.PaymentMeans.Information);
 
-                        if (!String.IsNullOrEmpty(this.Descriptor.PaymentMeans.SEPACreditorIdentifier) && !String.IsNullOrEmpty(this.Descriptor.PaymentMeans.SEPAMandateReference))
+                        if (this.Descriptor.PaymentMeans.FinancialCard != null)
                         {
-                            Writer.WriteStartElement("ram:ID");
-                            Writer.WriteAttributeString("schemeAgencyID", this.Descriptor.PaymentMeans.SEPACreditorIdentifier);
-                            Writer.WriteValue(this.Descriptor.PaymentMeans.SEPAMandateReference);
-                            Writer.WriteEndElement(); // !ram:ID
+                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended);
+                            _writeOptionalElementString(Writer, "ram:ID", Descriptor.PaymentMeans.FinancialCard.Id);
+                            _writeOptionalElementString(Writer, "ram:CardholderName", Descriptor.PaymentMeans.FinancialCard.CardholderName);
+                            Writer.WriteEndElement(); // !ram:ApplicableTradeSettlementFinancialCard
                         }
                         Writer.WriteEndElement(); // !SpecifiedTradeSettlementPaymentMeans
                     }
@@ -713,12 +718,12 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteElementString("ram:TypeCode", this.Descriptor.PaymentMeans.TypeCode.EnumToString());
                         Writer.WriteElementString("ram:Information", this.Descriptor.PaymentMeans.Information);
 
-                        if (!String.IsNullOrEmpty(this.Descriptor.PaymentMeans.SEPACreditorIdentifier) && !String.IsNullOrEmpty(this.Descriptor.PaymentMeans.SEPAMandateReference))
+                        if (this.Descriptor.PaymentMeans.FinancialCard != null)
                         {
-                            Writer.WriteStartElement("ram:ID");
-                            Writer.WriteAttributeString("schemeAgencyID", this.Descriptor.PaymentMeans.SEPACreditorIdentifier);
-                            Writer.WriteValue(this.Descriptor.PaymentMeans.SEPAMandateReference);
-                            Writer.WriteEndElement(); // !ram:ID
+                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended);
+                            _writeOptionalElementString(Writer, "ram:ID", Descriptor.PaymentMeans.FinancialCard.Id);
+                            _writeOptionalElementString(Writer, "ram:CardholderName", Descriptor.PaymentMeans.FinancialCard.CardholderName);
+                            Writer.WriteEndElement(); // !ram:ApplicableTradeSettlementFinancialCard
                         }
                     }
 
@@ -749,14 +754,6 @@ namespace s2industries.ZUGFeRD
                     {
                         Writer.WriteElementString("ram:TypeCode", this.Descriptor.PaymentMeans.TypeCode.EnumToString());
                         Writer.WriteElementString("ram:Information", this.Descriptor.PaymentMeans.Information);
-
-                        if (!String.IsNullOrEmpty(this.Descriptor.PaymentMeans.SEPACreditorIdentifier) && !String.IsNullOrEmpty(this.Descriptor.PaymentMeans.SEPAMandateReference))
-                        {
-                            Writer.WriteStartElement("ram:ID");
-                            Writer.WriteAttributeString("schemeAgencyID", this.Descriptor.PaymentMeans.SEPACreditorIdentifier);
-                            Writer.WriteValue(this.Descriptor.PaymentMeans.SEPAMandateReference);
-                            Writer.WriteEndElement(); // !ram:ID
-                        }
                     }
 
                     Writer.WriteStartElement("ram:PayerPartyDebtorFinancialAccount");
@@ -866,16 +863,17 @@ namespace s2industries.ZUGFeRD
             }
 
             //  15. SpecifiedTradePaymentTerms (optional)
-            if (this.Descriptor.PaymentTerms != null)
+            if (this.Descriptor.PaymentTerms != null || !string.IsNullOrEmpty(Descriptor.PaymentMeans?.SEPAMandateReference))
             {
                 Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
-                _writeOptionalElementString(Writer, "ram:Description", this.Descriptor.PaymentTerms.Description);
-                if (this.Descriptor.PaymentTerms.DueDate.HasValue)
+                _writeOptionalElementString(Writer, "ram:Description", this.Descriptor.PaymentTerms?.Description);
+                if (this.Descriptor.PaymentTerms?.DueDate.HasValue ?? false)
                 {
                     Writer.WriteStartElement("ram:DueDateDateTime");
                     _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(this.Descriptor.PaymentTerms.DueDate.Value));
                     Writer.WriteEndElement(); // !ram:DueDateDateTime
                 }
+                _writeOptionalElementString(Writer, "ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                 Writer.WriteEndElement();
             }
 

--- a/ZUGFeRD/PaymentMeans.cs
+++ b/ZUGFeRD/PaymentMeans.cs
@@ -48,5 +48,10 @@ namespace s2industries.ZUGFeRD
         /// https://de.wikipedia.org/wiki/Mandatsreferenz
         /// </summary>
         public string SEPAMandateReference { get; set; }
+
+        /// <summary>
+        /// Payment card information.
+        /// </summary>
+        public FinancialCard FinancialCard { get; set; }
     }
 }

--- a/demodata/zugferd20/zugferd_2p0_EN16931_OEPNV.xml
+++ b/demodata/zugferd20/zugferd_2p0_EN16931_OEPNV.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Nutzungsrechte 
+ZUGFeRD Datenformat Version 2.0, 30.11.2018
+Beispiel Version 30.11.2018
+
+Zweck des Forums für elektronische Rechnungen bei der AWV e.V („FeRD“) ist u.a. die Schaffung und Spezifizierung 
+eines offenen Datenformats für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht 
+diskriminierender, standardisierter Technologien („ZUGFeRD Datenformat“)
+
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung 
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine 
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht 
+diskriminierenden Bedingungen an.
+
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung 
+abrufbar unter www.ferd-net.de.
+
+Im Einzelnen schließt die Nutzungsgewährung ein: 
+=====================================
+
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils 
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein. 
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, 
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder 
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige 
+Anwendungen und Dienste. 
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente 
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um 
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch 
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden. 
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares, 
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit 
+anderen Produkten einzuräumen. 
+
+Die Lizenz wird kostenfrei zur Verfügung gestellt. 
+
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen 
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten, 
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete, 
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der 
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+<rsm:CrossIndustryInvoice xmlns:a="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:10" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+   <rsm:ExchangedDocumentContext>
+      <ram:GuidelineSpecifiedDocumentContextParameter>
+         <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+      </ram:GuidelineSpecifiedDocumentContextParameter>
+   </rsm:ExchangedDocumentContext>
+   <rsm:ExchangedDocument>
+      <ram:ID>E2018092011804</ram:ID>
+      <ram:TypeCode>380</ram:TypeCode>
+      <ram:IssueDateTime>
+         <udt:DateTimeString format="102">20180920</udt:DateTimeString>
+      </ram:IssueDateTime>
+      <ram:IncludedNote>
+         <ram:Content>Bei Schriftwechsel bitte Ihre Kundennummer 35040727 und Belegnummer 2018092011804 angeben</ram:Content>
+         <ram:SubjectCode>ADU</ram:SubjectCode>
+      </ram:IncludedNote>
+   </rsm:ExchangedDocument>
+   <rsm:SupplyChainTradeTransaction>
+      <ram:IncludedSupplyChainTradeLineItem>
+         <ram:AssociatedDocumentLineDocument>
+            <ram:LineID>0</ram:LineID>
+         </ram:AssociatedDocumentLineDocument>
+         <ram:SpecifiedTradeProduct>
+            <ram:Name>4-Fahrten-Karte Berlin AB</ram:Name>
+            <ram:Description>Gültig ab 20.09.2018 15:39 Uhr bis 20.09.2018 17:39 Uhr Abschnitt: 1/4</ram:Description>
+         </ram:SpecifiedTradeProduct>
+         <ram:SpecifiedLineTradeAgreement>
+            <ram:NetPriceProductTradePrice>
+               <ram:ChargeAmount>8.41</ram:ChargeAmount>
+            </ram:NetPriceProductTradePrice>
+         </ram:SpecifiedLineTradeAgreement>
+         <ram:SpecifiedLineTradeDelivery>
+            <ram:BilledQuantity unitCode="C62">1</ram:BilledQuantity>
+         </ram:SpecifiedLineTradeDelivery>
+         <ram:SpecifiedLineTradeSettlement>
+            <ram:ApplicableTradeTax>
+               <ram:TypeCode>VAT</ram:TypeCode>
+               <ram:CategoryCode>S</ram:CategoryCode>
+               <ram:RateApplicablePercent>7</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradeSettlementLineMonetarySummation>
+               <ram:LineTotalAmount>8.41</ram:LineTotalAmount>
+            </ram:SpecifiedTradeSettlementLineMonetarySummation>
+         </ram:SpecifiedLineTradeSettlement>
+      </ram:IncludedSupplyChainTradeLineItem>
+      <ram:ApplicableHeaderTradeAgreement>
+         <ram:BuyerReference>05 158 004 - 11023 - 45</ram:BuyerReference>
+         <ram:SellerTradeParty>
+            <ram:Name>Verkehrsbetriebe GmbH</ram:Name>
+            <ram:DefinedTradeContact>
+               <ram:PersonName>Torti Mayer</ram:PersonName>
+               <ram:TelephoneUniversalCommunication>
+                  <ram:CompleteNumber>+493012345678</ram:CompleteNumber>
+               </ram:TelephoneUniversalCommunication>
+               <ram:EmailURIUniversalCommunication>
+                  <ram:URIID>tm@verkehrsbetriebe.de</ram:URIID>
+               </ram:EmailURIUniversalCommunication>
+            </ram:DefinedTradeContact>
+            <ram:PostalTradeAddress>
+               <ram:PostcodeCode>12345</ram:PostcodeCode>
+               <ram:LineOne>Musterstraße 3</ram:LineOne>
+               <ram:LineTwo/>
+               <ram:CityName>Berlin</ram:CityName>
+               <ram:CountryID>DE</ram:CountryID>
+            </ram:PostalTradeAddress>
+            <ram:SpecifiedTaxRegistration>
+               <ram:ID schemeID="VA">DE123456789</ram:ID>
+            </ram:SpecifiedTaxRegistration>
+         </ram:SellerTradeParty>
+         <ram:BuyerTradeParty>
+            <ram:ID>Liselotte Müllermann</ram:ID>
+            <ram:Name>Liselotte Müllermann</ram:Name>
+            <ram:PostalTradeAddress>
+               <ram:PostcodeCode>12345</ram:PostcodeCode>
+               <ram:LineOne>Beispielstraße 24</ram:LineOne>
+               <ram:LineTwo/>
+               <ram:CityName>Berlin</ram:CityName>
+               <ram:CountryID>DE</ram:CountryID>
+            </ram:PostalTradeAddress>
+         </ram:BuyerTradeParty>
+         <ram:BuyerOrderReferencedDocument>
+            <ram:IssuerAssignedID>2018092011804</ram:IssuerAssignedID>
+         </ram:BuyerOrderReferencedDocument>
+      </ram:ApplicableHeaderTradeAgreement>
+      <ram:ApplicableHeaderTradeDelivery>
+        <ram:ActualDeliverySupplyChainEvent>
+          <ram:OccurrenceDateTime>
+            <udt:DateTimeString format="102">20180920</udt:DateTimeString>
+          </ram:OccurrenceDateTime>
+        </ram:ActualDeliverySupplyChainEvent>
+      </ram:ApplicableHeaderTradeDelivery>
+      <ram:ApplicableHeaderTradeSettlement>
+         <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+         <ram:SpecifiedTradeSettlementPaymentMeans>
+            <ram:TypeCode>30</ram:TypeCode>
+            <ram:PayeePartyCreditorFinancialAccount>
+               <ram:IBANID>DE12 1234 5678 9012 3456 78</ram:IBANID>
+               <ram:AccountName>Verkehrsbetriebe GmbH</ram:AccountName>
+            </ram:PayeePartyCreditorFinancialAccount>
+            <ram:PayeeSpecifiedCreditorFinancialInstitution>
+               <ram:BICID/>
+            </ram:PayeeSpecifiedCreditorFinancialInstitution>
+         </ram:SpecifiedTradeSettlementPaymentMeans>
+         <ram:ApplicableTradeTax>
+            <ram:CalculatedAmount>0.59</ram:CalculatedAmount>
+            <ram:TypeCode>VAT</ram:TypeCode>
+            <ram:BasisAmount>8.41</ram:BasisAmount>
+            <ram:CategoryCode>S</ram:CategoryCode>
+            <ram:RateApplicablePercent>7</ram:RateApplicablePercent>
+         </ram:ApplicableTradeTax>
+         <ram:SpecifiedTradePaymentTerms>
+            <ram:Description>Zahlungsbedingungen: Der Rechnungsbetrag wurde bereits beglichen.</ram:Description>
+            <ram:DueDateDateTime>
+               <udt:DateTimeString format="102">20181003</udt:DateTimeString>
+            </ram:DueDateDateTime>
+         </ram:SpecifiedTradePaymentTerms>
+         <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+            <ram:LineTotalAmount>8.41</ram:LineTotalAmount>
+            <ram:TaxBasisTotalAmount>8.41</ram:TaxBasisTotalAmount>
+            <ram:TaxTotalAmount currencyID="EUR">0.59</ram:TaxTotalAmount>
+            <ram:GrandTotalAmount>9.00</ram:GrandTotalAmount>
+            <ram:DuePayableAmount>9.00</ram:DuePayableAmount>
+         </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+      </ram:ApplicableHeaderTradeSettlement>
+   </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/demodata/zugferd20/zugferd_2p0_EN16931_SEPA_Prenotification.xml
+++ b/demodata/zugferd20/zugferd_2p0_EN16931_SEPA_Prenotification.xml
@@ -1,0 +1,213 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+
+<!--Nutzungsrechte 
+ZUGFeRD Datenformat Version 2.0, 30.11.2018
+Beispiel Version 30.11.2018
+
+Zweck des Forums für elektronische Rechnungen bei der AWV e.V („FeRD“) ist u.a. die Schaffung und Spezifizierung 
+eines offenen Datenformats für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht 
+diskriminierender, standardisierter Technologien („ZUGFeRD Datenformat“)
+
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung 
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine 
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht 
+diskriminierenden Bedingungen an.
+
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung 
+abrufbar unter www.ferd-net.de.
+
+Im Einzelnen schließt die Nutzungsgewährung ein: 
+=====================================
+
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils 
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein. 
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, 
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder 
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige 
+Anwendungen und Dienste. 
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente 
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um 
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch 
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden. 
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares, 
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit 
+anderen Produkten einzuräumen. 
+
+Die Lizenz wird kostenfrei zur Verfügung gestellt. 
+
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen 
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten, 
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete, 
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der 
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+<rsm:CrossIndustryInvoice xmlns:a="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:10" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>471102</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:Content>Rechnung gemäß Bestellung Nr. 2018-471331 vom 01.03.2018.</ram:Content>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Es bestehen Rabatt- und Bonusvereinbarungen.</ram:Content>
+      <ram:SubjectCode>AAK</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Lieferant GmbH				
+Lieferantenstraße 20				
+80333 München				
+Deutschland				
+Geschäftsführer: Hans Muster
+Handelsregisternummer: H A 123
+
+      </ram:Content>
+      <ram:SubjectCode>REG</ram:SubjectCode>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4012345001235</ram:GlobalID>
+        <ram:SellerAssignedID>TB100A4</ram:SellerAssignedID>
+        <ram:Name>Trennblätter A4</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">20.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>198.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>2</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4000050986428</ram:GlobalID>
+        <ram:SellerAssignedID>ARNR2</ram:SellerAssignedID>
+        <ram:Name>Joghurt Banane</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="C62">50.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>275.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+        <ram:GlobalID schemeID="0088">4000001123452</ram:GlobalID>
+        <ram:Name>Lieferant GmbH</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>80333</ram:PostcodeCode>
+          <ram:LineOne>Lieferantenstraße 20</ram:LineOne>
+          <ram:CityName>München</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">201/113/40209</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>GE2020211</ram:ID>
+        <ram:GlobalID schemeID="0088">4000001987658</ram:GlobalID>
+        <ram:Name>Kunden AG Mitte</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>69876</ram:PostcodeCode>
+          <ram:LineOne>Kundenstraße 15</ram:LineOne>
+          <ram:CityName>Frankfurt</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:CreditorReferenceID>DE98ZZZ09999999999</ram:CreditorReferenceID>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementPaymentMeans>
+      	<ram:TypeCode>59</ram:TypeCode>
+      	<ram:PayerPartyDebtorFinancialAccount>
+      		<ram:IBANID>DE21860000000086001055</ram:IBANID></ram:PayerPartyDebtorFinancialAccount>
+      </ram:SpecifiedTradeSettlementPaymentMeans>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>19.25</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>275.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>37.62</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>198.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:Description>Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.
+        </ram:Description>
+        <ram:DirectDebitMandateID>REF A-123</ram:DirectDebitMandateID>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>473.00</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>473.00</ram:TaxBasisTotalAmount>
+		<ram:TaxTotalAmount currencyID="EUR">56.87</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>529.87</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>529.87</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/demodata/zugferd21/zugferd_2p1_EN16931_SEPA_Prenotification.xml
+++ b/demodata/zugferd21/zugferd_2p1_EN16931_SEPA_Prenotification.xml
@@ -1,0 +1,257 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!-- English disclaimer below.-->
+<!--Nutzungsrechte 
+ZUGFeRD Datenformat Version 2.1.1, 01.07.2020
+Beispiel Version 01.07.2020
+ 
+Zweck des Forums elektronisch Rechnung Deutschland, welches am 31. März 2010 unter der Arbeitsgemeinschaft für 
+wirtschaftliche Verwaltung e. V. gegründet wurde, ist u. a. die Schaffung und Spezifizierung eines offenen Datenformats 
+für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht diskriminierender, standardisierter 
+Technologien („ZUGFeRD Datenformat“).
+ 
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung 
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine 
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht 
+diskriminierenden Bedingungen an.
+ 
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung 
+abrufbar unter www.ferd-net.de.
+ 
+Im Einzelnen schließt die Nutzungsgewährung ein: 
+=====================================
+ 
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils 
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein. 
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, 
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder 
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige 
+Anwendungen und Dienste. 
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente 
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um 
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch 
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden. 
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares, 
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit 
+anderen Produkten einzuräumen. 
+ 
+Die Lizenz wird kostenfrei zur Verfügung gestellt. 
+ 
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen 
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten, 
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete, 
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der 
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+ 
+ <!--Right of use 
+ZUGFeRD Data format version 2.1.1, July 1, 2020
+ 
+The purpose of the Forum elektronische Rechnung Deutschland (FeRD), which was founded on March 31, 2010 under the 
+umbrella of Arbeitsgemeinschaft für wirtschaftliche Verwaltung e. V., is, among other things, to create and specify an 
+open data format for structured electronic data exchange on the basis of open and non discriminatory, standardised 
+technologies ("ZUGFeRD data format").
+ 
+The ZUGFeRD data format is used by both companies and public administration according to the FeRD 
+made freely accessible. For this purpose FeRD offers all companies and organisations of the public administration a 
+License to use the copyrighted ZUGFeRD data format in a fair, appropriate and non 
+discriminatory conditions.
+ 
+The specification of the FeRD for the implementation of the ZUGFeRD data format is, in its currently valid version 
+available at www.ferd-net.de.
+ 
+In detail, the grant of use includes 
+=====================================
+ 
+FeRD grants a license for the use of the copyrighted ZUGFeRD data format in the respective 
+valid and accepted version (www.ferd-net.de). 
+The license includes an irrevocable right of use including the right of further development, 
+Further processing and connection with other products.
+The license applies in particular to the development, design, production, sale, use or 
+other use of the ZUGFeRD data format for hardware and/or software products and other 
+applications and services. 
+This license does not include the essential patents of the members of FeRD. The essential patents are patents 
+and patent applications worldwide which contain one or more claims that are 
+necessary claims. Necessary claims are only those claims of the essential patents which are 
+the implementation of the ZUGFeRD data format would necessarily be violated. 
+The Licensee is entitled to provide its respective group companies with an unlimited, worldwide, non-transferable, 
+irrevocable right of use including the right of further development, further processing and connection with 
+other products. 
+ 
+The license is provided free of charge. 
+ 
+Except in the case of intentional fault or gross negligence, FeRD is not liable for loss of use, loss of 
+Profit, loss of data, loss of communication, loss of revenue, loss of contracts, loss of business or for costs 
+damages, losses or liabilities in connection with an interruption of business, nor for concrete, 
+incidental, indirect, punitive or consequential damages, even if the possibility of 
+costs, losses or damages could normally have been foreseen.-->
+
+<rsm:CrossIndustryInvoice xmlns:a="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:10" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>471102</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+    </ram:IssueDateTime>
+    <ram:IncludedNote>
+      <ram:Content>Rechnung gemäß Bestellung Nr. 2018-471331 vom 01.03.2018.</ram:Content>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Es bestehen Rabatt- und Bonusvereinbarungen.</ram:Content>
+      <ram:SubjectCode>AAK</ram:SubjectCode>
+    </ram:IncludedNote>
+    <ram:IncludedNote>
+      <ram:Content>Lieferant GmbH				
+Lieferantenstraße 20				
+80333 München				
+Deutschland				
+Geschäftsführer: Hans Muster
+Handelsregisternummer: H A 123
+
+      </ram:Content>
+      <ram:SubjectCode>REG</ram:SubjectCode>
+    </ram:IncludedNote>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4012345001235</ram:GlobalID>
+        <ram:SellerAssignedID>TB100A4</ram:SellerAssignedID>
+        <ram:Name>Trennblätter A4</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">20.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>198.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>2</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:GlobalID schemeID="0160">4000050986428</ram:GlobalID>
+        <ram:SellerAssignedID>ARNR2</ram:SellerAssignedID>
+        <ram:Name>Joghurt Banane</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:GrossPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:GrossPriceProductTradePrice>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">50.0000</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>275.00</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:SellerTradeParty>
+		<ram:ID>549910</ram:ID>
+        <ram:GlobalID schemeID="0088">4000001123452</ram:GlobalID>
+        <ram:Name>Lieferant GmbH</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>80333</ram:PostcodeCode>
+          <ram:LineOne>Lieferantenstraße 20</ram:LineOne>
+          <ram:CityName>München</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">201/113/40209</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>GE2020211</ram:ID>
+        <ram:Name>Kunden AG Mitte</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>69876</ram:PostcodeCode>
+          <ram:LineOne>Kundenstraße 15</ram:LineOne>
+          <ram:CityName>Frankfurt</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:CreditorReferenceID>DE98ZZZ09999999999</ram:CreditorReferenceID>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementPaymentMeans>
+      	<ram:TypeCode>59</ram:TypeCode>
+      	<ram:PayerPartyDebtorFinancialAccount>
+      		<ram:IBANID>DE21860000000086001055</ram:IBANID></ram:PayerPartyDebtorFinancialAccount>
+      </ram:SpecifiedTradeSettlementPaymentMeans>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>19.25</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>275.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>37.62</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>198.00</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:Description>Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.
+        </ram:Description>
+        <ram:DirectDebitMandateID>REF A-123</ram:DirectDebitMandateID>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>473.00</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>473.00</ram:TaxBasisTotalAmount>
+		<ram:TaxTotalAmount currencyID="EUR">56.87</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>529.87</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>529.87</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
SEPA creditor ID and mandate reference are now inserted as per the ZUGFeRD 2 schema.

** Known Problems
As far as I can see it is impossible to automatically decide which reader (20 or 21) to use since the document URIs are the same for all versions of ZUGFeRD 2.x.x:
![image](https://user-images.githubusercontent.com/7949788/141491767-34ba7f61-d9c5-4ea5-9118-88ae9ef7eb9c.png)
After updating the target URIs for InvoiceDescriptor20Reader I couldn't make InvoiceDescriptor.Load use InvoiceDescriptor20Reader vs InvoiceDescriptor21Reader (because the URIs are the same). That also means that the tests for 20 and 21 all use the 21 Reader. Doesn't that basically make InvoiceDescriptor20Reader obsolete? I still implemented my changes for that version as well but it seemed like it hasn't been used in a while.