### PR TITLE
Correct namespace qdt in InvoiceDescriptionReader

### DIFF
--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -1010,6 +1010,12 @@ namespace ZUGFeRD_Test
             desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
 
             ms.Seek(0, SeekOrigin.Begin);
+
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
             Assert.AreEqual(1, loadedInvoice.AdditionalReferencedDocuments.Count);
             Assert.AreEqual("Additional Test Document", loadedInvoice.AdditionalReferencedDocuments[0].Name);

--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -994,5 +994,27 @@ namespace ZUGFeRD_Test
                 Assert.Fail();
             }
         } // !TestInvalidTaxTypes()
+
+
+
+        [TestMethod]
+        public void TestAdditionalReferencedDocument()
+        {
+            string uuid = Guid.NewGuid().ToString();
+            DateTime issueDateTime = DateTime.Today;
+
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            desc.AddAdditionalReferencedDocument(uuid, AdditionalReferencedDocumentTypeCode.Unknown, issueDateTime, "Additional Test Document");
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            Assert.AreEqual(1, loadedInvoice.AdditionalReferencedDocuments.Count);
+            Assert.AreEqual("Additional Test Document", loadedInvoice.AdditionalReferencedDocuments[0].Name);
+            Assert.AreEqual(issueDateTime, loadedInvoice.AdditionalReferencedDocuments[0].IssueDateTime);
+        }
+
     }
 }

--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -996,7 +996,6 @@ namespace ZUGFeRD_Test
         } // !TestInvalidTaxTypes()
 
 
-
         [TestMethod]
         public void TestAdditionalReferencedDocument()
         {
@@ -1010,17 +1009,14 @@ namespace ZUGFeRD_Test
             desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
 
             ms.Seek(0, SeekOrigin.Begin);
-
             StreamReader reader = new StreamReader(ms);
             string text = reader.ReadToEnd();
 
             ms.Seek(0, SeekOrigin.Begin);
-
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
             Assert.AreEqual(1, loadedInvoice.AdditionalReferencedDocuments.Count);
             Assert.AreEqual("Additional Test Document", loadedInvoice.AdditionalReferencedDocuments[0].Name);
             Assert.AreEqual(issueDateTime, loadedInvoice.AdditionalReferencedDocuments[0].IssueDateTime);
-        }
-
+        } // !TestAdditionalReferencedDocument()
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -47,7 +47,7 @@ namespace s2industries.ZUGFeRD
             XmlDocument doc = new XmlDocument();
             doc.Load(stream);
             XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.DocumentElement.OwnerDocument.NameTable);
-            nsmgr.AddNamespace("qdt", "urn:un:unece:uncefact:data:standard:QualifiedDataType:10");
+            nsmgr.AddNamespace("qdt", "urn:un:unece:uncefact:data:standard:QualifiedDataType:100");
             nsmgr.AddNamespace("a", "urn:un:unece:uncefact:data:standard:QualifiedDataType:100");
             nsmgr.AddNamespace("rsm", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
             nsmgr.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -48,7 +48,7 @@ namespace s2industries.ZUGFeRD
             XmlDocument doc = new XmlDocument();
             doc.Load(stream);
             XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.DocumentElement.OwnerDocument.NameTable);
-            nsmgr.AddNamespace("qdt", "urn:un:unece:uncefact:data:standard:QualifiedDataType:10");
+            nsmgr.AddNamespace("qdt", "urn:un:unece:uncefact:data:standard:QualifiedDataType:100");
             nsmgr.AddNamespace("a", "urn:un:unece:uncefact:data:standard:QualifiedDataType:100");
             nsmgr.AddNamespace("rsm", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
             nsmgr.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -125,7 +125,7 @@ namespace s2industries.ZUGFeRD
                 string _typeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:TypeCode", nsmgr);
                 string _referenceTypeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:ReferenceTypeCode", nsmgr);
                 string _name = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:Name", nsmgr);
-                DateTime? _date = _nodeAsDateTime(doc.DocumentElement, "//ram:AdditionalReferencedDocument/ram:FormattedIssueDateTime/ram:IssueDateTime/qdt:DateTimeString", nsmgr);
+                DateTime? _date = _nodeAsDateTime(doc.DocumentElement, "//ram:AdditionalReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr);
 
                 if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject", nsmgr) != null)
                 {


### PR DESCRIPTION
I also noticed that there was a mismatch between readers and writers for namspace "qdt". Because in the schema it is defined as 'xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" ' I have corrected this in the readers (10 > 100; in the writers it seems to be correct). So the most sample files in the ZUGFeRD zip-package seems not to be correct - or I missunderstand something.