### PR TITLE
renamed "Abschläge" to "Gutschriften" in inline xml doc

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -745,7 +745,7 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         /// <param name="lineTotalAmount">Gesamtbetrag der Positionen</param>
         /// <param name="chargeTotalAmount">Gesamtbetrag der Zuschläge</param>
-        /// <param name="allowanceTotalAmount">Gesamtbetrag der Abschläge</param>
+        /// <param name="allowanceTotalAmount">Gesamtbetrag der Gutschriften</param>
         /// <param name="taxBasisAmount">Basisbetrag der Steuerberechnung</param>
         /// <param name="taxTotalAmount">Steuergesamtbetrag</param>
         /// <param name="grandTotalAmount">Bruttosumme</param>


### PR DESCRIPTION
I renamed it because "Abschläge" are in many invoices something different. Imagine a water consumption invoice - it mentions "Abschläge" in the form of an invoice plan