### PR TITLE
Bugfixes and reading more than one AdditionalReferencedDocument

### DIFF
--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -354,6 +354,40 @@ namespace ZUGFeRD_Test
         } // !TestOrderInformation()
 
 
+        [TestMethod]
+        public void TestSellerOrderReferencedDocument()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
+
+            string uuid = System.Guid.NewGuid().ToString();
+            DateTime issueDateTime = DateTime.Today;
+
+            desc.SellerOrderReferencedDocument = new SellerOrderReferencedDocument()
+            {
+                ID = uuid,
+                IssueDateTime = issueDateTime
+            };
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual(Profile.Extended, loadedInvoice.Profile);
+            Assert.AreEqual(uuid, loadedInvoice.SellerOrderReferencedDocument.ID);
+            Assert.AreEqual(issueDateTime, loadedInvoice.SellerOrderReferencedDocument.IssueDateTime);
+        } // !TestSellerOrderReferencedDocument()
+
+
         /// <summary>
         /// This test ensure that Writer and Reader uses the same path and namespace for elements
         /// </summary>

--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -21,12 +21,15 @@ using s2industries.ZUGFeRD;
 using System;
 using System.IO;
 using System.Xml;
+using ZUGFeRD;
 
 namespace ZUGFeRD_Test
 {
     [TestClass]
     public class ZUGFeRD20Tests
     {
+        InvoiceProvider InvoiceProvider = new InvoiceProvider();
+
         [TestMethod]
         public void TestReferenceBasicInvoice()
         {
@@ -277,6 +280,7 @@ namespace ZUGFeRD_Test
 
             string filename1 = "myrandomdata.pdf";
             string filename2 = "myrandomdata.bin";
+            DateTime timestamp = DateTime.Now.Date;
             byte[] data = new byte[32768];
             new Random().NextBytes(data);
 
@@ -296,12 +300,13 @@ namespace ZUGFeRD_Test
 
             MemoryStream ms = new MemoryStream();
 
-            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
             ms.Seek(0, SeekOrigin.Begin);
 
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
 
-            Assert.AreEqual(loadedInvoice.AdditionalReferencedDocuments.Count, 1);
+            //One document is already referenced in "zuferd_2p0_EXTENDED_Warenrechnung.xml"
+            Assert.AreEqual(loadedInvoice.AdditionalReferencedDocuments.Count, 3);
 
             foreach (AdditionalReferencedDocument document in loadedInvoice.AdditionalReferencedDocuments)
             {
@@ -309,15 +314,356 @@ namespace ZUGFeRD_Test
                 {
                     Assert.AreEqual(document.Filename, filename1);
                     Assert.AreEqual("application/pdf", document.MimeType);
+                    Assert.AreEqual(timestamp, document.IssueDateTime);
                 }
 
                 if (document.ID == "My-File-BIN")
                 {
                     Assert.AreEqual(document.Filename, filename2);
                     Assert.AreEqual("application/octet-stream", document.MimeType);
+                    Assert.AreEqual(timestamp.AddDays(-2), document.IssueDateTime);
                 }
             }
         } // !TestMimetypeOfEmbeddedAttachment()
+
+        /// <summary>
+        /// This test ensure that Writer and Reader uses the same path and namespace for elements
+        /// </summary>
+        [TestMethod]
+        public void TestWriteAndReadExtended()
+        {
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            string filename2 = "myrandomdata.bin";
+            DateTime timestamp = DateTime.Now.Date;
+            byte[] data = new byte[32768];
+            new Random().NextBytes(data);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-BIN",
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                issueDateTime: timestamp.AddDays(-2),
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename2);
+
+            desc.OrderNo = "12345";
+            desc.OrderDate = timestamp;
+
+            desc.SetContractReferencedDocument("12345", timestamp);
+
+            desc.SpecifiedProcuringProject = new SpecifiedProcuringProject { ID = "123", Name = "Project 123" };
+
+            desc.ShipTo = new Party
+            {
+                ID = "123",
+                GlobalID = new GlobalID("456", "789"),
+                Name = "Ship To",
+                ContactName = "Max Mustermann",
+                Street = "Münchnerstr. 55",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Country = CountryCodes.DE
+            };
+
+            desc.ShipFrom = new Party
+            {
+                ID = "123",
+                GlobalID = new GlobalID("456", "789"),
+                Name = "Ship From",
+                ContactName = "Eva Musterfrau",
+                Street = "Alpenweg 5",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Country = CountryCodes.DE
+            };
+
+            desc.PaymentMeans.SEPACreditorIdentifier = "SepaID";
+            desc.PaymentMeans.SEPAMandateReference = "SepaMandat";
+            desc.PaymentMeans.FinancialCard = new FinancialCard { Id = "123", CardholderName = "Mustermann" };
+
+            desc.PaymentReference = "PaymentReference";
+
+            desc.Invoicee = new Party()
+            {
+                Name = "Test",
+                ContactName = "Max Mustermann",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Street = "Münchnerstraße 123",
+                AddressLine3 = "EG links",
+                CountrySubdivisionName = "Bayern",
+                Country = CountryCodes.DE
+            };
+
+            desc.Payee = new Party() // this information will not be stored in the output file since it is available in Extended profile only
+            {
+                Name = "Test",
+                ContactName = "Max Mustermann",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Street = "Münchnerstraße 123",
+                AddressLine3 = "EG links",
+                CountrySubdivisionName = "Bayern",
+                Country = CountryCodes.DE
+            };
+
+            desc.AddDebitorFinancialAccount(iban: "DE02120300000000202052", bic: "BYLADEM1001", bankName: "Musterbank");
+            desc.BillingPeriodStart = timestamp;
+            desc.BillingPeriodEnd = timestamp.AddDays(14);
+
+            desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m);
+            desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
+
+            desc.PaymentTerms.DueDate = timestamp.AddDays(14);
+            desc.SetInvoiceReferencedDocument("RE-12345", timestamp);
+
+
+            //set additional LineItem data
+            var lineItem = desc.TradeLineItems.FirstOrDefault(i => i.SellerAssignedID == "TB100A4");
+            Assert.IsNotNull(lineItem);
+            lineItem.Description = "This is line item TB100A4";
+            lineItem.BuyerAssignedID = "0815";
+            lineItem.SetOrderReferencedDocument("12345", timestamp);
+            lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp);
+            lineItem.SetContractReferencedDocument("12345", timestamp);
+
+            lineItem.AddAdditionalReferencedDocument("xyz", timestamp, ReferenceTypeCodes.AAB);
+
+            lineItem.UnitQuantity = 3m;
+            lineItem.ActualDeliveryDate = timestamp;
+
+            lineItem.ApplicableProductCharacteristics.Add(new ApplicableProductCharacteristic
+            {
+                Description = "Product characteristics",
+                Value = "Product value"
+            });
+
+            lineItem.BillingPeriodStart = timestamp;
+            lineItem.BillingPeriodEnd = timestamp.AddDays(10);
+
+            lineItem.AddReceivableSpecifiedTradeAccountingAccount("987654");
+            lineItem.AddTradeAllowanceCharge(false, CurrencyCodes.EUR, 10m, 50m, "Reason: UnitTest");
+
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual("471102", loadedInvoice.InvoiceNo);
+            Assert.AreEqual(new DateTime(2018, 03, 05), loadedInvoice.InvoiceDate);
+            Assert.AreEqual(CurrencyCodes.EUR, loadedInvoice.Currency);
+            Assert.IsTrue(loadedInvoice.Notes.Any(n => n.Content == "Rechnung gemäß Bestellung vom 01.03.2018."));
+            Assert.AreEqual("04011000-12345-34", loadedInvoice.ReferenceOrderNo);
+            Assert.AreEqual("Lieferant GmbH", loadedInvoice.Seller.Name);
+            Assert.AreEqual("80333", loadedInvoice.Seller.Postcode);
+            Assert.AreEqual("München", loadedInvoice.Seller.City);
+
+            Assert.AreEqual("Lieferantenstraße 20", loadedInvoice.Seller.Street);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Seller.Country);
+            Assert.AreEqual("0088", loadedInvoice.Seller.GlobalID.SchemeID);
+            Assert.AreEqual("4000001123452", loadedInvoice.Seller.GlobalID.ID);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.SellerContact.Name);
+            Assert.AreEqual("Muster-Einkauf", loadedInvoice.SellerContact.OrgUnit);
+            Assert.AreEqual("Max@Mustermann.de", loadedInvoice.SellerContact.EmailAddress);
+            Assert.AreEqual("+49891234567", loadedInvoice.SellerContact.PhoneNo);
+
+            Assert.AreEqual("Kunden AG Mitte", loadedInvoice.Buyer.Name);
+            Assert.AreEqual("69876", loadedInvoice.Buyer.Postcode);
+            Assert.AreEqual("Frankfurt", loadedInvoice.Buyer.City);
+            Assert.AreEqual("Kundenstraße 15", loadedInvoice.Buyer.Street);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Buyer.Country);
+            Assert.AreEqual("GE2020211", loadedInvoice.Buyer.ID);
+
+            Assert.AreEqual("12345", loadedInvoice.OrderNo);
+            Assert.AreEqual(timestamp, loadedInvoice.OrderDate);
+
+            //Currently not implemented
+            //Assert.AreEqual("12345", loadedInvoice.ContractReferencedDocument.ID);
+            //Assert.AreEqual(timestamp, loadedInvoice.ContractReferencedDocument.IssueDateTime);
+
+            //Currently not implemented
+            //Assert.AreEqual("123", loadedInvoice.SpecifiedProcuringProject.ID);
+            //Assert.AreEqual("Project 123", loadedInvoice.SpecifiedProcuringProject.Name);
+
+            Assert.AreEqual("123", loadedInvoice.ShipTo.ID);
+            Assert.AreEqual("456", loadedInvoice.ShipTo.GlobalID.SchemeID);
+            Assert.AreEqual("789", loadedInvoice.ShipTo.GlobalID.ID);
+            Assert.AreEqual("Ship To", loadedInvoice.ShipTo.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.ShipTo.ContactName);
+            Assert.AreEqual("Münchnerstr. 55", loadedInvoice.ShipTo.Street);
+            Assert.AreEqual("83022", loadedInvoice.ShipTo.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.ShipTo.City);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.ShipTo.Country);
+
+            Assert.AreEqual("123", loadedInvoice.ShipFrom.ID);
+            Assert.AreEqual("456", loadedInvoice.ShipFrom.GlobalID.SchemeID);
+            Assert.AreEqual("789", loadedInvoice.ShipFrom.GlobalID.ID);
+            Assert.AreEqual("Ship From", loadedInvoice.ShipFrom.Name);
+            Assert.AreEqual("Eva Musterfrau", loadedInvoice.ShipFrom.ContactName);
+            Assert.AreEqual("Alpenweg 5", loadedInvoice.ShipFrom.Street);
+            Assert.AreEqual("83022", loadedInvoice.ShipFrom.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.ShipFrom.City);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.ShipFrom.Country);
+
+
+            Assert.AreEqual(new DateTime(2018, 03, 05), loadedInvoice.ActualDeliveryDate);
+            Assert.AreEqual(PaymentMeansTypeCodes.SEPACreditTransfer, loadedInvoice.PaymentMeans.TypeCode);
+            Assert.AreEqual("Zahlung per SEPA Überweisung.", loadedInvoice.PaymentMeans.Information);
+
+            Assert.AreEqual("PaymentReference", loadedInvoice.PaymentReference);
+
+            Assert.AreEqual("SepaID", loadedInvoice.PaymentMeans.SEPACreditorIdentifier);
+            Assert.AreEqual("SepaMandat", loadedInvoice.PaymentMeans.SEPAMandateReference);
+            Assert.AreEqual("123", loadedInvoice.PaymentMeans.FinancialCard.Id);
+            Assert.AreEqual("Mustermann", loadedInvoice.PaymentMeans.FinancialCard.CardholderName);
+
+            var bankAccount = loadedInvoice.CreditorBankAccounts.FirstOrDefault(a => a.IBAN == "DE02120300000000202051");
+            Assert.IsNotNull(bankAccount);
+            Assert.AreEqual("Kunden AG", bankAccount.Name);
+            Assert.AreEqual("DE02120300000000202051", bankAccount.IBAN);
+            Assert.AreEqual("BYLADEM1001", bankAccount.BIC);
+
+            var debitorBankAccount = loadedInvoice.DebitorBankAccounts.FirstOrDefault(a => a.IBAN == "DE02120300000000202052");
+            Assert.IsNotNull(debitorBankAccount);
+            Assert.AreEqual("DE02120300000000202052", debitorBankAccount.IBAN);
+
+
+            Assert.AreEqual("Test", loadedInvoice.Invoicee.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.Invoicee.ContactName);
+            Assert.AreEqual("83022", loadedInvoice.Invoicee.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.Invoicee.City);
+            Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Invoicee.Street);
+            Assert.AreEqual("EG links", loadedInvoice.Invoicee.AddressLine3);
+            Assert.AreEqual("Bayern", loadedInvoice.Invoicee.CountrySubdivisionName);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Invoicee.Country);
+
+            Assert.AreEqual("Test", loadedInvoice.Payee.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.Payee.ContactName);
+            Assert.AreEqual("83022", loadedInvoice.Payee.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.Payee.City);
+            Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Payee.Street);
+            Assert.AreEqual("EG links", loadedInvoice.Payee.AddressLine3);
+            Assert.AreEqual("Bayern", loadedInvoice.Payee.CountrySubdivisionName);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Payee.Country);
+
+
+            var tax = loadedInvoice.Taxes.FirstOrDefault(t => t.BasisAmount == 275m);
+            Assert.IsNotNull(tax);
+            Assert.AreEqual(275m, tax.BasisAmount);
+            Assert.AreEqual(7m, tax.Percent);
+            Assert.AreEqual(TaxTypes.VAT, tax.TypeCode);
+            Assert.AreEqual(TaxCategoryCodes.S, tax.CategoryCode);
+
+            Assert.AreEqual(timestamp, loadedInvoice.BillingPeriodStart);
+            Assert.AreEqual(timestamp.AddDays(14), loadedInvoice.BillingPeriodEnd);
+
+            //TradeAllowanceCharges
+            var tradeAllowanceCharge = loadedInvoice.TradeAllowanceCharges.FirstOrDefault(i => i.Reason == "Reason for charge");
+            Assert.IsNotNull(tradeAllowanceCharge);
+            Assert.IsTrue(tradeAllowanceCharge.ChargeIndicator);
+            Assert.AreEqual("Reason for charge", tradeAllowanceCharge.Reason);
+            Assert.AreEqual(5m, tradeAllowanceCharge.BasisAmount);
+            Assert.AreEqual(15m, tradeAllowanceCharge.ActualAmount);
+            Assert.AreEqual(CurrencyCodes.EUR, tradeAllowanceCharge.Currency);
+            Assert.AreEqual(19m, tradeAllowanceCharge.Tax.Percent);
+            Assert.AreEqual(TaxTypes.AAB, tradeAllowanceCharge.Tax.TypeCode);
+            Assert.AreEqual(TaxCategoryCodes.AB, tradeAllowanceCharge.Tax.CategoryCode);
+
+            //ServiceCharges
+            var serviceCharge = desc.ServiceCharges.FirstOrDefault(i => i.Description == "Logistics service charge");
+            Assert.IsNotNull(serviceCharge);
+            Assert.AreEqual("Logistics service charge", serviceCharge.Description);
+            Assert.AreEqual(10m, serviceCharge.Amount);
+            Assert.AreEqual(7m, serviceCharge.Tax.Percent);
+            Assert.AreEqual(TaxTypes.AAC, serviceCharge.Tax.TypeCode);
+            Assert.AreEqual(TaxCategoryCodes.AC, serviceCharge.Tax.CategoryCode);
+
+            Assert.AreEqual("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018", loadedInvoice.PaymentTerms.Description);
+            Assert.AreEqual(timestamp.AddDays(14), loadedInvoice.PaymentTerms.DueDate);
+
+
+            Assert.AreEqual(473.0m, loadedInvoice.LineTotalAmount);
+            Assert.AreEqual(0.0m, loadedInvoice.ChargeTotalAmount);
+            Assert.AreEqual(0.0m, loadedInvoice.AllowanceTotalAmount);
+            Assert.AreEqual(473.0m, loadedInvoice.TaxBasisAmount);
+            Assert.AreEqual(56.87m, loadedInvoice.TaxTotalAmount);
+            Assert.AreEqual(529.87m, loadedInvoice.GrandTotalAmount);
+            Assert.AreEqual(0.0m, loadedInvoice.TotalPrepaidAmount);
+            Assert.AreEqual(529.87m, loadedInvoice.DuePayableAmount);
+
+            //InvoiceReferencedDocument
+            Assert.AreEqual("RE-12345", loadedInvoice.InvoiceReferencedDocument.ID);
+            Assert.AreEqual(timestamp, loadedInvoice.InvoiceReferencedDocument.IssueDateTime);
+
+
+            //Line items
+            var loadedLineItem = loadedInvoice.TradeLineItems.FirstOrDefault(i => i.SellerAssignedID == "TB100A4");
+            Assert.IsNotNull(loadedLineItem);
+            Assert.IsTrue(!string.IsNullOrEmpty(loadedLineItem.LineID));
+            Assert.AreEqual("This is line item TB100A4", loadedLineItem.Description);
+
+            Assert.AreEqual("Trennblätter A4", loadedLineItem.Name);
+
+            Assert.AreEqual("TB100A4", loadedLineItem.SellerAssignedID);
+            Assert.AreEqual("0815", loadedLineItem.BuyerAssignedID);
+            Assert.AreEqual("0160", loadedLineItem.GlobalID.SchemeID);
+            Assert.AreEqual("4012345001235", loadedLineItem.GlobalID.ID);
+
+            //GrossPriceProductTradePrice
+            Assert.AreEqual(9.9m, loadedLineItem.GrossUnitPrice);
+            Assert.AreEqual(QuantityCodes.H87, loadedLineItem.UnitCode);
+            Assert.AreEqual(3m, loadedLineItem.UnitQuantity);
+
+            //NetPriceProductTradePrice
+            Assert.AreEqual(9.9m, loadedLineItem.NetUnitPrice);
+            Assert.AreEqual(20m, loadedLineItem.BilledQuantity);
+
+            Assert.AreEqual(TaxTypes.VAT, loadedLineItem.TaxType);
+            Assert.AreEqual(TaxCategoryCodes.S, loadedLineItem.TaxCategoryCode);
+            Assert.AreEqual(19m, loadedLineItem.TaxPercent);
+
+            Assert.AreEqual("12345", loadedLineItem.BuyerOrderReferencedDocument.ID);
+            Assert.AreEqual(timestamp, loadedLineItem.BuyerOrderReferencedDocument.IssueDateTime);
+            Assert.AreEqual("12345", loadedLineItem.DeliveryNoteReferencedDocument.ID);
+            Assert.AreEqual(timestamp, loadedLineItem.DeliveryNoteReferencedDocument.IssueDateTime);
+            Assert.AreEqual("12345", loadedLineItem.ContractReferencedDocument.ID);
+            Assert.AreEqual(timestamp, loadedLineItem.ContractReferencedDocument.IssueDateTime);
+
+            var lineItemReferencedDoc = loadedLineItem.AdditionalReferencedDocuments.FirstOrDefault();
+            Assert.IsNotNull(lineItemReferencedDoc);
+            Assert.AreEqual("xyz", lineItemReferencedDoc.ID);
+            Assert.AreEqual(timestamp, lineItemReferencedDoc.IssueDateTime);
+            Assert.AreEqual(ReferenceTypeCodes.AAB, lineItemReferencedDoc.ReferenceTypeCode);
+
+
+            var productCharacteristics = loadedLineItem.ApplicableProductCharacteristics.FirstOrDefault();
+            Assert.IsNotNull(productCharacteristics);
+            Assert.AreEqual("Product characteristics", productCharacteristics.Description);
+            Assert.AreEqual("Product value", productCharacteristics.Value);
+
+            Assert.AreEqual(timestamp, loadedLineItem.ActualDeliveryDate);
+            Assert.AreEqual(timestamp, loadedLineItem.BillingPeriodStart);
+            Assert.AreEqual(timestamp.AddDays(10), loadedLineItem.BillingPeriodEnd);
+
+            //Currently not implemented
+            //var accountingAccount = loadedLineItem.ReceivableSpecifiedTradeAccountingAccounts.FirstOrDefault();
+            //Assert.IsNotNull(accountingAccount);
+            //Assert.AreEqual("987654", accountingAccount.TradeAccountID);
+
+
+            var lineItemTradeAllowanceCharge = loadedLineItem.TradeAllowanceCharges.FirstOrDefault(i => i.Reason == "Reason: UnitTest");
+            Assert.IsNotNull(lineItemTradeAllowanceCharge);
+            Assert.IsTrue(lineItemTradeAllowanceCharge.ChargeIndicator);
+            Assert.AreEqual(10m, lineItemTradeAllowanceCharge.BasisAmount);
+            Assert.AreEqual(50m, lineItemTradeAllowanceCharge.ActualAmount);
+            Assert.AreEqual("Reason: UnitTest", lineItemTradeAllowanceCharge.Reason);
+        }
 
     }
 }

