### PR TITLE
Enable setting seller description

### DIFF
--- a/ZUGFeRD-Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD22Tests.cs
@@ -2000,5 +2000,31 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(allowanceCharge.Reason, "Discount 10%");
         } // !SpecifiedTradeAllowanceCharge()
 
+        [TestMethod]
+        public void TestSellerDescription()
+        {
+            InvoiceDescriptor invoice = InvoiceProvider.CreateInvoice();
+
+            string description = "Test description";
+
+			invoice.SetSeller(name: "Lieferant GmbH",
+                              postcode: "80333",
+                              city: "München",
+                              street: "Lieferantenstraße 20",
+                              country: CountryCodes.DE,
+                              id: "",
+                              globalID: new GlobalID(GlobalIDSchemeIdentifiers.GLN, "4000001123452"),
+                              legalOrganization: new LegalOrganization(GlobalIDSchemeIdentifiers.GLN, "4000001123452", "Lieferant GmbH"),
+                              description: description
+                              );
+
+            MemoryStream ms = new MemoryStream();
+            invoice.Save(ms, ZUGFeRDVersion.Version22, Profile.Extended);
+            ms.Position = 0;
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual(loadedInvoice.Seller.Description, description);
+        } // !TestSellerDescription()
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -567,7 +567,7 @@ namespace s2industries.ZUGFeRD
 
 
         public void SetSeller(string name, string postcode, string city, string street, CountryCodes country, string id = null,
-            GlobalID globalID = null, LegalOrganization legalOrganization = null)
+            GlobalID globalID = null, LegalOrganization legalOrganization = null, string description = null)
         {
             this.Seller = new Party()
             {
@@ -579,6 +579,7 @@ namespace s2industries.ZUGFeRD
                 Country = country,
                 GlobalID = globalID,
                 SpecifiedLegalOrganization = legalOrganization,
+                Description = description
             };
         } // !SetSeller()
 


### PR DESCRIPTION
Hello :wave:

In this recent PR https://github.com/stephanstapel/ZUGFeRD-csharp/pull/303 the "Description" field was added to Seller parties, however as far as I can tell there is no way to set it using the methods of the InvoiceDescriptor?

What would you think of adding an argument to the `SetSeller` method to enable this?

It also seemed to me that the situation is the same for the new invoice root `Name` property, however I wasn't sure what is the prefered way to expose it, maybe adding an optional argument to the static `CreateInvoice` method?