### PR TITLE
Expand party with AddressLineThree and CountrySubdivisionName

### DIFF
--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -229,5 +229,42 @@ namespace ZUGFeRD_Test
                 Assert.AreEqual("DE21860000000086001055", d2.DebitorBankAccounts[0].IBAN);
             }
         } // !TestStoringSepaPreNotification()
+
+        [TestMethod]
+        public void TestPartyExtensions()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
+
+            desc.Invoicee = new Party() // this information will not be stored in the output file since it is available in Extended profile only
+            {
+                Name = "Test",
+                ContactName = "Max Mustermann",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Street = "Münchnerstraße 123",
+                AddressLine3 = "EG links",
+                CountrySubdivisionName = "Bayern",
+                Country = CountryCodes.DE
+            };
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            Assert.AreEqual("Test", loadedInvoice.Invoicee.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.Invoicee.ContactName);
+            Assert.AreEqual("83022", loadedInvoice.Invoicee.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.Invoicee.City);
+            Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Invoicee.Street);
+            Assert.AreEqual("EG links", loadedInvoice.Invoicee.AddressLine3);
+            Assert.AreEqual("Bayern", loadedInvoice.Invoicee.CountrySubdivisionName);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Invoicee.Country);
+        } // !TestMinimumInvoice()
+
     }
 }

--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -994,5 +994,37 @@ namespace ZUGFeRD_Test
                 Assert.Fail();
             }
         } // !TestInvalidTaxTypes()
+
+        [TestMethod]
+        public void TestPartyExtensions()
+        {
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            desc.Invoicee = new Party() // this information will not be stored in the output file since it is available in Extended profile only
+            {
+                Name = "Test",
+                ContactName = "Max Mustermann",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Street = "Münchnerstraße 123",
+                AddressLine3 = "EG links",
+                CountrySubdivisionName = "Bayern",
+                Country = CountryCodes.DE
+            };
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            Assert.AreEqual("Test", loadedInvoice.Invoicee.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.Invoicee.ContactName);
+            Assert.AreEqual("83022", loadedInvoice.Invoicee.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.Invoicee.City);
+            Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Invoicee.Street);
+            Assert.AreEqual("EG links", loadedInvoice.Invoicee.AddressLine3);
+            Assert.AreEqual("Bayern", loadedInvoice.Invoicee.CountrySubdivisionName);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Invoicee.Country);
+        } // !TestMinimumInvoice()
+
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -493,6 +493,9 @@ namespace s2industries.ZUGFeRD
                 retval.ContactName = null;
             }
 
+            retval.AddressLine3 = _nodeAsString(node, "ram:PostalTradeAddress/ram:LineThree", nsmgr);
+            retval.CountrySubdivisionName = _nodeAsString(node, "ram:PostalTradeAddress/ram:CountrySubDivisionName", nsmgr);
+
             return retval;
         } // !_nodeAsParty()
     }

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -897,8 +897,12 @@ namespace s2industries.ZUGFeRD
                 writer.WriteElementString("ram:LineOne", string.IsNullOrEmpty(Party.ContactName) ? Party.Street : Party.ContactName);
                 if (!string.IsNullOrEmpty(Party.ContactName))
                     writer.WriteElementString("ram:LineTwo", Party.Street);
+                if (!string.IsNullOrEmpty(Party.AddressLine3))
+                    writer.WriteElementString("ram:LineThree", Party.AddressLine3); // BT-163
                 writer.WriteElementString("ram:CityName", Party.City);
                 writer.WriteElementString("ram:CountryID", Party.Country.EnumToString());
+                if (!string.IsNullOrEmpty(Party.CountrySubdivisionName))
+                    writer.WriteElementString("ram:CountrySubDivisionName", Party.CountrySubdivisionName); // BT-79
                 writer.WriteEndElement(); // !PostalTradeAddress
 
                 if (TaxRegistrations != null)

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -579,6 +579,9 @@ namespace s2industries.ZUGFeRD
                 retval.ContactName = null;
             }
 
+            retval.AddressLine3 = _nodeAsString(node, "ram:PostalTradeAddress/ram:LineThree", nsmgr);
+            retval.CountrySubdivisionName = _nodeAsString(node, "ram:PostalTradeAddress/ram:CountrySubDivisionName", nsmgr);
+
             return retval;
         } // !_nodeAsParty()
     }

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -1149,9 +1149,12 @@ namespace s2industries.ZUGFeRD
                 writer.WriteElementString("ram:LineOne", string.IsNullOrEmpty(party.ContactName) ? party.Street : party.ContactName); // BT-50
                 if (!string.IsNullOrEmpty(party.ContactName))
                     writer.WriteElementString("ram:LineTwo", party.Street); // BT-51
-                // no implementation of BT-163 (ram:LineThree) so far
+                if (!string.IsNullOrEmpty(party.AddressLine3))
+                    writer.WriteElementString("ram:LineThree", party.AddressLine3); // BT-163
                 writer.WriteElementString("ram:CityName", party.City); // BT-52
                 writer.WriteElementString("ram:CountryID", party.Country.EnumToString()); // BT-55
+                if (!string.IsNullOrEmpty(party.CountrySubdivisionName))
+                    writer.WriteElementString("ram:CountrySubDivisionName", party.CountrySubdivisionName); // BT-79
                 writer.WriteEndElement(); // !PostalTradeAddress
 
                 if (taxRegistrations != null)

--- a/ZUGFeRD/Party.cs
+++ b/ZUGFeRD/Party.cs
@@ -63,5 +63,15 @@ namespace s2industries.ZUGFeRD
       /// </summary>
       public string Street { get; set; }
       public GlobalID GlobalID { get; set; }
-   }
+
+      /// <summary>
+      /// Address line 3
+      /// </summary>
+      public string AddressLine3 { get; set; }
+
+      /// <summary>
+      /// Country subdivision
+      /// </summary>
+      public string CountrySubdivisionName { get; set; }
+    }
 }


### PR DESCRIPTION
I have added the two properties "AddressLineThree" and "CountrySubdivisionName" to the class "Party".
Although I only need to read this data I have implemented this for reader and writer for Version 2.0 and 2.1.
With the UnitTest I ensure that writing and reading both properties are the same.