--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -255,7 +255,7 @@ namespace ZUGFeRD_Test
             };
             MemoryStream ms = new MemoryStream();
 
-            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
             ms.Seek(0, SeekOrigin.Begin);
 
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
@@ -325,6 +325,34 @@ namespace ZUGFeRD_Test
                 }
             }
         } // !TestMimetypeOfEmbeddedAttachment()
+
+
+        [TestMethod]
+        public void TestOrderInformation()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
+            DateTime timestamp = DateTime.Now.Date;
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            desc.OrderDate = timestamp;
+            desc.OrderNo = "12345";
+            s.Close();
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            Assert.AreEqual(timestamp, loadedInvoice.OrderDate);
+            Assert.AreEqual("12345", loadedInvoice.OrderNo);
+
+        } // !TestOrderInformation()
+
 
         /// <summary>
         /// This test ensure that Writer and Reader uses the same path and namespace for elements

--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -1133,6 +1133,36 @@ namespace ZUGFeRD_Test
 
         } // !TestOrderInformation()
 
+        [TestMethod]
+        public void TestSellerOrderReferencedDocument()
+        {
+            string uuid = System.Guid.NewGuid().ToString();
+            DateTime issueDateTime = DateTime.Today;
+
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            desc.SellerOrderReferencedDocument = new SellerOrderReferencedDocument()
+            {
+                ID = uuid,
+                IssueDateTime = issueDateTime
+            };
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual(Profile.Extended, loadedInvoice.Profile);
+            Assert.AreEqual(uuid, loadedInvoice.SellerOrderReferencedDocument.ID);
+            Assert.AreEqual(issueDateTime, loadedInvoice.SellerOrderReferencedDocument.IssueDateTime);
+        } // !TestSellerOrderReferencedDocument()
+
+
+
         /// <summary>
         /// This test ensure that Writer and Reader uses the same path and namespace for elements
         /// </summary>

