### PR TITLE
New Get-Property "MimeType" to get the MimeType of AdditionalReferencedDocument

### DIFF
--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -229,5 +229,58 @@ namespace ZUGFeRD_Test
                 Assert.AreEqual("DE21860000000086001055", d2.DebitorBankAccounts[0].IBAN);
             }
         } // !TestStoringSepaPreNotification()
+
+        [TestMethod]
+        public void TestMimetypeOfEmbeddedAttachment()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
+
+            string filename1 = "myrandomdata.pdf";
+            string filename2 = "myrandomdata.bin";
+            byte[] data = new byte[32768];
+            new Random().NextBytes(data);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-PDF",
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename1);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-BIN",
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename2);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual(loadedInvoice.AdditionalReferencedDocuments.Count, 1);
+
+            foreach (AdditionalReferencedDocument document in loadedInvoice.AdditionalReferencedDocuments)
+            {
+                if (document.ID == "My-File-PDF")
+                {
+                    Assert.AreEqual(document.Filename, filename1);
+                    Assert.AreEqual("application/pdf", document.MimeType);
+                }
+
+                if (document.ID == "My-File-BIN")
+                {
+                    Assert.AreEqual(document.Filename, filename2);
+                    Assert.AreEqual("application/octet-stream", document.MimeType);
+                }
+            }
+        } // !TestMimetypeOfEmbeddedAttachment()
+
     }
 }

--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -1020,5 +1020,54 @@ namespace ZUGFeRD_Test
             Assert.AreEqual("Additional Test Document", loadedInvoice.AdditionalReferencedDocuments[0].Name);
             Assert.AreEqual(issueDateTime, loadedInvoice.AdditionalReferencedDocuments[0].IssueDateTime);
         } // !TestAdditionalReferencedDocument()
+
+        [TestMethod]
+        public void TestMimetypeOfEmbeddedAttachment()
+        {
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            string filename1 = "myrandomdata.pdf";
+            string filename2 = "myrandomdata.bin";
+            byte[] data = new byte[32768];
+            new Random().NextBytes(data);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-PDF",
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename1);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-BIN",
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename2);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual(loadedInvoice.AdditionalReferencedDocuments.Count, 1);
+
+            foreach (AdditionalReferencedDocument document in loadedInvoice.AdditionalReferencedDocuments)
+            {
+                if (document.ID == "My-File-PDF")
+                {
+                    Assert.AreEqual(document.Filename, filename1);
+                    Assert.AreEqual("application/pdf", document.MimeType);
+                }
+
+                if (document.ID == "My-File-BIN")
+                {
+                    Assert.AreEqual(document.Filename, filename2);
+                    Assert.AreEqual("application/octet-stream", document.MimeType);
+                }
+            }
+        } // !TestMimetypeOfEmbeddedAttachment()
+
     }
 }

--- a/ZUGFeRD/AdditionalReferencedDocument.cs
+++ b/ZUGFeRD/AdditionalReferencedDocument.cs
@@ -55,5 +55,10 @@ namespace s2industries.ZUGFeRD
         /// Type of the reference document
         /// </summary>
         public AdditionalReferencedDocumentTypeCode TypeCode { get; set; }
+
+        /// <summary>
+        /// MimeType of the attached document embedded as binary object.
+        /// </summary>
+        public string MimeType => MimeTypeMapper.GetMimeType(Filename);
     }
 }


### PR DESCRIPTION
The property "MimeType" returns the mime type of the document. It is determined from the filename using the MimeTypeMapper.