### PR TITLE
Added Austria VAT Number to ElectronicAddressSchemeIdentifiers.cs

### DIFF
--- a/ZUGFeRD/ElectronicAddressSchemeIdentifiers.cs
+++ b/ZUGFeRD/ElectronicAddressSchemeIdentifiers.cs
@@ -46,6 +46,11 @@ namespace s2industries.ZUGFeRD
         HungaryVatNumber = 9910,
 
         /// <summary>
+        /// Austria VAT number
+        /// </summary>      
+        AustriaVatNumber = 9914,
+
+        /// <summary>
         /// Andorra VAT number
         /// </summary>      
         AndorraVatNumber = 9922,


### PR DESCRIPTION
As mentioned in https://github.com/stephanstapel/ZUGFeRD-csharp/issues/353, this Enum was missing the value for the Austrian VAT Number.