--- a/ZUGFeRD-Test/ZUGFeRD21Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD21Tests.cs
@@ -1107,6 +1107,32 @@ namespace ZUGFeRD_Test
             }
         } // !TestMimetypeOfEmbeddedAttachment()
 
+        [TestMethod]
+        public void TestOrderInformation()
+        {
+            string path = @"..\..\..\..\demodata\zugferd21\zugferd_2p1_EXTENDED_Warenrechnung-factur-x.xml";
+            DateTime timestamp = DateTime.Now.Date;
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            desc.OrderDate = timestamp;
+            desc.OrderNo = "12345";
+            s.Close();
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version21, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            Assert.AreEqual(timestamp, loadedInvoice.OrderDate);
+            Assert.AreEqual("12345", loadedInvoice.OrderNo);
+
+        } // !TestOrderInformation()
+
         /// <summary>
         /// This test ensure that Writer and Reader uses the same path and namespace for elements
         /// </summary>

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -294,6 +294,13 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         public DateTime? BillingPeriodEnd { get; set; }
 
+        /// <summary>
+        /// Details about the associated order confirmation (BT-14).
+        /// This is optional and can be used in Profiles Comfort and Extended.
+        /// If you add a SellerOrderReferencedDocument you must set the property "ID".
+        /// The property "IssueDateTime" is optional an only used in profile "Extended"
+        /// </summary>
+        public SellerOrderReferencedDocument SellerOrderReferencedDocument { get; set; } = new SellerOrderReferencedDocument();
 
         /// <summary>
         /// Gets the ZUGFeRD version of a ZUGFeRD invoice that is passed via filename

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -576,7 +576,6 @@ namespace s2industries.ZUGFeRD
             });
         } // !AddAdditionalReferencedDocument()
 
