### PR TITLE
If the ram:ID is not set for the Seller or Buyer Party, an empty tag is no longer written

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -480,7 +480,7 @@ namespace s2industries.ZUGFeRD
         } // !AddNote()        
 
 
-        public void SetBuyer(string name, string postcode, string city, string street, CountryCodes country, string id,
+        public void SetBuyer(string name, string postcode, string city, string street, CountryCodes country, string id = null,
             GlobalID globalID = null, string receiver = "", LegalOrganization legalOrganization = null)
         {
             this.Buyer = new Party()
@@ -498,7 +498,7 @@ namespace s2industries.ZUGFeRD
         }
 
 
-        public void SetSeller(string name, string postcode, string city, string street, CountryCodes country, string id,
+        public void SetSeller(string name, string postcode, string city, string street, CountryCodes country, string id = null,
             GlobalID globalID = null, LegalOrganization legalOrganization = null)
         {
             this.Seller = new Party()

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -1348,7 +1348,7 @@ namespace s2industries.ZUGFeRD
                         writer.WriteValue(party.ID.ID);
                         writer.WriteEndElement();
                     }
-                    else
+                    else if (!String.IsNullOrEmpty(party.ID.ID))
                     {
                         writer.WriteElementString("ram:ID", party.ID.ID);
                     }


### PR DESCRIPTION
1. The `SetBuyer` and `SetSeller` methods in the `InvoiceDescriptor.cs` file have been updated to include an optional parameter for `id`. This parameters has a default values of `null`. This change allows for more flexibility when setting the buyer or seller information. (Reference: `InvoiceDescriptor.cs`)

2. In the `InvoiceDescriptor21Writer.cs` file, a condition has been added to the `else` clause in the `if` statement. Now, the `ram:ID` element will only be written if `party.ID.ID` is not null or an empty string. This change prevents writing an emtpy 'ram:id'. (Reference: `InvoiceDescriptor21Writer.cs`)