### PR TITLE
remove non-standard quantity code "PCE"

### DIFF
--- a/ZUGFeRD/QuantityCodes.cs
+++ b/ZUGFeRD/QuantityCodes.cs
@@ -169,11 +169,6 @@ namespace s2industries.ZUGFeRD
         P1,
 
         /// <summary>
-        /// Stück
-        /// </summary>
-        PCE,
-
-        /// <summary>
         /// Set
         /// Abkürzung: Set(s)
         /// </summary>


### PR DESCRIPTION
Using `QuantityCodes.PCE` throws at least a warning (or an error, depending on the validator used). Instead you should use `QuantityCodes.H87` ("piece") or depending on your use case `QuantityCodes.C62` ("one").

> [BR-CL-23]-Unit code MUST be coded according to the UN/ECE Recommendation 20 with Rec 21 extension. "PCE" is an invalid value

You might not willig to remove it as I propose, but at least a `depreceated` note would be good I think?

UN/ECE trade codes:
https://unece.org/trade/cefact/UNLOCODE-Download
https://www.xrepository.de/api/xrepository/urn:xoev-de:kosit:codeliste:rec20_2:technischerBestandteilGenericode