-
         /// <summary>
         /// Sets details of the associated order
         /// </summary>
@@ -603,6 +602,19 @@ namespace s2industries.ZUGFeRD
             };
         } // !SetDeliveryNoteReferenceDocument()
 
+        /// <summary>
+        /// Sets detailed information about the corresponding contract
+        /// </summary>
+        /// <param name="contractNo">Contract number</param>
+        /// <param name="contractDate">Date of the contract</param>
+        public void SetContractReferencedDocument(string contractNo, DateTime? contractDate)
+        {
+            this.ContractReferencedDocument = new ContractReferencedDocument()
+            {
+                ID = contractNo,
+                IssueDateTime = contractDate
+            };
+        } // !SetContractReferencedDocument()
 
         public void AddLogisticsServiceCharge(decimal amount, string description, TaxTypes taxTypeCode, TaxCategoryCodes taxCategoryCode, decimal taxPercent)
         {

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -47,7 +47,7 @@ namespace s2industries.ZUGFeRD
             XmlDocument doc = new XmlDocument();
             doc.Load(stream);
             XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.DocumentElement.OwnerDocument.NameTable);
-            nsmgr.AddNamespace("qdt", "urn:un:unece:uncefact:data:standard:QualifiedDataType:10");
+            nsmgr.AddNamespace("qdt", "urn:un:unece:uncefact:data:standard:QualifiedDataType:100");
             nsmgr.AddNamespace("a", "urn:un:unece:uncefact:data:standard:QualifiedDataType:100");
             nsmgr.AddNamespace("rsm", "urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100");
             nsmgr.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
@@ -70,10 +70,10 @@ namespace s2industries.ZUGFeRD
                 retval.AddNote(content, subjectCode);
             }
 
