### PR TITLE
Update InvoiceDescriptor21Reader.cs to enable XRechnung 2.3 loading

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor21Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Reader.cs
@@ -400,7 +400,8 @@ namespace s2industries.ZUGFeRD
                     "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_1.2", // XRechnung 1.2
                     "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.0", // XRechnung 2.0
                     "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.1", // XRechnung 2.1
-                    "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2" // XRechnung 2.2
+                    "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2", // XRechnung 2.2                    
+                    "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3" // XRechnung 2.3
                 };
 
       return _IsReadableByThisReaderVersion(stream, validURIs);


### PR DESCRIPTION
Right now it's only possible to save data in 2.3, but not to load the saved files.

Therefore I added a pull request, to make the files loadable again.