### PR TITLE
Add XRechnung 2.0 as valid URI in InvoiceDescriptor21Reader.

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -374,6 +374,7 @@ namespace s2industries.ZUGFeRD
                     "urn:factur-x.eu:1p0:basicwl", // BASIC WL
                     "urn:factur-x.eu:1p0:minimum", // MINIMUM
                     "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_1.2", // XRechnung 1.2
+                    "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.0", // XRechnung 2.0
                     "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.1", // XRechnung 2.1
                     "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2" // XRechnung 2.2
                 };


### PR DESCRIPTION
As discussed in #211 the InvoiceDescriptor21Reader can support reading version 2.0, it just needs to accept the URI.