-            retval.ReferenceOrderNo = _nodeAsString(doc, "//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerReference", nsmgr);
+            retval.ReferenceOrderNo = _nodeAsString(doc, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerReference", nsmgr);
 
             retval.Seller = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty", nsmgr);
-            foreach (XmlNode node in doc.SelectNodes("//ram:ApplicableSupplyChainTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration", nsmgr))
+            foreach (XmlNode node in doc.SelectNodes("//ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration", nsmgr))
             {
                 string id = _nodeAsString(node, ".//ram:ID", nsmgr);
                 string schemeID = _nodeAsString(node, ".//ram:ID/@schemeID", nsmgr);
@@ -114,16 +114,23 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
-            retval.ShipTo = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ShipToTradeParty", nsmgr);
-            retval.ShipFrom = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ShipFromTradeParty", nsmgr);
-            retval.ActualDeliveryDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
+            //Get all referenced and embedded documents (BG-24)
+            XmlNodeList referencedDocNodes = doc.SelectNodes(".//ram:ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
+            foreach (XmlNode referenceNode in referencedDocNodes)
+            {
+                retval.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(referenceNode, nsmgr));
+            }
 
-            string _deliveryNoteNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID", nsmgr);
-            DateTime? _deliveryNoteDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString", nsmgr);
+            retval.ShipTo = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty", nsmgr);
+            retval.ShipFrom = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:ShipFromTradeParty", nsmgr);
+            retval.ActualDeliveryDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
+
+            string _deliveryNoteNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID", nsmgr);
+            DateTime? _deliveryNoteDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString", nsmgr);
 
             if (!_deliveryNoteDate.HasValue)
             {
-                _deliveryNoteDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime", nsmgr);
+                _deliveryNoteDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime", nsmgr);
             }
 
             if (_deliveryNoteDate.HasValue || !String.IsNullOrEmpty(_deliveryNoteNo))
@@ -135,10 +142,10 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
-            retval.Invoicee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:InvoiceeTradeParty", nsmgr);
-            retval.Payee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:PayeeTradeParty", nsmgr);
+            retval.Invoicee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:InvoiceeTradeParty", nsmgr);
+            retval.Payee = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:PayeeTradeParty", nsmgr);
 
-            retval.PaymentReference = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:PaymentReference", nsmgr);
+            retval.PaymentReference = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:PaymentReference", nsmgr);
             retval.Currency = default(CurrencyCodes).FromString(_nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:InvoiceCurrencyCode", nsmgr));
 
             // TODO: Multiple SpecifiedTradeSettlementPaymentMeans can exist for each account/institution (with different SEPA?)
@@ -149,8 +156,8 @@ namespace s2industries.ZUGFeRD
                 SEPACreditorIdentifier = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:CreditorReferenceID", nsmgr),
                 SEPAMandateReference = _nodeAsString(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID", nsmgr),
             };
-            var financialCardId = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:ID", nsmgr);
-            var financialCardCardholderName = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:CardholderName", nsmgr);
+            var financialCardId = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:ID", nsmgr);
+            var financialCardCardholderName = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:CardholderName", nsmgr);
             
             if (!string.IsNullOrEmpty(financialCardId) || !string.IsNullOrEmpty(financialCardCardholderName))
             {
@@ -177,10 +184,10 @@ namespace s2industries.ZUGFeRD
                     {
                         ID = _nodeAsString(creditorFinancialAccountNodes[0], ".//ram:ProprietaryID", nsmgr),
                         IBAN = _nodeAsString(creditorFinancialAccountNodes[0], ".//ram:IBANID", nsmgr),
+                        Name = _nodeAsString(creditorFinancialAccountNodes[0], ".//ram:AccountName", nsmgr),
                         BIC = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:BICID", nsmgr),
                         Bankleitzahl = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:GermanBankleitzahlID", nsmgr),
                         BankName = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:Name", nsmgr),
-                        Name = _nodeAsString(creditorFinancialInstitutions[0], ".//ram:AccountName", nsmgr),
                     };
 
                     retval.CreditorBankAccounts.Add(_account);
@@ -233,7 +240,7 @@ namespace s2industries.ZUGFeRD
             //    } // !for(i)
             //}
 
-            foreach (XmlNode node in doc.SelectNodes("//ram:ApplicableSupplyChainTradeSettlement/ram:ApplicableTradeTax", nsmgr))
+            foreach (XmlNode node in doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:ApplicableTradeTax", nsmgr))
             {
                 retval.AddApplicableTradeTax(_nodeAsDecimal(node, ".//ram:BasisAmount", nsmgr, 0).Value,
                                              _nodeAsDecimal(node, ".//ram:RateApplicablePercent", nsmgr, 0).Value,
@@ -283,17 +290,12 @@ namespace s2industries.ZUGFeRD
 
             retval.InvoiceReferencedDocument = new InvoiceReferencedDocument()
             {
-                ID = _nodeAsString(doc.DocumentElement, "//ram:InvoiceReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                IssueDateTime = _nodeAsDateTime(doc.DocumentElement, "//ram:InvoiceReferencedDocument/ram:FormattedIssueDateTime", nsmgr)
+                ID = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                IssueDateTime = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument/ram:FormattedIssueDateTime", nsmgr)
             };
 
-            retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/udt:FormattedIssueDateTime", nsmgr);
-            if (!retval.OrderDate.HasValue)
-            {
-                retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime", nsmgr);
-            }
-            retval.OrderNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr);
-
+            retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr);
+            retval.OrderNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr);
 
             foreach (XmlNode node in doc.SelectNodes("//ram:IncludedSupplyChainTradeLineItem", nsmgr))
             {
@@ -375,7 +377,7 @@ namespace s2industries.ZUGFeRD
 
             }
 
-            XmlNodeList appliedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge", nsmgr);
+            XmlNodeList appliedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge", nsmgr);
             foreach (XmlNode appliedTradeAllowanceChargeNode in appliedTradeAllowanceChargeNodes)
             {
                 bool chargeIndicator = _nodeAsBool(appliedTradeAllowanceChargeNode, "./ram:ChargeIndicator/udt:Indicator", nsmgr);
@@ -398,57 +400,43 @@ namespace s2industries.ZUGFeRD
                 item.UnitCode = default(QuantityCodes).FromString(_nodeAsString(tradeLineItem, ".//ram:BilledQuantity/@unitCode", nsmgr));
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
             {
                 item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
                 {
-                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/udt:DateTimeString", nsmgr),
+                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr),
                 };
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
             {
                 item.DeliveryNoteReferencedDocument = new DeliveryNoteReferencedDocument()
                 {
-                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/udt:DateTimeString", nsmgr),
+                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr),
                 };
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime", nsmgr) != null)
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime", nsmgr) != null)
             {
-                item.ActualDeliveryDate = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
+                item.ActualDeliveryDate = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
             {
                 item.ContractReferencedDocument = new ContractReferencedDocument()
                 {
-                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/udt:DateTimeString", nsmgr),
+                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr),
                 };
             }
 
-            XmlNodeList referenceNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedSupplyChainTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
+            //Get all referenced AND embedded documents
+            XmlNodeList referenceNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedLineTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
             foreach (XmlNode referenceNode in referenceNodes)
             {
-                string _code = _nodeAsString(referenceNode, "ram:ReferenceTypeCode", nsmgr);
-
-                item.AddAdditionalReferencedDocument(
-                    id: _nodeAsString(referenceNode, "ram:IssuerAssignedID", nsmgr),
-                    date: _nodeAsDateTime(referenceNode, "ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr),
-                    code: default(ReferenceTypeCodes).FromString(_code)
-                );
-            }
-
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
-            {
-                item.ContractReferencedDocument = new ContractReferencedDocument()
-                {
-                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/udt:DateTimeString", nsmgr),
-                };
+                item.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(referenceNode, nsmgr));
             }
 
             return item;
@@ -485,7 +473,7 @@ namespace s2industries.ZUGFeRD
             if (!String.IsNullOrEmpty(lineTwo))
             {
                 retval.ContactName = lineOne;
-                retval.Street = lineOne;
+                retval.Street = lineTwo;
             }
             else
             {
@@ -498,5 +486,21 @@ namespace s2industries.ZUGFeRD
 
             return retval;
         } // !_nodeAsParty()
+
+        private static AdditionalReferencedDocument _getAdditionalReferencedDocument(XmlNode a_oXmlNode, XmlNamespaceManager a_nsmgr)
+        {
+            string strBase64BinaryData = _nodeAsString(a_oXmlNode, "ram:AttachmentBinaryObject", a_nsmgr);
+            return new AdditionalReferencedDocument
+            {
+                ID = _nodeAsString(a_oXmlNode, "ram:IssuerAssignedID", a_nsmgr),
+                TypeCode = default(AdditionalReferencedDocumentTypeCode).FromString(_nodeAsString(a_oXmlNode, "ram:TypeCode", a_nsmgr)),
+                Name = _nodeAsString(a_oXmlNode, "ram:Name", a_nsmgr),
+                IssueDateTime = _nodeAsDateTime(a_oXmlNode, "ram:FormattedIssueDateTime/qdt:DateTimeString", a_nsmgr),
+                AttachmentBinaryObject = !string.IsNullOrEmpty(strBase64BinaryData) ? Convert.FromBase64String(strBase64BinaryData) : null,
+                Filename = _nodeAsString(a_oXmlNode, "ram:AttachmentBinaryObject/@filename", a_nsmgr),
+                ReferenceTypeCode = default(ReferenceTypeCodes).FromString(_nodeAsString(a_oXmlNode, "ram:ReferenceTypeCode", a_nsmgr))
+            };
+        }
+
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -301,7 +301,21 @@ namespace s2industries.ZUGFeRD
             {
                 retval.TradeLineItems.Add(_parseTradeLineItem(node, nsmgr));
             }
+
+            //SellerOrderReferencedDocument
+            if (doc.SelectSingleNode("//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument", nsmgr) != null)
+            {
+                retval.SellerOrderReferencedDocument = new SellerOrderReferencedDocument()
+                {
+                    ID = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr)
+                };
+            }
+
+
+
             return retval;
+
         } // !Load()        
 
 

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -187,19 +187,22 @@ namespace s2industries.ZUGFeRD
 
                 if (tradeLineItem.ContractReferencedDocument != null)
                 {
-                    Writer.WriteStartElement("ram:InvoiceReferencedDocument");
+                    Writer.WriteStartElement("ram:ContractReferencedDocument", Profile.Extended);
                     if (tradeLineItem.ContractReferencedDocument.IssueDateTime.HasValue)
                     {
                         Writer.WriteStartElement("ram:FormattedIssueDateTime");
-                        Writer.WriteValue(_formatDate(tradeLineItem.ContractReferencedDocument.IssueDateTime.Value, true));
-                        Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+                        Writer.WriteStartElement("qdt:DateTimeString");
+                        Writer.WriteAttributeString("format", "102");
+                        Writer.WriteValue(_formatDate(tradeLineItem.ContractReferencedDocument.IssueDateTime.Value));
+                        Writer.WriteEndElement(); // !udt:DateTimeString
+                        Writer.WriteEndElement(); // !ram:IssueDateTime
                     }
                     if (!String.IsNullOrEmpty(tradeLineItem.ContractReferencedDocument.ID))
                     {
                         Writer.WriteElementString("ram:IssuerAssignedID", tradeLineItem.ContractReferencedDocument.ID);
                     }
 
-                    Writer.WriteEndElement(); // !ram:InvoiceReferencedDocument
+                    Writer.WriteEndElement(); // !ram:ContractReferencedDocument(Extended)
                 }
 
                 if (tradeLineItem.AdditionalReferencedDocuments != null)
@@ -211,7 +214,7 @@ namespace s2industries.ZUGFeRD
                         {
                             Writer.WriteStartElement("ram:FormattedIssueDateTime");
                             Writer.WriteStartElement("qdt:DateTimeString");
-                            Writer.WriteValue(_formatDate(document.IssueDateTime.Value, false));
+                            Writer.WriteValue(_formatDate(document.IssueDateTime.Value));
                             Writer.WriteEndElement(); // !qdt:DateTimeString
                             Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
                         }
@@ -279,13 +282,22 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteStartElement("ram:DeliveryNoteReferencedDocument");
                         if (tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.HasValue)
                         {
-                            Writer.WriteStartElement("ram:IssueDateTime");
-                            Writer.WriteValue(_formatDate(tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.Value, false));
-                            Writer.WriteEndElement(); // !ram:IssueDateTime
+                            //Old path of Version 1.0
+                            //Writer.WriteStartElement("ram:IssueDateTime");
+                            //Writer.WriteValue(_formatDate(tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.Value));
+                            //Writer.WriteEndElement(); // !ram:IssueDateTime
+
+                            Writer.WriteStartElement("ram:FormattedIssueDateTime");
+                            Writer.WriteStartElement("qdt:DateTimeString");
+                            Writer.WriteAttributeString("format", "102");
+                            Writer.WriteValue(_formatDate(this.Descriptor.OrderDate.Value));
+                            Writer.WriteEndElement(); // !qdt:DateTimeString
+                            Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
                         }
+
                         if (!String.IsNullOrEmpty(tradeLineItem.DeliveryNoteReferencedDocument.ID))
                         {
-                            Writer.WriteElementString("ram:ID", tradeLineItem.DeliveryNoteReferencedDocument.ID);
+                            Writer.WriteElementString("ram:IssuerAssignedID", tradeLineItem.DeliveryNoteReferencedDocument.ID);
                         }
 
                         Writer.WriteEndElement(); // !ram:DeliveryNoteReferencedDocument
@@ -394,8 +406,8 @@ namespace s2industries.ZUGFeRD
                     if (document.IssueDateTime.HasValue)
                     {
                         Writer.WriteStartElement("ram:FormattedIssueDateTime");
-                        Writer.WriteStartElement("udt:DateTimeString");
-                        Writer.WriteValue(_formatDate(document.IssueDateTime.Value, false));
+                        Writer.WriteStartElement("qdt:DateTimeString");
+                        Writer.WriteValue(_formatDate(document.IssueDateTime.Value));
                         Writer.WriteEndElement(); // !udt:DateTimeString
                         Writer.WriteEndElement(); // !FormattedIssueDateTime
                     }

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -381,6 +381,27 @@ namespace s2industries.ZUGFeRD
             _writeOptionalParty(Writer, "ram:SellerTradeParty", this.Descriptor.Seller, this.Descriptor.SellerContact, TaxRegistrations: this.Descriptor.SellerTaxRegistration);
             _writeOptionalParty(Writer, "ram:BuyerTradeParty", this.Descriptor.Buyer, this.Descriptor.BuyerContact, TaxRegistrations: this.Descriptor.BuyerTaxRegistration);
 
+
+            #region SellerOrderReferencedDocument (BT-14: Comfort, Extended)
+            if (null != this.Descriptor.SellerOrderReferencedDocument && !string.IsNullOrEmpty(Descriptor.SellerOrderReferencedDocument.ID))
+            {
+                Writer.WriteStartElement("ram:SellerOrderReferencedDocument", Profile.Comfort | Profile.Extended);
+                Writer.WriteElementString("ram:IssuerAssignedID", this.Descriptor.SellerOrderReferencedDocument.ID);
+                if (this.Descriptor.SellerOrderReferencedDocument.IssueDateTime.HasValue)
+                {
+                    Writer.WriteStartElement("ram:FormattedIssueDateTime", Profile.Extended);
+                    Writer.WriteStartElement("qdt:DateTimeString");
+                    Writer.WriteAttributeString("format", "102");
+                    Writer.WriteValue(_formatDate(this.Descriptor.SellerOrderReferencedDocument.IssueDateTime.Value));
+                    Writer.WriteEndElement(); // !qdt:DateTimeString
+                    Writer.WriteEndElement(); // !IssueDateTime()
+                }
+
+                Writer.WriteEndElement(); // !SellerOrderReferencedDocument
+            }
+            #endregion
+
+
             if (!String.IsNullOrEmpty(this.Descriptor.OrderNo))
             {
                 Writer.WriteStartElement("ram:BuyerOrderReferencedDocument");

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -119,36 +119,48 @@ namespace s2industries.ZUGFeRD
             // TODO: Read BuyerOrderReferencedDocument
             // TODO: Read ContractReferencedDocument
 
-            if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument", nsmgr) != null)
+
+            //Get all referenced and embedded documents (BG-24)
+            XmlNodeList referencedDocNodes = doc.SelectNodes(".//ram:ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
+            foreach (XmlNode referenceNode in referencedDocNodes)
             {
-                string _issuerAssignedID = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:IssuerAssignedID", nsmgr);
-                string _typeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:TypeCode", nsmgr);
-                string _referenceTypeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:ReferenceTypeCode", nsmgr);
-                string _name = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:Name", nsmgr);
-                DateTime? _date = _nodeAsDateTime(doc.DocumentElement, "//ram:AdditionalReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr);
-
-                if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject", nsmgr) != null)
-                {
-                    string _filename = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject/@filename", nsmgr);
-                    byte[] data = Convert.FromBase64String(_nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject", nsmgr));
-
-                    retval.AddAdditionalReferencedDocument(id: _issuerAssignedID,
-                                                           typeCode: default(AdditionalReferencedDocumentTypeCode).FromString(_typeCode),
-                                                           issueDateTime: _date,                                                           
-                                                           referenceTypeCode: default(ReferenceTypeCodes).FromString(_referenceTypeCode),
-                                                           name: _name,
-                                                           attachmentBinaryObject: data,
-                                                           filename: _filename);
-                }
-                else
-                {
-                    retval.AddAdditionalReferencedDocument(id: _issuerAssignedID,
-                                                           typeCode: default(AdditionalReferencedDocumentTypeCode).FromString(_typeCode),
-                                                           issueDateTime: _date,                                                           
-                                                           referenceTypeCode: default(ReferenceTypeCodes).FromString(_referenceTypeCode),
-                                                           name: _name);
-                }
+                retval.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(referenceNode, nsmgr));
             }
+
+            //-------------------------------------------------
+            // hzi: With old implementation only the first document has been read instead of all documents
+            //-------------------------------------------------
+            //if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument", nsmgr) != null)
+            //{
+            //    string _issuerAssignedID = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:IssuerAssignedID", nsmgr);
+            //    string _typeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:TypeCode", nsmgr);
+            //    string _referenceTypeCode = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:ReferenceTypeCode", nsmgr);
+            //    string _name = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:Name", nsmgr);
+            //    DateTime? _date = _nodeAsDateTime(doc.DocumentElement, "//ram:AdditionalReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr);
+
+            //    if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject", nsmgr) != null)
+            //    {
+            //        string _filename = _nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject/@filename", nsmgr);
+            //        byte[] data = Convert.FromBase64String(_nodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject", nsmgr));
+
+            //        retval.AddAdditionalReferencedDocument(id: _issuerAssignedID,
+            //                                               typeCode: default(AdditionalReferencedDocumentTypeCode).FromString(_typeCode),
+            //                                               issueDateTime: _date,                                                           
+            //                                               referenceTypeCode: default(ReferenceTypeCodes).FromString(_referenceTypeCode),
+            //                                               name: _name,
+            //                                               attachmentBinaryObject: data,
+            //                                               filename: _filename);
+            //    }
+            //    else
+            //    {
+            //        retval.AddAdditionalReferencedDocument(id: _issuerAssignedID,
+            //                                               typeCode: default(AdditionalReferencedDocumentTypeCode).FromString(_typeCode),
+            //                                               issueDateTime: _date,                                                           
+            //                                               referenceTypeCode: default(ReferenceTypeCodes).FromString(_referenceTypeCode),
+            //                                               name: _name);
+            //    }
+            //}
+            //-------------------------------------------------
 
 
             retval.ShipTo = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty", nsmgr);
@@ -187,8 +199,8 @@ namespace s2industries.ZUGFeRD
                 SEPAMandateReference = _nodeAsString(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:DirectDebitMandateID", nsmgr)
             };
 
-            var financialCardId = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:ID", nsmgr);
-            var financialCardCardholderName = _nodeAsString(doc.DocumentElement, "//ram:ApplicableSupplyChainTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:CardholderName", nsmgr);
+            var financialCardId = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:ID", nsmgr);
+            var financialCardCardholderName = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:ApplicableTradeSettlementFinancialCard/ram:CardholderName", nsmgr);
 
             if (!string.IsNullOrEmpty(financialCardId) || !string.IsNullOrEmpty(financialCardCardholderName))
             {
@@ -218,6 +230,7 @@ namespace s2industries.ZUGFeRD
             {
                 retval.CreditorBankAccounts[i].ID = _nodeAsString(creditorFinancialAccountNodes[i], ".//ram:ProprietaryID", nsmgr);
                 retval.CreditorBankAccounts[i].IBAN = _nodeAsString(creditorFinancialAccountNodes[i], ".//ram:IBANID", nsmgr);
+                retval.CreditorBankAccounts[i].Name = _nodeAsString(creditorFinancialAccountNodes[i], ".//ram:AccountName", nsmgr);
             }
 
             for (int i = 0; i < creditorFinancialInstitutions.Count; i++)
@@ -225,7 +238,6 @@ namespace s2industries.ZUGFeRD
                 retval.CreditorBankAccounts[i].BIC = _nodeAsString(creditorFinancialInstitutions[i], ".//ram:BICID", nsmgr);
                 retval.CreditorBankAccounts[i].Bankleitzahl = _nodeAsString(creditorFinancialInstitutions[i], ".//ram:GermanBankleitzahlID", nsmgr);
                 retval.CreditorBankAccounts[i].BankName = _nodeAsString(creditorFinancialInstitutions[i], ".//ram:Name", nsmgr);
-                retval.CreditorBankAccounts[i].Name = _nodeAsString(creditorFinancialInstitutions[i], ".//ram:AccountName", nsmgr);
             }            
 
             var specifiedTradeSettlementPaymentMeansNodes = doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans", nsmgr);
@@ -317,11 +329,7 @@ namespace s2industries.ZUGFeRD
                 });
             }
 
-            retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/udt:DateTimeString", nsmgr);
-            if (!retval.OrderDate.HasValue)
-            {
-                retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime", nsmgr);
-            }
+            retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr);
             retval.OrderNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr);
 
             retval.ContractReferencedDocument = new ContractReferencedDocument
@@ -332,8 +340,8 @@ namespace s2industries.ZUGFeRD
 
             retval.SpecifiedProcuringProject = new SpecifiedProcuringProject
             {
-                ID = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:ContractReferencedDocument/ram:ID", nsmgr),
-                Name = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:ContractReferencedDocument/ram:Name", nsmgr)
+                ID = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:SpecifiedProcuringProject/ram:ID", nsmgr),
+                Name = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:SpecifiedProcuringProject/ram:Name", nsmgr)
             };
 
             foreach (XmlNode node in doc.SelectNodes("//ram:IncludedSupplyChainTradeLineItem", nsmgr))
@@ -408,7 +416,7 @@ namespace s2industries.ZUGFeRD
                 item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
                 {
                     ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime/qdt:DateTimeString", nsmgr)
+                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr)
                 };
             }
 
