### PR TITLE
ApplicableTradeSettlementFinancialCard (payment card info) gets generated for XRechnung

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -527,7 +527,7 @@ namespace s2industries.ZUGFeRD
 
                         if (this.Descriptor.PaymentMeans.FinancialCard != null)
                         {
-                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended);
+                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended | Profile.XRechnung);
                             Writer.WriteElementString("ram:ID", Descriptor.PaymentMeans.FinancialCard.Id);
                             Writer.WriteElementString("ram:CardholderName", Descriptor.PaymentMeans.FinancialCard.CardholderName);
                             Writer.WriteEndElement(); // !ram:ApplicableTradeSettlementFinancialCard
@@ -549,7 +549,7 @@ namespace s2industries.ZUGFeRD
 
                         if (this.Descriptor.PaymentMeans.FinancialCard != null)
                         {
-                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended);
+                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended | Profile.XRechnung);
                             Writer.WriteElementString("ram:ID", Descriptor.PaymentMeans.FinancialCard.Id);
                             Writer.WriteElementString("ram:CardholderName", Descriptor.PaymentMeans.FinancialCard.CardholderName);
                             Writer.WriteEndElement(); // !ram:ApplicableTradeSettlementFinancialCard

--- a/ZUGFeRD/InvoiceDescriptor21Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor21Writer.cs
@@ -704,7 +704,7 @@ namespace s2industries.ZUGFeRD
 
                         if (this.Descriptor.PaymentMeans.FinancialCard != null)
                         {
-                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended);
+                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended | Profile.XRechnung);
                             Writer.WriteOptionalElementString("ram:ID", Descriptor.PaymentMeans.FinancialCard.Id);
                             Writer.WriteOptionalElementString("ram:CardholderName", Descriptor.PaymentMeans.FinancialCard.CardholderName);
                             Writer.WriteEndElement(); // !ram:ApplicableTradeSettlementFinancialCard
@@ -726,7 +726,7 @@ namespace s2industries.ZUGFeRD
 
                         if (this.Descriptor.PaymentMeans.FinancialCard != null)
                         {
-                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended);
+                            Writer.WriteStartElement("ram:ApplicableTradeSettlementFinancialCard", Profile.Comfort | Profile.Extended | Profile.XRechnung);
                             Writer.WriteOptionalElementString("ram:ID", Descriptor.PaymentMeans.FinancialCard.Id);
                             Writer.WriteOptionalElementString("ram:CardholderName", Descriptor.PaymentMeans.FinancialCard.CardholderName);
                             Writer.WriteEndElement(); // !ram:ApplicableTradeSettlementFinancialCard


### PR DESCRIPTION
The XRechnung validation fails if the payment is made by card because its missing the payment card info (`ApplicableTradeSettlementFinancialCard`)

Example code:

```
        invoice.SetPaymentMeans(paymentCode: PaymentMeansTypeCodes.BankCard, information: "info");
        invoice.PaymentMeans.FinancialCard = new FinancialCard
        {
            Id = "1234",
            CardholderName = "John John"
        };
```

or

`invoice.SetPaymentMeansFinancialCard("1234", "John John", "info");`

using any of the above examples will lead to this error
![image](https://github.com/stephanstapel/ZUGFeRD-csharp/assets/51375082/a381b3c4-280f-4aa6-ac4f-16c072255178)

I apologize in advance if I am missing something as I didn't have much time diving into the code.