### PR TITLE
Upper-case TaxExemptionReasonCodes ToString extension method

### DIFF
--- a/ZUGFeRD/TaxExemptionReasonCodes.cs
+++ b/ZUGFeRD/TaxExemptionReasonCodes.cs
@@ -453,7 +453,7 @@ namespace s2industries.ZUGFeRD
 
         public static string EnumToString(this TaxExemptionReasonCodes codes)
         {
-            return codes.ToString("g").Replace("_","-");
+            return codes.ToString("g").ToUpperInvariant().Replace("_","-");
         } // !ToString()
     }
 }


### PR DESCRIPTION
Fixes https://github.com/stephanstapel/ZUGFeRD-csharp/issues/274