@@ -417,7 +425,7 @@ namespace s2industries.ZUGFeRD
                 item.ContractReferencedDocument = new ContractReferencedDocument()
                 {
                     ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssueDateTime/qdt:DateTimeString", nsmgr)
+                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr)
                 };
             }
 
@@ -470,7 +478,7 @@ namespace s2industries.ZUGFeRD
 
             }
 
-            XmlNodeList appliedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedSupplyChainTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge", nsmgr);
+            XmlNodeList appliedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedLineTradeAgreement/ram:GrossPriceProductTradePrice/ram:AppliedTradeAllowanceCharge", nsmgr);
             foreach (XmlNode appliedTradeAllowanceChargeNode in appliedTradeAllowanceChargeNodes)
             {
                 bool chargeIndicator = _nodeAsBool(appliedTradeAllowanceChargeNode, "./ram:ChargeIndicator/udt:Indicator", nsmgr);
@@ -493,48 +501,34 @@ namespace s2industries.ZUGFeRD
                 item.UnitCode = default(QuantityCodes).FromString(_nodeAsString(tradeLineItem, ".//ram:BilledQuantity/@unitCode", nsmgr));
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
-            {
-                item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
-                {
-                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssueDateTime", nsmgr),
-                };
-            }
-
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
             {
                 item.DeliveryNoteReferencedDocument = new DeliveryNoteReferencedDocument()
                 {
-                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString", nsmgr),
+                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr),
                 };
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime", nsmgr) != null)
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime", nsmgr) != null)
             {
-                item.ActualDeliveryDate = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
+                item.ActualDeliveryDate = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
-            {
-                item.ContractReferencedDocument = new ContractReferencedDocument()
-                {
-                    ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssueDateTime/udt:DateTimeString", nsmgr),
-                };
-            }
+            //if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr) != null)
+            //{
+            //    item.ContractReferencedDocument = new ContractReferencedDocument()
+            //    {
+            //        ID = _nodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
+            //        IssueDateTime = _nodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr),
+            //    };
+            //}
 
-            XmlNodeList referenceNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedSupplyChainTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
+            //Get all referenced AND embedded documents
+            XmlNodeList referenceNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedLineTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
             foreach (XmlNode referenceNode in referenceNodes)
             {
-                string _code = _nodeAsString(referenceNode, "ram:ReferenceTypeCode", nsmgr);
-
-                item.AddAdditionalReferencedDocument(
-                    id: _nodeAsString(referenceNode, "ram:IssuerAssignedID", nsmgr),
-                    date: _nodeAsDateTime(referenceNode, "ram:IssueDateTime/udt:DateTimeString", nsmgr),
-                    code: default(ReferenceTypeCodes).FromString(_code)
-                );
+                item.AdditionalReferencedDocuments.Add(_getAdditionalReferencedDocument(referenceNode, nsmgr));
             }
 
             return item;
@@ -584,5 +578,21 @@ namespace s2industries.ZUGFeRD
 
             return retval;
         } // !_nodeAsParty()
+
+        private static AdditionalReferencedDocument _getAdditionalReferencedDocument(XmlNode a_oXmlNode, XmlNamespaceManager a_nsmgr)
+        {
+            string strBase64BinaryData = _nodeAsString(a_oXmlNode, "ram:AttachmentBinaryObject", a_nsmgr);
+            return new AdditionalReferencedDocument
+            {
+                ID = _nodeAsString(a_oXmlNode, "ram:IssuerAssignedID", a_nsmgr),
+                TypeCode = default(AdditionalReferencedDocumentTypeCode).FromString(_nodeAsString(a_oXmlNode, "ram:TypeCode", a_nsmgr)),
+                Name = _nodeAsString(a_oXmlNode, "ram:Name", a_nsmgr),
+                IssueDateTime = _nodeAsDateTime(a_oXmlNode, "ram:FormattedIssueDateTime/qdt:DateTimeString", a_nsmgr),
+                AttachmentBinaryObject = !string.IsNullOrEmpty(strBase64BinaryData) ? Convert.FromBase64String(strBase64BinaryData) : null,
+                Filename = _nodeAsString(a_oXmlNode, "ram:AttachmentBinaryObject/@filename", a_nsmgr),
+                ReferenceTypeCode = default(ReferenceTypeCodes).FromString(_nodeAsString(a_oXmlNode, "ram:ReferenceTypeCode", a_nsmgr))
+            };
+        }
+
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -115,10 +115,6 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
-            // TODO: Read SellerOrderReferencedDocument
-            // TODO: Read BuyerOrderReferencedDocument
-            // TODO: Read ContractReferencedDocument
-
 
             //Get all referenced and embedded documents (BG-24)
             XmlNodeList referencedDocNodes = doc.SelectNodes(".//ram:ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
@@ -332,11 +328,25 @@ namespace s2industries.ZUGFeRD
             retval.OrderDate = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr);
             retval.OrderNo = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr);
 
