### PR TITLE
Ensure ElectronicAddressSchemeIdentifiers are written with 4 digits

### DIFF
--- a/ZUGFeRD/ElectronicAddressSchemeIdentifiers.cs
+++ b/ZUGFeRD/ElectronicAddressSchemeIdentifiers.cs
@@ -228,7 +228,7 @@ namespace s2industries.ZUGFeRD
 
       public static string EnumToString(this ElectronicAddressSchemeIdentifiers eas)
       {
-         return ((int)eas).ToString();
+         return ((int)eas).ToString("D4");
       } // !ToString()
    }
 }


### PR DESCRIPTION
Added padding to Identifiers when converted from Enum to String