-            retval.ContractReferencedDocument = new ContractReferencedDocument
+            // Read SellerOrderReferencedDocument
+            if (doc.SelectSingleNode("//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument", nsmgr) != null)
             {
-                ID = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                IssueDateTime = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime", nsmgr)
-            };
+                retval.SellerOrderReferencedDocument = new SellerOrderReferencedDocument()
+                {
+                    ID = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:SellerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr)
+                };
+            }
+
+            // Read ContractReferencedDocument
+            if (doc.SelectSingleNode("//ram:ApplicableHeaderTradeAgreement/ram:ContractReferencedDocument", nsmgr) != null)
+            {
+                retval.ContractReferencedDocument = new ContractReferencedDocument
+                {
+                    ID = _nodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = _nodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime", nsmgr)
+                };
+            }
 
             retval.SpecifiedProcuringProject = new SpecifiedProcuringProject
             {
@@ -348,6 +358,7 @@ namespace s2industries.ZUGFeRD
             {
                 retval.TradeLineItems.Add(_parseTradeLineItem(node, nsmgr));
             }
+
             return retval;
         } // !Load()        
 

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -518,6 +518,26 @@ namespace s2industries.ZUGFeRD
             }
             #endregion            
 
+
+            #region SellerOrderReferencedDocument (BT-14: Comfort, Extended)
+            if (null != this.Descriptor.SellerOrderReferencedDocument && !string.IsNullOrEmpty(Descriptor.SellerOrderReferencedDocument.ID))
+            {
+                Writer.WriteStartElement("ram:SellerOrderReferencedDocument", Profile.Comfort | Profile.Extended);
+                Writer.WriteElementString("ram:IssuerAssignedID", this.Descriptor.SellerOrderReferencedDocument.ID);
+                if (this.Descriptor.SellerOrderReferencedDocument.IssueDateTime.HasValue)
+                {
+                    Writer.WriteStartElement("ram:FormattedIssueDateTime", Profile.Extended);
+                    Writer.WriteStartElement("qdt:DateTimeString");
+                    Writer.WriteAttributeString("format", "102");
+                    Writer.WriteValue(_formatDate(this.Descriptor.SellerOrderReferencedDocument.IssueDateTime.Value));
+                    Writer.WriteEndElement(); // !qdt:DateTimeString
+                    Writer.WriteEndElement(); // !IssueDateTime()
+                }
+
+                Writer.WriteEndElement(); // !SellerOrderReferencedDocument
+            }
+            #endregion
+
             #region ContractReferencedDocument
             // BT-12
             if (this.Descriptor.ContractReferencedDocument != null)

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -211,8 +211,8 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteStartElement("ram:ContractReferencedDocument", Profile.Extended);
                         if (tradeLineItem.ContractReferencedDocument.IssueDateTime.HasValue)
                         {
-                            Writer.WriteStartElement("ram:IssueDateTime");
-                            Writer.WriteStartElement("udt:DateTimeString");
+                            Writer.WriteStartElement("ram:FormattedIssueDateTime");
+                            Writer.WriteStartElement("qdt:DateTimeString");
                             Writer.WriteAttributeString("format", "102");
                             Writer.WriteValue(_formatDate(tradeLineItem.ContractReferencedDocument.IssueDateTime.Value));
                             Writer.WriteEndElement(); // !udt:DateTimeString
@@ -335,7 +335,7 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteStartElement("ram:FormattedIssueDateTime");
                         Writer.WriteStartElement("qdt:DateTimeString");
                         Writer.WriteAttributeString("format", "102");
-                        Writer.WriteValue(_formatDate(tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.Value, false));
+                        Writer.WriteValue(_formatDate(tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.Value));
                         Writer.WriteEndElement(); // "qdt:DateTimeString
                         Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
                     }
@@ -881,7 +881,7 @@ namespace s2industries.ZUGFeRD
             //Gesamtsummen auf Dokumentenebene
             Writer.WriteStartElement("ram:SpecifiedTradeSettlementHeaderMonetarySummation");
             _writeOptionalAmount(Writer, "ram:LineTotalAmount", this.Descriptor.LineTotalAmount);                                  // Summe der Nettobeträge aller Rechnungspositionen
-            _writeOptionalAmount(Writer, "ram:ChargeTotalAmount", this.Descriptor.ChargeTotalAmount);                              // S umme der Zuschläge auf Dokumentenebene
+            _writeOptionalAmount(Writer, "ram:ChargeTotalAmount", this.Descriptor.ChargeTotalAmount);                              // Summe der Zuschläge auf Dokumentenebene
             _writeOptionalAmount(Writer, "ram:AllowanceTotalAmount", this.Descriptor.AllowanceTotalAmount);                        // Summe der Abschläge auf Dokumentenebene
 
             if (this.Descriptor.Profile == Profile.Extended)

--- a/ZUGFeRD/SellerOrderReferencedDocument.cs
+++ b/ZUGFeRD/SellerOrderReferencedDocument.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace s2industries.ZUGFeRD
+{
+    /// <summary>
+    /// Structure containing details of the associated order confirmation (BT-14)
+    /// </summary>
+    public class SellerOrderReferencedDocument : BaseReferencedDocument
+    {
+    }
+}


### PR DESCRIPTION
Primary I wanted only add reading more than AdditionalReferencedDocuments. But when writing the UnitTest for my changes I detected many bugs because of differences beetween Writer and Reader. So I decided to write a UnitTest to compare all written data with the read data. With this UnitTest I found some little bugs in Writer but a lot of bugs in Reader mostly because of false element pathes. Following I list my changes:

- Bugfix: Rename element name "SpecifiedSupplyChainTradeAgreement" to "SpecifiedLineTradeAgreement";
- Bugfix: Rename element name "SpecifiedSupplyChainTradeDelivery" to "SpecifiedLineTradeDelivery";
- Bugfix: Rename element name "ApplicableSupplyChainTradeSettlement" to "ApplicableHeaderTradeSettlement" (InvoiceDescriptor20Reader)
- Bugfix: AccountName of CreditorBankAccounts must be read from "PayeePartyCreditorFinancialAccount" instead from "PayeeSpecifiedCreditorFinancialInstitution"
- Bugfix: tradeLineItem.BuyerOrderReferencedDocument was read twice
- Bugfix: tradeLineItem.ContractReferencedDocument was read twice
- Bugfix: Format DeliveryNoteReferencedDocument.IssueDateTime as "102"
- Bugfix: SpecifiedProcuringProject was read from element "ContractReferencedDocument" instead from element "SpecifiedProcuringProject"
- Bugfix: IssueDateTime of DeliveryNoteReferencedDocument was written in a false path (InvoiceDescriptor20Reader)
- Bugfix: tradeLineItem.ContractReferencedDocument was written as Element "InvoiceReferencedDocument" instead of "ContractReferencedDocument" (InvoiceDescriptor20Writer)
- Feature: Read all AdditionalReferencedDocuments not only the first one;
- Test: Correct existing UnitTest "TestMimetypeOfEmbeddedAttachment", because there are now more than one referenced document.
- Test: New UnitTest to ensure that reader gets all data written by writer