### PR TITLE
Change SpecifiedTradePaymentTerms from type to List<>

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ desc.SetTotals(202.76m, 5.80m, 14.73m, 193.83m, 21.31m, 215.14m, 50.0m, 165.14m)
 desc.AddApplicableTradeTax(129.37m, 7m, TaxTypes.VAT, TaxCategoryCodes.S);
 desc.AddApplicableTradeTax(64.46m, 19m, TaxTypes.VAT, TaxCategoryCodes.S);
 desc.AddLogisticsServiceCharge(5.80m, "Versandkosten", TaxTypes.VAT, TaxCategoryCodes.S, 7m);
-desc.SetTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.07.2013, 3% Skonto innerhalb 10 Tagen bis 15.06.2013", new DateTime(2013, 07, 04));
+desc.AddTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
+desc.AddTradePaymentTerms("3% Skonto innerhalb 10 Tagen bis 15.03.2018", new DateTime(2018, 3, 15), 3m);
 ```
 
 Optionally, to support Peppol, an electronic address can be passed:

--- a/ZUGFeRD-Test/InvoiceProvider.cs
+++ b/ZUGFeRD-Test/InvoiceProvider.cs
@@ -102,7 +102,7 @@ namespace ZUGFeRD_Test
 									   categoryCode: TaxCategoryCodes.S
 									   );
 
-			desc.SetTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018");
+			desc.AddTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018");
 			desc.SetTotals(lineTotalAmount: 473.0m,
 						   taxBasisAmount: 473.0m,
 						   taxTotalAmount: 56.87m,

--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -16,747 +16,746 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-using System;
-using System.IO;
-using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using s2industries.ZUGFeRD;
 
 
 namespace ZUGFeRD_Test
 {
-  [TestClass]
-  public class ZUGFeRD20Tests : TestBase
-  {
-    InvoiceProvider InvoiceProvider = new InvoiceProvider();
-
-    [TestMethod]
-    public void TestReferenceBasicInvoice()
+    [TestClass]
+    public class ZUGFeRD20Tests : TestBase
     {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
+        InvoiceProvider InvoiceProvider = new InvoiceProvider();
 
-      Stream s = File.Open(path, FileMode.Open);
-      InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
-      s.Close();
+        [TestMethod]
+        public void TestReferenceBasicInvoice()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
 
-      Assert.AreEqual(desc.Profile, Profile.Basic);
-      Assert.AreEqual(desc.Type, InvoiceType.Invoice);
-      Assert.AreEqual(desc.InvoiceNo, "471102");
-      Assert.AreEqual(desc.TradeLineItems.Count, 1);
-      Assert.AreEqual(desc.LineTotalAmount, 198.0m);
-      Assert.IsFalse(desc.IsTest);
-    } // !TestReferenceBasicInvoice()
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
+
+            Assert.AreEqual(desc.Profile, Profile.Basic);
+            Assert.AreEqual(desc.Type, InvoiceType.Invoice);
+            Assert.AreEqual(desc.InvoiceNo, "471102");
+            Assert.AreEqual(desc.TradeLineItems.Count, 1);
+            Assert.AreEqual(desc.LineTotalAmount, 198.0m);
+            Assert.IsFalse(desc.IsTest);
+        } // !TestReferenceBasicInvoice()
 
 
-    [TestMethod]
-    public void TestReferenceExtendedInvoice()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
+        [TestMethod]
+        public void TestReferenceExtendedInvoice()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
 
-      Stream s = File.Open(path, FileMode.Open);
-      InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
-      s.Close();
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
 
-      Assert.AreEqual(desc.Profile, Profile.Extended);
-      Assert.AreEqual(desc.Type, InvoiceType.Invoice);
-      Assert.AreEqual(desc.InvoiceNo, "R87654321012345");
-      Assert.AreEqual(desc.TradeLineItems.Count, 6);
-      Assert.AreEqual(desc.LineTotalAmount, 457.20m);
-      Assert.IsTrue(desc.IsTest);
+            Assert.AreEqual(desc.Profile, Profile.Extended);
+            Assert.AreEqual(desc.Type, InvoiceType.Invoice);
+            Assert.AreEqual(desc.InvoiceNo, "R87654321012345");
+            Assert.AreEqual(desc.TradeLineItems.Count, 6);
+            Assert.AreEqual(desc.LineTotalAmount, 457.20m);
+            Assert.IsTrue(desc.IsTest);
         } // !TestReferenceExtendedInvoice()
 
 
-    [TestMethod]
-    public void TestTotalRounding()
-    {
-      var uuid = Guid.NewGuid().ToString();
-      var issueDateTime = DateTime.Today;
-
-      var desc = new InvoiceDescriptor
-      {
-        ContractReferencedDocument = new ContractReferencedDocument
+        [TestMethod]
+        public void TestTotalRounding()
         {
-          ID = uuid,
-          IssueDateTime = issueDateTime
-        }
-      };
-      desc.SetTotals(1.99m, 0m, 0m, 0m, 0m, 2m, 0m, 2m, 0.01m);
+            var uuid = Guid.NewGuid().ToString();
+            var issueDateTime = DateTime.Today;
 
-      var msExtended = new MemoryStream();
-      desc.Save(msExtended, ZUGFeRDVersion.Version20, Profile.Extended);
-      msExtended.Seek(0, SeekOrigin.Begin);
+            var desc = new InvoiceDescriptor
+            {
+                ContractReferencedDocument = new ContractReferencedDocument
+                {
+                    ID = uuid,
+                    IssueDateTime = issueDateTime
+                }
+            };
+            desc.SetTotals(1.99m, 0m, 0m, 0m, 0m, 2m, 0m, 2m, 0.01m);
 
-      var loadedInvoice = InvoiceDescriptor.Load(msExtended);
-      Assert.AreEqual(loadedInvoice.RoundingAmount, 0.01m);
+            var msExtended = new MemoryStream();
+            desc.Save(msExtended, ZUGFeRDVersion.Version20, Profile.Extended);
+            msExtended.Seek(0, SeekOrigin.Begin);
 
-      var msBasic = new MemoryStream();
-      desc.Save(msBasic, ZUGFeRDVersion.Version20);
-      msBasic.Seek(0, SeekOrigin.Begin);
+            var loadedInvoice = InvoiceDescriptor.Load(msExtended);
+            Assert.AreEqual(loadedInvoice.RoundingAmount, 0.01m);
 
-      loadedInvoice = InvoiceDescriptor.Load(msBasic);
-      Assert.AreEqual(loadedInvoice.RoundingAmount, 0m);
-    } // !TestTotalRounding()
+            var msBasic = new MemoryStream();
+            desc.Save(msBasic, ZUGFeRDVersion.Version20);
+            msBasic.Seek(0, SeekOrigin.Begin);
 
-
-    [TestMethod]
-    public void TestMissingPropertiesAreNull()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
-
-      var invoiceDescriptor = InvoiceDescriptor.Load(path);
-
-      Assert.IsTrue(invoiceDescriptor.TradeLineItems.TrueForAll(x => x.BillingPeriodStart == null));
-      Assert.IsTrue(invoiceDescriptor.TradeLineItems.TrueForAll(x => x.BillingPeriodEnd == null));
-    } // !TestMissingPropertiesAreNull()
+            loadedInvoice = InvoiceDescriptor.Load(msBasic);
+            Assert.AreEqual(loadedInvoice.RoundingAmount, 0m);
+        } // !TestTotalRounding()
 
 
-    [TestMethod]
-    public void TestMissingPropertListsEmpty()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
-
-      var invoiceDescriptor = InvoiceDescriptor.Load(path);
-
-      Assert.IsTrue(invoiceDescriptor.TradeLineItems.TrueForAll(x => x.ApplicableProductCharacteristics.Count == 0));
-    } // !TestMissingPropertListsEmpty()
-
-
-    [TestMethod]
-    public void TestLoadingSepaPreNotification()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EN16931_SEPA_Prenotification.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
-
-      var invoiceDescriptor = InvoiceDescriptor.Load(path);
-      Assert.AreEqual(Profile.Comfort, invoiceDescriptor.Profile);
-
-      Assert.AreEqual("DE98ZZZ09999999999", invoiceDescriptor.PaymentMeans.SEPACreditorIdentifier);
-      Assert.AreEqual("REF A-123", invoiceDescriptor.PaymentMeans.SEPAMandateReference);
-      Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
-      Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
-
-      Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.Description.Trim());
-    } // !TestLoadingSepaPreNotification()
-
-
-    [TestMethod]
-    public void TestStoringSepaPreNotification()
-    {
-      var d = new InvoiceDescriptor();
-      d.Type = InvoiceType.Invoice;
-      d.InvoiceNo = "471102";
-      d.Currency = CurrencyCodes.EUR;
-      d.InvoiceDate = new DateTime(2018, 3, 5);
-      d.AddTradeLineItem(
-          lineID: "1",
-          id: new GlobalID(GlobalIDSchemeIdentifiers.EAN, "4012345001235"),
-          sellerAssignedID: "TB100A4",
-          name: "Trennblätter A4",
-          billedQuantity: 20m,
-          unitCode: QuantityCodes.C62,
-          netUnitPrice: 9.9m,
-          grossUnitPrice: 9.9m,
-          categoryCode: TaxCategoryCodes.S,
-          taxPercent: 19.0m,
-          taxType: TaxTypes.VAT);
-      d.AddTradeLineItem(
-          lineID: "2",
-          id: new GlobalID(GlobalIDSchemeIdentifiers.EAN, "4000050986428"),
-          sellerAssignedID: "ARNR2",
-          name: "Joghurt Banane",
-          billedQuantity: 50m,
-          unitCode: QuantityCodes.C62,
-          netUnitPrice: 5.5m,
-          grossUnitPrice: 5.5m,
-          categoryCode: TaxCategoryCodes.S,
-          taxPercent: 7.0m,
-          taxType: TaxTypes.VAT);
-      d.SetSeller(
-          id: null,
-          globalID: new GlobalID(GlobalIDSchemeIdentifiers.GLN, "4000001123452"),
-          name: "Lieferant GmbH",
-          postcode: "80333",
-          city: "München",
-          street: "Lieferantenstraße 20",
-          country: CountryCodes.DE,
-          legalOrganization: new LegalOrganization(GlobalIDSchemeIdentifiers.GLN, "4000001123452", "Lieferant GmbH"));
-      d.SetBuyer(
-          id: "GE2020211",
-          globalID: new GlobalID(GlobalIDSchemeIdentifiers.GLN, "4000001987658"),
-          name: "Kunden AG Mitte",
-          postcode: "69876",
-          city: "Frankfurt",
-          street: "Kundenstraße 15",
-          country: CountryCodes.DE);
-      d.SetPaymentMeansSepaDirectDebit(
-          "DE98ZZZ09999999999",
-          "REF A-123");
-      d.AddDebitorFinancialAccount(
-          "DE21860000000086001055",
-          null);
-      d.SetTradePaymentTerms(
-          "Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.");
-      d.SetTotals(
-          473.00m,
-          0.00m,
-          0.00m,
-          473.00m,
-          56.87m,
-          529.87m,
-          0.00m,
-          529.87m);
-      d.SellerTaxRegistration.Add(new TaxRegistration
-      {
-        SchemeID = TaxRegistrationSchemeID.FC,
-        No = "201/113/40209"
-      });
-      d.SellerTaxRegistration.Add(new TaxRegistration
-      {
-        SchemeID = TaxRegistrationSchemeID.VA,
-        No = "DE123456789"
-      });
-      d.AddApplicableTradeTax(
-          275.00m,
-          7.00m,
-          TaxTypes.VAT,
-          TaxCategoryCodes.S);
-      d.AddApplicableTradeTax(
-          198.00m,
-          19.00m,
-          TaxTypes.VAT,
-          TaxCategoryCodes.S);
-
-      using (var stream = new MemoryStream())
-      {
-        d.Save(stream, ZUGFeRDVersion.Version20, Profile.Comfort);
-
-        stream.Seek(0, SeekOrigin.Begin);
-
-        var d2 = InvoiceDescriptor.Load(stream);
-        Assert.AreEqual("DE98ZZZ09999999999", d2.PaymentMeans.SEPACreditorIdentifier);
-        Assert.AreEqual("REF A-123", d2.PaymentMeans.SEPAMandateReference);
-        Assert.AreEqual(1, d2.DebitorBankAccounts.Count);
-        Assert.AreEqual("DE21860000000086001055", d2.DebitorBankAccounts[0].IBAN);
-      }
-    } // !TestStoringSepaPreNotification()
-
-    [TestMethod]
-    public void TestPartyExtensions()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
-
-      Stream s = File.Open(path, FileMode.Open);
-      InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
-      s.Close();
-
-      desc.Invoicee = new Party() // this information will not be stored in the output file since it is available in Extended profile only
-      {
-        Name = "Test",
-        ContactName = "Max Mustermann",
-        Postcode = "83022",
-        City = "Rosenheim",
-        Street = "Münchnerstraße 123",
-        AddressLine3 = "EG links",
-        CountrySubdivisionName = "Bayern",
-        Country = CountryCodes.DE
-      };
-      MemoryStream ms = new MemoryStream();
-
-      desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
-      ms.Seek(0, SeekOrigin.Begin);
-
-      InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
-      Assert.AreEqual("Test", loadedInvoice.Invoicee.Name);
-      Assert.AreEqual("Max Mustermann", loadedInvoice.Invoicee.ContactName);
-      Assert.AreEqual("83022", loadedInvoice.Invoicee.Postcode);
-      Assert.AreEqual("Rosenheim", loadedInvoice.Invoicee.City);
-      Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Invoicee.Street);
-      Assert.AreEqual("EG links", loadedInvoice.Invoicee.AddressLine3);
-      Assert.AreEqual("Bayern", loadedInvoice.Invoicee.CountrySubdivisionName);
-      Assert.AreEqual(CountryCodes.DE, loadedInvoice.Invoicee.Country);
-    } // !TestMinimumInvoice()
-
-
-    [TestMethod]
-    public void TestMimetypeOfEmbeddedAttachment()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
-
-      Stream s = File.Open(path, FileMode.Open);
-      InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
-      s.Close();
-
-      string filename1 = "myrandomdata.pdf";
-      string filename2 = "myrandomdata.bin";
-      DateTime timestamp = DateTime.Now.Date;
-      byte[] data = new byte[32768];
-      new Random().NextBytes(data);
-
-      desc.AddAdditionalReferencedDocument(
-          id: "My-File-PDF",
-          issueDateTime: timestamp,
-          typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
-          name: "EmbeddedPdf",
-          attachmentBinaryObject: data,
-          filename: filename1);
-
-      desc.AddAdditionalReferencedDocument(
-          id: "My-File-BIN",
-          issueDateTime: timestamp,
-          typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
-          name: "EmbeddedPdf",
-          attachmentBinaryObject: data,
-          filename: filename2);
-
-      MemoryStream ms = new MemoryStream();
-
-      desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
-      ms.Seek(0, SeekOrigin.Begin);
-
-      InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
-
-      //One document is already referenced in "zuferd_2p0_EXTENDED_Warenrechnung.xml"
-      Assert.AreEqual(loadedInvoice.AdditionalReferencedDocuments.Count, 3);
-
-      foreach (AdditionalReferencedDocument document in loadedInvoice.AdditionalReferencedDocuments)
-      {
-        if (document.ID == "My-File-PDF")
+        [TestMethod]
+        public void TestMissingPropertiesAreNull()
         {
-          Assert.AreEqual(document.Filename, filename1);
-          Assert.AreEqual("application/pdf", document.MimeType);
-          Assert.AreEqual(timestamp, document.IssueDateTime);
-        }
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
 
-        if (document.ID == "My-File-BIN")
+            var invoiceDescriptor = InvoiceDescriptor.Load(path);
+
+            Assert.IsTrue(invoiceDescriptor.TradeLineItems.TrueForAll(x => x.BillingPeriodStart == null));
+            Assert.IsTrue(invoiceDescriptor.TradeLineItems.TrueForAll(x => x.BillingPeriodEnd == null));
+        } // !TestMissingPropertiesAreNull()
+
+
+        [TestMethod]
+        public void TestMissingPropertListsEmpty()
         {
-          Assert.AreEqual(document.Filename, filename2);
-          Assert.AreEqual("application/octet-stream", document.MimeType);
-          Assert.AreEqual(timestamp.AddDays(-2), document.IssueDateTime);
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            var invoiceDescriptor = InvoiceDescriptor.Load(path);
+
+            Assert.IsTrue(invoiceDescriptor.TradeLineItems.TrueForAll(x => x.ApplicableProductCharacteristics.Count == 0));
+        } // !TestMissingPropertListsEmpty()
+
+
+        [TestMethod]
+        public void TestLoadingSepaPreNotification()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EN16931_SEPA_Prenotification.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            var invoiceDescriptor = InvoiceDescriptor.Load(path);
+            Assert.AreEqual(Profile.Comfort, invoiceDescriptor.Profile);
+
+            Assert.AreEqual("DE98ZZZ09999999999", invoiceDescriptor.PaymentMeans.SEPACreditorIdentifier);
+            Assert.AreEqual("REF A-123", invoiceDescriptor.PaymentMeans.SEPAMandateReference);
+            Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
+            Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
+
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.FirstOrDefault().Description.Trim());
+        } // !TestLoadingSepaPreNotification()
+
+
+        [TestMethod]
+        public void TestStoringSepaPreNotification()
+        {
+            var d = new InvoiceDescriptor();
+            d.Type = InvoiceType.Invoice;
+            d.InvoiceNo = "471102";
+            d.Currency = CurrencyCodes.EUR;
+            d.InvoiceDate = new DateTime(2018, 3, 5);
+            d.AddTradeLineItem(
+                lineID: "1",
+                id: new GlobalID(GlobalIDSchemeIdentifiers.EAN, "4012345001235"),
+                sellerAssignedID: "TB100A4",
+                name: "Trennblätter A4",
+                billedQuantity: 20m,
+                unitCode: QuantityCodes.C62,
+                netUnitPrice: 9.9m,
+                grossUnitPrice: 9.9m,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 19.0m,
+                taxType: TaxTypes.VAT);
+            d.AddTradeLineItem(
+                lineID: "2",
+                id: new GlobalID(GlobalIDSchemeIdentifiers.EAN, "4000050986428"),
+                sellerAssignedID: "ARNR2",
+                name: "Joghurt Banane",
+                billedQuantity: 50m,
+                unitCode: QuantityCodes.C62,
+                netUnitPrice: 5.5m,
+                grossUnitPrice: 5.5m,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 7.0m,
+                taxType: TaxTypes.VAT);
+            d.SetSeller(
+                id: null,
+                globalID: new GlobalID(GlobalIDSchemeIdentifiers.GLN, "4000001123452"),
+                name: "Lieferant GmbH",
+                postcode: "80333",
+                city: "München",
+                street: "Lieferantenstraße 20",
+                country: CountryCodes.DE,
+                legalOrganization: new LegalOrganization(GlobalIDSchemeIdentifiers.GLN, "4000001123452", "Lieferant GmbH"));
+            d.SetBuyer(
+                id: "GE2020211",
+                globalID: new GlobalID(GlobalIDSchemeIdentifiers.GLN, "4000001987658"),
+                name: "Kunden AG Mitte",
+                postcode: "69876",
+                city: "Frankfurt",
+                street: "Kundenstraße 15",
+                country: CountryCodes.DE);
+            d.SetPaymentMeansSepaDirectDebit(
+                "DE98ZZZ09999999999",
+                "REF A-123");
+            d.AddDebitorFinancialAccount(
+                "DE21860000000086001055",
+                null);
+            d.SetTradePaymentTerms(
+                "Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.");
+            d.SetTotals(
+                473.00m,
+                0.00m,
+                0.00m,
+                473.00m,
+                56.87m,
+                529.87m,
+                0.00m,
+                529.87m);
+            d.SellerTaxRegistration.Add(new TaxRegistration
+            {
+                SchemeID = TaxRegistrationSchemeID.FC,
+                No = "201/113/40209"
+            });
+            d.SellerTaxRegistration.Add(new TaxRegistration
+            {
+                SchemeID = TaxRegistrationSchemeID.VA,
+                No = "DE123456789"
+            });
+            d.AddApplicableTradeTax(
+                275.00m,
+                7.00m,
+                TaxTypes.VAT,
+                TaxCategoryCodes.S);
+            d.AddApplicableTradeTax(
+                198.00m,
+                19.00m,
+                TaxTypes.VAT,
+                TaxCategoryCodes.S);
+
+            using (var stream = new MemoryStream())
+            {
+                d.Save(stream, ZUGFeRDVersion.Version20, Profile.Comfort);
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                var d2 = InvoiceDescriptor.Load(stream);
+                Assert.AreEqual("DE98ZZZ09999999999", d2.PaymentMeans.SEPACreditorIdentifier);
+                Assert.AreEqual("REF A-123", d2.PaymentMeans.SEPAMandateReference);
+                Assert.AreEqual(1, d2.DebitorBankAccounts.Count);
+                Assert.AreEqual("DE21860000000086001055", d2.DebitorBankAccounts[0].IBAN);
+            }
+        } // !TestStoringSepaPreNotification()
+
+        [TestMethod]
+        public void TestPartyExtensions()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_BASIC_Einfach.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
+
+            desc.Invoicee = new Party() // this information will not be stored in the output file since it is available in Extended profile only
+            {
+                Name = "Test",
+                ContactName = "Max Mustermann",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Street = "Münchnerstraße 123",
+                AddressLine3 = "EG links",
+                CountrySubdivisionName = "Bayern",
+                Country = CountryCodes.DE
+            };
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            Assert.AreEqual("Test", loadedInvoice.Invoicee.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.Invoicee.ContactName);
+            Assert.AreEqual("83022", loadedInvoice.Invoicee.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.Invoicee.City);
+            Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Invoicee.Street);
+            Assert.AreEqual("EG links", loadedInvoice.Invoicee.AddressLine3);
+            Assert.AreEqual("Bayern", loadedInvoice.Invoicee.CountrySubdivisionName);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Invoicee.Country);
+        } // !TestMinimumInvoice()
+
+
+        [TestMethod]
+        public void TestMimetypeOfEmbeddedAttachment()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
+
+            string filename1 = "myrandomdata.pdf";
+            string filename2 = "myrandomdata.bin";
+            DateTime timestamp = DateTime.Now.Date;
+            byte[] data = new byte[32768];
+            new Random().NextBytes(data);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-PDF",
+                issueDateTime: timestamp,
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename1);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-BIN",
+                issueDateTime: timestamp,
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename2);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            //One document is already referenced in "zuferd_2p0_EXTENDED_Warenrechnung.xml"
+            Assert.AreEqual(loadedInvoice.AdditionalReferencedDocuments.Count, 3);
+
+            foreach (AdditionalReferencedDocument document in loadedInvoice.AdditionalReferencedDocuments)
+            {
+                if (document.ID == "My-File-PDF")
+                {
+                    Assert.AreEqual(document.Filename, filename1);
+                    Assert.AreEqual("application/pdf", document.MimeType);
+                    Assert.AreEqual(timestamp, document.IssueDateTime);
+                }
+
+                if (document.ID == "My-File-BIN")
+                {
+                    Assert.AreEqual(document.Filename, filename2);
+                    Assert.AreEqual("application/octet-stream", document.MimeType);
+                    Assert.AreEqual(timestamp.AddDays(-2), document.IssueDateTime);
+                }
+            }
+        } // !TestMimetypeOfEmbeddedAttachment()
+
+
+        [TestMethod]
+        public void TestOrderInformation()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            DateTime timestamp = DateTime.Now.Date;
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            desc.OrderDate = timestamp;
+            desc.OrderNo = "12345";
+            s.Close();
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            Assert.AreEqual(timestamp, loadedInvoice.OrderDate);
+            Assert.AreEqual("12345", loadedInvoice.OrderNo);
+
+        } // !TestOrderInformation()
+
+
+        [TestMethod]
+        public void TestSellerOrderReferencedDocument()
+        {
+            string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            Stream s = File.Open(path, FileMode.Open);
+            InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+            s.Close();
+
+            string uuid = System.Guid.NewGuid().ToString();
+            DateTime issueDateTime = DateTime.Today;
+
+            desc.SellerOrderReferencedDocument = new SellerOrderReferencedDocument()
+            {
+                ID = uuid,
+                IssueDateTime = issueDateTime
+            };
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual(Profile.Extended, loadedInvoice.Profile);
+            Assert.AreEqual(uuid, loadedInvoice.SellerOrderReferencedDocument.ID);
+            Assert.AreEqual(issueDateTime, loadedInvoice.SellerOrderReferencedDocument.IssueDateTime);
+        } // !TestSellerOrderReferencedDocument()
+
+        [TestMethod]
+        public void TestWriteAndReadBusinessProcess()
+        {
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            desc.BusinessProcess = "A1";
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual("A1", loadedInvoice.BusinessProcess);
+        } // !TestWriteAndReadBusinessProcess
+
+        /// <summary>
+        /// This test ensure that Writer and Reader uses the same path and namespace for elements
+        /// </summary>
+        [TestMethod]
+        public void TestWriteAndReadExtended()
+        {
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            string filename2 = "myrandomdata.bin";
+            DateTime timestamp = DateTime.Now.Date;
+            byte[] data = new byte[32768];
+            new Random().NextBytes(data);
+
+            desc.AddAdditionalReferencedDocument(
+                id: "My-File-BIN",
+                typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
+                issueDateTime: timestamp.AddDays(-2),
+                name: "EmbeddedPdf",
+                attachmentBinaryObject: data,
+                filename: filename2);
+
+            desc.OrderNo = "12345";
+            desc.OrderDate = timestamp;
+
+            desc.SetContractReferencedDocument("12345", timestamp);
+
+            desc.SpecifiedProcuringProject = new SpecifiedProcuringProject { ID = "123", Name = "Project 123" };
+
+            desc.ShipTo = new Party
+            {
+                ID = new GlobalID(GlobalIDSchemeIdentifiers.Unknown, "123"),
+                GlobalID = new GlobalID(GlobalIDSchemeIdentifiers.DUNS, "789"),
+                Name = "Ship To",
+                ContactName = "Max Mustermann",
+                Street = "Münchnerstr. 55",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Country = CountryCodes.DE
+            };
+
+            desc.ShipFrom = new Party
+            {
+                ID = new GlobalID(GlobalIDSchemeIdentifiers.Unknown, "123"),
+                GlobalID = new GlobalID(GlobalIDSchemeIdentifiers.DUNS, "789"),
+                Name = "Ship From",
+                ContactName = "Eva Musterfrau",
+                Street = "Alpenweg 5",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Country = CountryCodes.DE
+            };
+
+            desc.PaymentMeans.SEPACreditorIdentifier = "SepaID";
+            desc.PaymentMeans.SEPAMandateReference = "SepaMandat";
+            desc.PaymentMeans.FinancialCard = new FinancialCard { Id = "123", CardholderName = "Mustermann" };
+
+            desc.PaymentReference = "PaymentReference";
+
+            desc.Invoicee = new Party()
+            {
+                Name = "Test",
+                ContactName = "Max Mustermann",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Street = "Münchnerstraße 123",
+                AddressLine3 = "EG links",
+                CountrySubdivisionName = "Bayern",
+                Country = CountryCodes.DE
+            };
+
+            desc.Payee = new Party() // this information will not be stored in the output file since it is available in Extended profile only
+            {
+                Name = "Test",
+                ContactName = "Max Mustermann",
+                Postcode = "83022",
+                City = "Rosenheim",
+                Street = "Münchnerstraße 123",
+                AddressLine3 = "EG links",
+                CountrySubdivisionName = "Bayern",
+                Country = CountryCodes.DE
+            };
+
+            desc.AddDebitorFinancialAccount(iban: "DE02120300000000202052", bic: "BYLADEM1001", bankName: "Musterbank");
+            desc.BillingPeriodStart = timestamp;
+            desc.BillingPeriodEnd = timestamp.AddDays(14);
+
+            desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m);
+            desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
+
+            desc.PaymentTerms.FirstOrDefault().DueDate = timestamp.AddDays(14);
+            desc.AddInvoiceReferencedDocument("RE-12345", timestamp);
+
+
+            //set additional LineItem data
+            var lineItem = desc.TradeLineItems.FirstOrDefault(i => i.SellerAssignedID == "TB100A4");
+            Assert.IsNotNull(lineItem);
+            lineItem.Description = "This is line item TB100A4";
+            lineItem.BuyerAssignedID = "0815";
+            lineItem.SetOrderReferencedDocument("12345", timestamp);
+            lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp);
+            lineItem.SetContractReferencedDocument("12345", timestamp);
+
+            lineItem.AddAdditionalReferencedDocument("xyz", ReferenceTypeCodes.AAB, timestamp);
+
+            lineItem.UnitQuantity = 3m;
+            lineItem.ActualDeliveryDate = timestamp;
+
+            lineItem.ApplicableProductCharacteristics.Add(new ApplicableProductCharacteristic
+            {
+                Description = "Product characteristics",
+                Value = "Product value"
+            });
+
+            lineItem.BillingPeriodStart = timestamp;
+            lineItem.BillingPeriodEnd = timestamp.AddDays(10);
+
+            lineItem.AddReceivableSpecifiedTradeAccountingAccount("987654");
+            lineItem.AddTradeAllowanceCharge(false, CurrencyCodes.EUR, 10m, 50m, "Reason: UnitTest");
+
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            StreamReader reader = new StreamReader(ms);
+            string text = reader.ReadToEnd();
+
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            Assert.AreEqual("471102", loadedInvoice.InvoiceNo);
+            Assert.AreEqual(new DateTime(2018, 03, 05), loadedInvoice.InvoiceDate);
+            Assert.AreEqual(CurrencyCodes.EUR, loadedInvoice.Currency);
+            Assert.IsTrue(loadedInvoice.Notes.Any(n => n.Content == "Rechnung gemäß Bestellung vom 01.03.2018."));
+            Assert.AreEqual("04011000-12345-34", loadedInvoice.ReferenceOrderNo);
+            Assert.AreEqual("Lieferant GmbH", loadedInvoice.Seller.Name);
+            Assert.AreEqual("80333", loadedInvoice.Seller.Postcode);
+            Assert.AreEqual("München", loadedInvoice.Seller.City);
+
+            Assert.AreEqual("Lieferantenstraße 20", loadedInvoice.Seller.Street);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Seller.Country);
+            Assert.AreEqual(GlobalIDSchemeIdentifiers.GLN, loadedInvoice.Seller.GlobalID.SchemeID);
+            Assert.AreEqual("4000001123452", loadedInvoice.Seller.GlobalID.ID);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.SellerContact.Name);
+            Assert.AreEqual("Muster-Einkauf", loadedInvoice.SellerContact.OrgUnit);
+            Assert.AreEqual("Max@Mustermann.de", loadedInvoice.SellerContact.EmailAddress);
+            Assert.AreEqual("+49891234567", loadedInvoice.SellerContact.PhoneNo);
+
+            Assert.AreEqual("Kunden AG Mitte", loadedInvoice.Buyer.Name);
+            Assert.AreEqual("69876", loadedInvoice.Buyer.Postcode);
+            Assert.AreEqual("Frankfurt", loadedInvoice.Buyer.City);
+            Assert.AreEqual("Kundenstraße 15", loadedInvoice.Buyer.Street);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Buyer.Country);
+            Assert.AreEqual<string>("GE2020211", loadedInvoice.Buyer.ID.ID);
+
+            Assert.AreEqual("12345", loadedInvoice.OrderNo);
+            Assert.AreEqual(timestamp, loadedInvoice.OrderDate);
+
+            //Currently not implemented
+            //Assert.AreEqual("12345", loadedInvoice.ContractReferencedDocument.ID);
+            //Assert.AreEqual(timestamp, loadedInvoice.ContractReferencedDocument.IssueDateTime);
+
+            //Currently not implemented
+            //Assert.AreEqual("123", loadedInvoice.SpecifiedProcuringProject.ID);
+            //Assert.AreEqual("Project 123", loadedInvoice.SpecifiedProcuringProject.Name);
+
+            Assert.AreEqual<string>("123", loadedInvoice.ShipTo.ID.ID);
+            Assert.AreEqual(GlobalIDSchemeIdentifiers.DUNS, loadedInvoice.ShipTo.GlobalID.SchemeID);
+            Assert.AreEqual("789", loadedInvoice.ShipTo.GlobalID.ID);
+            Assert.AreEqual("Ship To", loadedInvoice.ShipTo.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.ShipTo.ContactName);
+            Assert.AreEqual("Münchnerstr. 55", loadedInvoice.ShipTo.Street);
+            Assert.AreEqual("83022", loadedInvoice.ShipTo.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.ShipTo.City);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.ShipTo.Country);
+
+            Assert.AreEqual<string>("123", loadedInvoice.ShipFrom.ID.ID);
+            Assert.AreEqual(GlobalIDSchemeIdentifiers.DUNS, loadedInvoice.ShipFrom.GlobalID.SchemeID);
+            Assert.AreEqual("789", loadedInvoice.ShipFrom.GlobalID.ID);
+            Assert.AreEqual("Ship From", loadedInvoice.ShipFrom.Name);
+            Assert.AreEqual("Eva Musterfrau", loadedInvoice.ShipFrom.ContactName);
+            Assert.AreEqual("Alpenweg 5", loadedInvoice.ShipFrom.Street);
+            Assert.AreEqual("83022", loadedInvoice.ShipFrom.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.ShipFrom.City);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.ShipFrom.Country);
+
+
+            Assert.AreEqual(new DateTime(2018, 03, 05), loadedInvoice.ActualDeliveryDate);
+            Assert.AreEqual(PaymentMeansTypeCodes.SEPACreditTransfer, loadedInvoice.PaymentMeans.TypeCode);
+            Assert.AreEqual("Zahlung per SEPA Überweisung.", loadedInvoice.PaymentMeans.Information);
+
+            Assert.AreEqual("PaymentReference", loadedInvoice.PaymentReference);
+
+            Assert.AreEqual("SepaID", loadedInvoice.PaymentMeans.SEPACreditorIdentifier);
+            Assert.AreEqual("SepaMandat", loadedInvoice.PaymentMeans.SEPAMandateReference);
+            Assert.AreEqual("123", loadedInvoice.PaymentMeans.FinancialCard.Id);
+            Assert.AreEqual("Mustermann", loadedInvoice.PaymentMeans.FinancialCard.CardholderName);
+
+            var bankAccount = loadedInvoice.CreditorBankAccounts.FirstOrDefault(a => a.IBAN == "DE02120300000000202051");
+            Assert.IsNotNull(bankAccount);
+            Assert.AreEqual("Kunden AG", bankAccount.Name);
+            Assert.AreEqual("DE02120300000000202051", bankAccount.IBAN);
+            Assert.AreEqual("BYLADEM1001", bankAccount.BIC);
+
+            var debitorBankAccount = loadedInvoice.DebitorBankAccounts.FirstOrDefault(a => a.IBAN == "DE02120300000000202052");
+            Assert.IsNotNull(debitorBankAccount);
+            Assert.AreEqual("DE02120300000000202052", debitorBankAccount.IBAN);
+
+
+            Assert.AreEqual("Test", loadedInvoice.Invoicee.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.Invoicee.ContactName);
+            Assert.AreEqual("83022", loadedInvoice.Invoicee.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.Invoicee.City);
+            Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Invoicee.Street);
+            Assert.AreEqual("EG links", loadedInvoice.Invoicee.AddressLine3);
+            Assert.AreEqual("Bayern", loadedInvoice.Invoicee.CountrySubdivisionName);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Invoicee.Country);
+
+            Assert.AreEqual("Test", loadedInvoice.Payee.Name);
+            Assert.AreEqual("Max Mustermann", loadedInvoice.Payee.ContactName);
+            Assert.AreEqual("83022", loadedInvoice.Payee.Postcode);
+            Assert.AreEqual("Rosenheim", loadedInvoice.Payee.City);
+            Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Payee.Street);
+            Assert.AreEqual("EG links", loadedInvoice.Payee.AddressLine3);
+            Assert.AreEqual("Bayern", loadedInvoice.Payee.CountrySubdivisionName);
+            Assert.AreEqual(CountryCodes.DE, loadedInvoice.Payee.Country);
+
+
+            var tax = loadedInvoice.Taxes.FirstOrDefault(t => t.BasisAmount == 275m);
+            Assert.IsNotNull(tax);
+            Assert.AreEqual(275m, tax.BasisAmount);
+            Assert.AreEqual(7m, tax.Percent);
+            Assert.AreEqual(TaxTypes.VAT, tax.TypeCode);
+            Assert.AreEqual(TaxCategoryCodes.S, tax.CategoryCode);
+
+            Assert.AreEqual(timestamp, loadedInvoice.BillingPeriodStart);
+            Assert.AreEqual(timestamp.AddDays(14), loadedInvoice.BillingPeriodEnd);
+
+            //TradeAllowanceCharges
+            var tradeAllowanceCharge = loadedInvoice.GetTradeAllowanceCharges().FirstOrDefault(i => i.Reason == "Reason for charge");
+            Assert.IsNotNull(tradeAllowanceCharge);
+            Assert.IsTrue(tradeAllowanceCharge.ChargeIndicator);
+            Assert.AreEqual("Reason for charge", tradeAllowanceCharge.Reason);
+            Assert.AreEqual(5m, tradeAllowanceCharge.BasisAmount);
+            Assert.AreEqual(15m, tradeAllowanceCharge.ActualAmount);
+            Assert.AreEqual(CurrencyCodes.EUR, tradeAllowanceCharge.Currency);
+            Assert.AreEqual(19m, tradeAllowanceCharge.Tax.Percent);
+            Assert.AreEqual(TaxTypes.AAB, tradeAllowanceCharge.Tax.TypeCode);
+            Assert.AreEqual(TaxCategoryCodes.AB, tradeAllowanceCharge.Tax.CategoryCode);
+
+            //ServiceCharges
+            var serviceCharge = desc.ServiceCharges.FirstOrDefault(i => i.Description == "Logistics service charge");
+            Assert.IsNotNull(serviceCharge);
+            Assert.AreEqual("Logistics service charge", serviceCharge.Description);
+            Assert.AreEqual(10m, serviceCharge.Amount);
+            Assert.AreEqual(7m, serviceCharge.Tax.Percent);
+            Assert.AreEqual(TaxTypes.AAC, serviceCharge.Tax.TypeCode);
+            Assert.AreEqual(TaxCategoryCodes.AC, serviceCharge.Tax.CategoryCode);
+
+            //PaymentTerms
+            var paymentTerms = loadedInvoice.GetTradePaymentTerms().FirstOrDefault();
+            Assert.IsNotNull(paymentTerms);
+            Assert.AreEqual("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018", paymentTerms.Description);
+            Assert.AreEqual(timestamp.AddDays(14), paymentTerms.DueDate);
+
+            Assert.AreEqual(473.0m, loadedInvoice.LineTotalAmount);
+            Assert.AreEqual(null, loadedInvoice.ChargeTotalAmount); // optional
+            Assert.AreEqual(null, loadedInvoice.AllowanceTotalAmount); // optional
+            Assert.AreEqual(473.0m, loadedInvoice.TaxBasisAmount);
+            Assert.AreEqual(56.87m, loadedInvoice.TaxTotalAmount);
+            Assert.AreEqual(529.87m, loadedInvoice.GrandTotalAmount);
+            Assert.AreEqual(null, loadedInvoice.TotalPrepaidAmount); // optional
+            Assert.AreEqual(529.87m, loadedInvoice.DuePayableAmount);
+
+            //InvoiceReferencedDocument
+            Assert.AreEqual("RE-12345", loadedInvoice.GetInvoiceReferencedDocuments().First().ID);
+            Assert.AreEqual(timestamp, loadedInvoice.GetInvoiceReferencedDocuments().First().IssueDateTime);
+
+
+            //Line items
+            var loadedLineItem = loadedInvoice.TradeLineItems.FirstOrDefault(i => i.SellerAssignedID == "TB100A4");
+            Assert.IsNotNull(loadedLineItem);
+            Assert.IsTrue(!string.IsNullOrEmpty(loadedLineItem.AssociatedDocument.LineID));
+            Assert.AreEqual("This is line item TB100A4", loadedLineItem.Description);
+
+            Assert.AreEqual("Trennblätter A4", loadedLineItem.Name);
+
+            Assert.AreEqual("TB100A4", loadedLineItem.SellerAssignedID);
+            Assert.AreEqual("0815", loadedLineItem.BuyerAssignedID);
+            Assert.AreEqual(GlobalIDSchemeIdentifiers.EAN, loadedLineItem.GlobalID.SchemeID);
+            Assert.AreEqual("4012345001235", loadedLineItem.GlobalID.ID);
+
+            //GrossPriceProductTradePrice
+            Assert.AreEqual(9.9m, loadedLineItem.GrossUnitPrice);
+            Assert.AreEqual(QuantityCodes.H87, loadedLineItem.UnitCode);
+            Assert.AreEqual(3m, loadedLineItem.UnitQuantity);
+
+            //NetPriceProductTradePrice
+            Assert.AreEqual(9.9m, loadedLineItem.NetUnitPrice);
+            Assert.AreEqual(20m, loadedLineItem.BilledQuantity);
+
+            Assert.AreEqual(TaxTypes.VAT, loadedLineItem.TaxType);
+            Assert.AreEqual(TaxCategoryCodes.S, loadedLineItem.TaxCategoryCode);
+            Assert.AreEqual(19m, loadedLineItem.TaxPercent);
+
+            Assert.AreEqual("12345", loadedLineItem.BuyerOrderReferencedDocument.ID);
+            Assert.AreEqual(timestamp, loadedLineItem.BuyerOrderReferencedDocument.IssueDateTime);
+            Assert.AreEqual("12345", loadedLineItem.DeliveryNoteReferencedDocument.ID);
+            Assert.AreEqual(timestamp, loadedLineItem.DeliveryNoteReferencedDocument.IssueDateTime);
+            Assert.AreEqual("12345", loadedLineItem.ContractReferencedDocument.ID);
+            Assert.AreEqual(timestamp, loadedLineItem.ContractReferencedDocument.IssueDateTime);
+
+            var lineItemReferencedDoc = loadedLineItem.GetAdditionalReferencedDocuments().FirstOrDefault();
+            Assert.IsNotNull(lineItemReferencedDoc);
+            Assert.AreEqual("xyz", lineItemReferencedDoc.ID);
+            Assert.AreEqual(timestamp, lineItemReferencedDoc.IssueDateTime);
+            Assert.AreEqual(ReferenceTypeCodes.AAB, lineItemReferencedDoc.ReferenceTypeCode);
+
+
+            var productCharacteristics = loadedLineItem.ApplicableProductCharacteristics.FirstOrDefault();
+            Assert.IsNotNull(productCharacteristics);
+            Assert.AreEqual("Product characteristics", productCharacteristics.Description);
+            Assert.AreEqual("Product value", productCharacteristics.Value);
+
+            Assert.AreEqual(timestamp, loadedLineItem.ActualDeliveryDate);
+            Assert.AreEqual(timestamp, loadedLineItem.BillingPeriodStart);
+            Assert.AreEqual(timestamp.AddDays(10), loadedLineItem.BillingPeriodEnd);
+
+            //Currently not implemented
+            //var accountingAccount = loadedLineItem.ReceivableSpecifiedTradeAccountingAccounts.FirstOrDefault();
+            //Assert.IsNotNull(accountingAccount);
+            //Assert.AreEqual("987654", accountingAccount.TradeAccountID);
+
+
+            var lineItemTradeAllowanceCharge = loadedLineItem.GetTradeAllowanceCharges().FirstOrDefault(i => i.Reason == "Reason: UnitTest");
+            Assert.IsNotNull(lineItemTradeAllowanceCharge);
+            Assert.IsTrue(lineItemTradeAllowanceCharge.ChargeIndicator);
+            Assert.AreEqual(10m, lineItemTradeAllowanceCharge.BasisAmount);
+            Assert.AreEqual(50m, lineItemTradeAllowanceCharge.ActualAmount);
+            Assert.AreEqual("Reason: UnitTest", lineItemTradeAllowanceCharge.Reason);
         }
-      }
-    } // !TestMimetypeOfEmbeddedAttachment()
-
-
-    [TestMethod]
-    public void TestOrderInformation()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
-
-      DateTime timestamp = DateTime.Now.Date;
-
-      Stream s = File.Open(path, FileMode.Open);
-      InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
-      desc.OrderDate = timestamp;
-      desc.OrderNo = "12345";
-      s.Close();
-
-      MemoryStream ms = new MemoryStream();
-      desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
-
-      ms.Seek(0, SeekOrigin.Begin);
-      StreamReader reader = new StreamReader(ms);
-      string text = reader.ReadToEnd();
-
-      ms.Seek(0, SeekOrigin.Begin);
-      InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
-      Assert.AreEqual(timestamp, loadedInvoice.OrderDate);
-      Assert.AreEqual("12345", loadedInvoice.OrderNo);
-
-    } // !TestOrderInformation()
-
-
-    [TestMethod]
-    public void TestSellerOrderReferencedDocument()
-    {
-      string path = @"..\..\..\..\demodata\zugferd20\zugferd_2p0_EXTENDED_Warenrechnung.xml";
-      path = _makeSurePathIsCrossPlatformCompatible(path);
-
-      Stream s = File.Open(path, FileMode.Open);
-      InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
-      s.Close();
-
-      string uuid = System.Guid.NewGuid().ToString();
-      DateTime issueDateTime = DateTime.Today;
-
-      desc.SellerOrderReferencedDocument = new SellerOrderReferencedDocument()
-      {
-        ID = uuid,
-        IssueDateTime = issueDateTime
-      };
-
-      MemoryStream ms = new MemoryStream();
-      desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
-
-      ms.Seek(0, SeekOrigin.Begin);
-      StreamReader reader = new StreamReader(ms);
-      string text = reader.ReadToEnd();
-
-      ms.Seek(0, SeekOrigin.Begin);
-      InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
-
-      Assert.AreEqual(Profile.Extended, loadedInvoice.Profile);
-      Assert.AreEqual(uuid, loadedInvoice.SellerOrderReferencedDocument.ID);
-      Assert.AreEqual(issueDateTime, loadedInvoice.SellerOrderReferencedDocument.IssueDateTime);
-    } // !TestSellerOrderReferencedDocument()
-
-    [TestMethod]
-    public void TestWriteAndReadBusinessProcess()
-    {
-      InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
-      desc.BusinessProcess = "A1";
-
-      MemoryStream ms = new MemoryStream();
-      desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
-      ms.Seek(0, SeekOrigin.Begin);
-      InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
-
-      Assert.AreEqual("A1", loadedInvoice.BusinessProcess);
-    } // !TestWriteAndReadBusinessProcess
-
-    /// <summary>
-    /// This test ensure that Writer and Reader uses the same path and namespace for elements
-    /// </summary>
-    [TestMethod]
-    public void TestWriteAndReadExtended()
-    {
-      InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
-      string filename2 = "myrandomdata.bin";
-      DateTime timestamp = DateTime.Now.Date;
-      byte[] data = new byte[32768];
-      new Random().NextBytes(data);
-
-      desc.AddAdditionalReferencedDocument(
-          id: "My-File-BIN",
-          typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
-          issueDateTime: timestamp.AddDays(-2),
-          name: "EmbeddedPdf",
-          attachmentBinaryObject: data,
-          filename: filename2);
-
-      desc.OrderNo = "12345";
-      desc.OrderDate = timestamp;
-
-      desc.SetContractReferencedDocument("12345", timestamp);
-
-      desc.SpecifiedProcuringProject = new SpecifiedProcuringProject { ID = "123", Name = "Project 123" };
-
-      desc.ShipTo = new Party
-      {
-        ID = new GlobalID(GlobalIDSchemeIdentifiers.Unknown, "123"),
-        GlobalID = new GlobalID(GlobalIDSchemeIdentifiers.DUNS, "789"),
-        Name = "Ship To",
-        ContactName = "Max Mustermann",
-        Street = "Münchnerstr. 55",
-        Postcode = "83022",
-        City = "Rosenheim",
-        Country = CountryCodes.DE
-      };
-
-      desc.ShipFrom = new Party
-      {
-        ID = new GlobalID(GlobalIDSchemeIdentifiers.Unknown, "123"),
-        GlobalID = new GlobalID(GlobalIDSchemeIdentifiers.DUNS, "789"),
-        Name = "Ship From",
-        ContactName = "Eva Musterfrau",
-        Street = "Alpenweg 5",
-        Postcode = "83022",
-        City = "Rosenheim",
-        Country = CountryCodes.DE
-      };
-
-      desc.PaymentMeans.SEPACreditorIdentifier = "SepaID";
-      desc.PaymentMeans.SEPAMandateReference = "SepaMandat";
-      desc.PaymentMeans.FinancialCard = new FinancialCard { Id = "123", CardholderName = "Mustermann" };
-
-      desc.PaymentReference = "PaymentReference";
-
-      desc.Invoicee = new Party()
-      {
-        Name = "Test",
-        ContactName = "Max Mustermann",
-        Postcode = "83022",
-        City = "Rosenheim",
-        Street = "Münchnerstraße 123",
-        AddressLine3 = "EG links",
-        CountrySubdivisionName = "Bayern",
-        Country = CountryCodes.DE
-      };
-
-      desc.Payee = new Party() // this information will not be stored in the output file since it is available in Extended profile only
-      {
-        Name = "Test",
-        ContactName = "Max Mustermann",
-        Postcode = "83022",
-        City = "Rosenheim",
-        Street = "Münchnerstraße 123",
-        AddressLine3 = "EG links",
-        CountrySubdivisionName = "Bayern",
-        Country = CountryCodes.DE
-      };
-
-      desc.AddDebitorFinancialAccount(iban: "DE02120300000000202052", bic: "BYLADEM1001", bankName: "Musterbank");
-      desc.BillingPeriodStart = timestamp;
-      desc.BillingPeriodEnd = timestamp.AddDays(14);
-
-      desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m);
-      desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
-
-      desc.PaymentTerms.DueDate = timestamp.AddDays(14);
-      desc.AddInvoiceReferencedDocument("RE-12345", timestamp);
-
-
-      //set additional LineItem data
-      var lineItem = desc.TradeLineItems.FirstOrDefault(i => i.SellerAssignedID == "TB100A4");
-      Assert.IsNotNull(lineItem);
-      lineItem.Description = "This is line item TB100A4";
-      lineItem.BuyerAssignedID = "0815";
-      lineItem.SetOrderReferencedDocument("12345", timestamp);
-      lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp);
-      lineItem.SetContractReferencedDocument("12345", timestamp);
-
-      lineItem.AddAdditionalReferencedDocument("xyz", ReferenceTypeCodes.AAB, timestamp);
-
-      lineItem.UnitQuantity = 3m;
-      lineItem.ActualDeliveryDate = timestamp;
-
-      lineItem.ApplicableProductCharacteristics.Add(new ApplicableProductCharacteristic
-      {
-        Description = "Product characteristics",
-        Value = "Product value"
-      });
-
-      lineItem.BillingPeriodStart = timestamp;
-      lineItem.BillingPeriodEnd = timestamp.AddDays(10);
-
-      lineItem.AddReceivableSpecifiedTradeAccountingAccount("987654");
-      lineItem.AddTradeAllowanceCharge(false, CurrencyCodes.EUR, 10m, 50m, "Reason: UnitTest");
-
-
-      MemoryStream ms = new MemoryStream();
-      desc.Save(ms, ZUGFeRDVersion.Version20, Profile.Extended);
-
-      ms.Seek(0, SeekOrigin.Begin);
-      StreamReader reader = new StreamReader(ms);
-      string text = reader.ReadToEnd();
-
-      ms.Seek(0, SeekOrigin.Begin);
-      InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
-
-      Assert.AreEqual("471102", loadedInvoice.InvoiceNo);
-      Assert.AreEqual(new DateTime(2018, 03, 05), loadedInvoice.InvoiceDate);
-      Assert.AreEqual(CurrencyCodes.EUR, loadedInvoice.Currency);
-      Assert.IsTrue(loadedInvoice.Notes.Any(n => n.Content == "Rechnung gemäß Bestellung vom 01.03.2018."));
-      Assert.AreEqual("04011000-12345-34", loadedInvoice.ReferenceOrderNo);
-      Assert.AreEqual("Lieferant GmbH", loadedInvoice.Seller.Name);
-      Assert.AreEqual("80333", loadedInvoice.Seller.Postcode);
-      Assert.AreEqual("München", loadedInvoice.Seller.City);
-
-      Assert.AreEqual("Lieferantenstraße 20", loadedInvoice.Seller.Street);
-      Assert.AreEqual(CountryCodes.DE, loadedInvoice.Seller.Country);
-      Assert.AreEqual(GlobalIDSchemeIdentifiers.GLN, loadedInvoice.Seller.GlobalID.SchemeID);
-      Assert.AreEqual("4000001123452", loadedInvoice.Seller.GlobalID.ID);
-      Assert.AreEqual("Max Mustermann", loadedInvoice.SellerContact.Name);
-      Assert.AreEqual("Muster-Einkauf", loadedInvoice.SellerContact.OrgUnit);
-      Assert.AreEqual("Max@Mustermann.de", loadedInvoice.SellerContact.EmailAddress);
-      Assert.AreEqual("+49891234567", loadedInvoice.SellerContact.PhoneNo);
-
-      Assert.AreEqual("Kunden AG Mitte", loadedInvoice.Buyer.Name);
-      Assert.AreEqual("69876", loadedInvoice.Buyer.Postcode);
-      Assert.AreEqual("Frankfurt", loadedInvoice.Buyer.City);
-      Assert.AreEqual("Kundenstraße 15", loadedInvoice.Buyer.Street);
-      Assert.AreEqual(CountryCodes.DE, loadedInvoice.Buyer.Country);
-      Assert.AreEqual<string>("GE2020211", loadedInvoice.Buyer.ID.ID);
-
-      Assert.AreEqual("12345", loadedInvoice.OrderNo);
-      Assert.AreEqual(timestamp, loadedInvoice.OrderDate);
-
-      //Currently not implemented
-      //Assert.AreEqual("12345", loadedInvoice.ContractReferencedDocument.ID);
-      //Assert.AreEqual(timestamp, loadedInvoice.ContractReferencedDocument.IssueDateTime);
-
-      //Currently not implemented
-      //Assert.AreEqual("123", loadedInvoice.SpecifiedProcuringProject.ID);
-      //Assert.AreEqual("Project 123", loadedInvoice.SpecifiedProcuringProject.Name);
-
-      Assert.AreEqual<string>("123", loadedInvoice.ShipTo.ID.ID);
-      Assert.AreEqual(GlobalIDSchemeIdentifiers.DUNS, loadedInvoice.ShipTo.GlobalID.SchemeID);
-      Assert.AreEqual("789", loadedInvoice.ShipTo.GlobalID.ID);
-      Assert.AreEqual("Ship To", loadedInvoice.ShipTo.Name);
-      Assert.AreEqual("Max Mustermann", loadedInvoice.ShipTo.ContactName);
-      Assert.AreEqual("Münchnerstr. 55", loadedInvoice.ShipTo.Street);
-      Assert.AreEqual("83022", loadedInvoice.ShipTo.Postcode);
-      Assert.AreEqual("Rosenheim", loadedInvoice.ShipTo.City);
-      Assert.AreEqual(CountryCodes.DE, loadedInvoice.ShipTo.Country);
-
-      Assert.AreEqual<string>("123", loadedInvoice.ShipFrom.ID.ID);
-      Assert.AreEqual(GlobalIDSchemeIdentifiers.DUNS, loadedInvoice.ShipFrom.GlobalID.SchemeID);
-      Assert.AreEqual("789", loadedInvoice.ShipFrom.GlobalID.ID);
-      Assert.AreEqual("Ship From", loadedInvoice.ShipFrom.Name);
-      Assert.AreEqual("Eva Musterfrau", loadedInvoice.ShipFrom.ContactName);
-      Assert.AreEqual("Alpenweg 5", loadedInvoice.ShipFrom.Street);
-      Assert.AreEqual("83022", loadedInvoice.ShipFrom.Postcode);
-      Assert.AreEqual("Rosenheim", loadedInvoice.ShipFrom.City);
-      Assert.AreEqual(CountryCodes.DE, loadedInvoice.ShipFrom.Country);
-
-
-      Assert.AreEqual(new DateTime(2018, 03, 05), loadedInvoice.ActualDeliveryDate);
-      Assert.AreEqual(PaymentMeansTypeCodes.SEPACreditTransfer, loadedInvoice.PaymentMeans.TypeCode);
-      Assert.AreEqual("Zahlung per SEPA Überweisung.", loadedInvoice.PaymentMeans.Information);
-
-      Assert.AreEqual("PaymentReference", loadedInvoice.PaymentReference);
-
-      Assert.AreEqual("SepaID", loadedInvoice.PaymentMeans.SEPACreditorIdentifier);
-      Assert.AreEqual("SepaMandat", loadedInvoice.PaymentMeans.SEPAMandateReference);
-      Assert.AreEqual("123", loadedInvoice.PaymentMeans.FinancialCard.Id);
-      Assert.AreEqual("Mustermann", loadedInvoice.PaymentMeans.FinancialCard.CardholderName);
-
-      var bankAccount = loadedInvoice.CreditorBankAccounts.FirstOrDefault(a => a.IBAN == "DE02120300000000202051");
-      Assert.IsNotNull(bankAccount);
-      Assert.AreEqual("Kunden AG", bankAccount.Name);
-      Assert.AreEqual("DE02120300000000202051", bankAccount.IBAN);
-      Assert.AreEqual("BYLADEM1001", bankAccount.BIC);
-
-      var debitorBankAccount = loadedInvoice.DebitorBankAccounts.FirstOrDefault(a => a.IBAN == "DE02120300000000202052");
-      Assert.IsNotNull(debitorBankAccount);
-      Assert.AreEqual("DE02120300000000202052", debitorBankAccount.IBAN);
-
-
-      Assert.AreEqual("Test", loadedInvoice.Invoicee.Name);
-      Assert.AreEqual("Max Mustermann", loadedInvoice.Invoicee.ContactName);
-      Assert.AreEqual("83022", loadedInvoice.Invoicee.Postcode);
-      Assert.AreEqual("Rosenheim", loadedInvoice.Invoicee.City);
-      Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Invoicee.Street);
-      Assert.AreEqual("EG links", loadedInvoice.Invoicee.AddressLine3);
-      Assert.AreEqual("Bayern", loadedInvoice.Invoicee.CountrySubdivisionName);
-      Assert.AreEqual(CountryCodes.DE, loadedInvoice.Invoicee.Country);
-
-      Assert.AreEqual("Test", loadedInvoice.Payee.Name);
-      Assert.AreEqual("Max Mustermann", loadedInvoice.Payee.ContactName);
-      Assert.AreEqual("83022", loadedInvoice.Payee.Postcode);
-      Assert.AreEqual("Rosenheim", loadedInvoice.Payee.City);
-      Assert.AreEqual("Münchnerstraße 123", loadedInvoice.Payee.Street);
-      Assert.AreEqual("EG links", loadedInvoice.Payee.AddressLine3);
-      Assert.AreEqual("Bayern", loadedInvoice.Payee.CountrySubdivisionName);
-      Assert.AreEqual(CountryCodes.DE, loadedInvoice.Payee.Country);
-
-
-      var tax = loadedInvoice.Taxes.FirstOrDefault(t => t.BasisAmount == 275m);
-      Assert.IsNotNull(tax);
-      Assert.AreEqual(275m, tax.BasisAmount);
-      Assert.AreEqual(7m, tax.Percent);
-      Assert.AreEqual(TaxTypes.VAT, tax.TypeCode);
-      Assert.AreEqual(TaxCategoryCodes.S, tax.CategoryCode);
-
-      Assert.AreEqual(timestamp, loadedInvoice.BillingPeriodStart);
-      Assert.AreEqual(timestamp.AddDays(14), loadedInvoice.BillingPeriodEnd);
-
-      //TradeAllowanceCharges
-      var tradeAllowanceCharge = loadedInvoice.GetTradeAllowanceCharges().FirstOrDefault(i => i.Reason == "Reason for charge");
-      Assert.IsNotNull(tradeAllowanceCharge);
-      Assert.IsTrue(tradeAllowanceCharge.ChargeIndicator);
-      Assert.AreEqual("Reason for charge", tradeAllowanceCharge.Reason);
-      Assert.AreEqual(5m, tradeAllowanceCharge.BasisAmount);
-      Assert.AreEqual(15m, tradeAllowanceCharge.ActualAmount);
-      Assert.AreEqual(CurrencyCodes.EUR, tradeAllowanceCharge.Currency);
-      Assert.AreEqual(19m, tradeAllowanceCharge.Tax.Percent);
-      Assert.AreEqual(TaxTypes.AAB, tradeAllowanceCharge.Tax.TypeCode);
-      Assert.AreEqual(TaxCategoryCodes.AB, tradeAllowanceCharge.Tax.CategoryCode);
-
-      //ServiceCharges
-      var serviceCharge = desc.ServiceCharges.FirstOrDefault(i => i.Description == "Logistics service charge");
-      Assert.IsNotNull(serviceCharge);
-      Assert.AreEqual("Logistics service charge", serviceCharge.Description);
-      Assert.AreEqual(10m, serviceCharge.Amount);
-      Assert.AreEqual(7m, serviceCharge.Tax.Percent);
-      Assert.AreEqual(TaxTypes.AAC, serviceCharge.Tax.TypeCode);
-      Assert.AreEqual(TaxCategoryCodes.AC, serviceCharge.Tax.CategoryCode);
-
-      Assert.AreEqual("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018", loadedInvoice.PaymentTerms.Description);
-      Assert.AreEqual(timestamp.AddDays(14), loadedInvoice.PaymentTerms.DueDate);
-
-
-      Assert.AreEqual(473.0m, loadedInvoice.LineTotalAmount);
-      Assert.AreEqual(null, loadedInvoice.ChargeTotalAmount); // optional
-      Assert.AreEqual(null, loadedInvoice.AllowanceTotalAmount); // optional
-      Assert.AreEqual(473.0m, loadedInvoice.TaxBasisAmount);
-      Assert.AreEqual(56.87m, loadedInvoice.TaxTotalAmount);
-      Assert.AreEqual(529.87m, loadedInvoice.GrandTotalAmount);
-      Assert.AreEqual(null, loadedInvoice.TotalPrepaidAmount); // optional
-      Assert.AreEqual(529.87m, loadedInvoice.DuePayableAmount);
-
-      //InvoiceReferencedDocument
-      Assert.AreEqual("RE-12345", loadedInvoice.GetInvoiceReferencedDocuments().First().ID);
-      Assert.AreEqual(timestamp, loadedInvoice.GetInvoiceReferencedDocuments().First().IssueDateTime);
-
-
-      //Line items
-      var loadedLineItem = loadedInvoice.TradeLineItems.FirstOrDefault(i => i.SellerAssignedID == "TB100A4");
-      Assert.IsNotNull(loadedLineItem);
-      Assert.IsTrue(!string.IsNullOrEmpty(loadedLineItem.AssociatedDocument.LineID));
-      Assert.AreEqual("This is line item TB100A4", loadedLineItem.Description);
-
-      Assert.AreEqual("Trennblätter A4", loadedLineItem.Name);
-
-      Assert.AreEqual("TB100A4", loadedLineItem.SellerAssignedID);
-      Assert.AreEqual("0815", loadedLineItem.BuyerAssignedID);
-      Assert.AreEqual(GlobalIDSchemeIdentifiers.EAN, loadedLineItem.GlobalID.SchemeID);
-      Assert.AreEqual("4012345001235", loadedLineItem.GlobalID.ID);
-
-      //GrossPriceProductTradePrice
-      Assert.AreEqual(9.9m, loadedLineItem.GrossUnitPrice);
-      Assert.AreEqual(QuantityCodes.H87, loadedLineItem.UnitCode);
-      Assert.AreEqual(3m, loadedLineItem.UnitQuantity);
-
-      //NetPriceProductTradePrice
-      Assert.AreEqual(9.9m, loadedLineItem.NetUnitPrice);
-      Assert.AreEqual(20m, loadedLineItem.BilledQuantity);
-
-      Assert.AreEqual(TaxTypes.VAT, loadedLineItem.TaxType);
-      Assert.AreEqual(TaxCategoryCodes.S, loadedLineItem.TaxCategoryCode);
-      Assert.AreEqual(19m, loadedLineItem.TaxPercent);
-
-      Assert.AreEqual("12345", loadedLineItem.BuyerOrderReferencedDocument.ID);
-      Assert.AreEqual(timestamp, loadedLineItem.BuyerOrderReferencedDocument.IssueDateTime);
-      Assert.AreEqual("12345", loadedLineItem.DeliveryNoteReferencedDocument.ID);
-      Assert.AreEqual(timestamp, loadedLineItem.DeliveryNoteReferencedDocument.IssueDateTime);
-      Assert.AreEqual("12345", loadedLineItem.ContractReferencedDocument.ID);
-      Assert.AreEqual(timestamp, loadedLineItem.ContractReferencedDocument.IssueDateTime);
-
-      var lineItemReferencedDoc = loadedLineItem.GetAdditionalReferencedDocuments().FirstOrDefault();
-      Assert.IsNotNull(lineItemReferencedDoc);
-      Assert.AreEqual("xyz", lineItemReferencedDoc.ID);
-      Assert.AreEqual(timestamp, lineItemReferencedDoc.IssueDateTime);
-      Assert.AreEqual(ReferenceTypeCodes.AAB, lineItemReferencedDoc.ReferenceTypeCode);
-
-
-      var productCharacteristics = loadedLineItem.ApplicableProductCharacteristics.FirstOrDefault();
-      Assert.IsNotNull(productCharacteristics);
-      Assert.AreEqual("Product characteristics", productCharacteristics.Description);
-      Assert.AreEqual("Product value", productCharacteristics.Value);
-
-      Assert.AreEqual(timestamp, loadedLineItem.ActualDeliveryDate);
-      Assert.AreEqual(timestamp, loadedLineItem.BillingPeriodStart);
-      Assert.AreEqual(timestamp.AddDays(10), loadedLineItem.BillingPeriodEnd);
-
-      //Currently not implemented
-      //var accountingAccount = loadedLineItem.ReceivableSpecifiedTradeAccountingAccounts.FirstOrDefault();
-      //Assert.IsNotNull(accountingAccount);
-      //Assert.AreEqual("987654", accountingAccount.TradeAccountID);
-
-
-      var lineItemTradeAllowanceCharge = loadedLineItem.GetTradeAllowanceCharges().FirstOrDefault(i => i.Reason == "Reason: UnitTest");
-      Assert.IsNotNull(lineItemTradeAllowanceCharge);
-      Assert.IsTrue(lineItemTradeAllowanceCharge.ChargeIndicator);
-      Assert.AreEqual(10m, lineItemTradeAllowanceCharge.BasisAmount);
-      Assert.AreEqual(50m, lineItemTradeAllowanceCharge.ActualAmount);
-      Assert.AreEqual("Reason: UnitTest", lineItemTradeAllowanceCharge.Reason);
     }
-  }
 }

--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -136,7 +136,8 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
             Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
 
-            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.FirstOrDefault().Description.Trim());
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", 
+                invoiceDescriptor.GetTradePaymentTerms().FirstOrDefault().Description.Trim());
         } // !TestLoadingSepaPreNotification()
 
 
@@ -505,7 +506,7 @@ namespace ZUGFeRD_Test
             desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m);
             desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
 
-            desc.PaymentTerms.FirstOrDefault().DueDate = timestamp.AddDays(14);
+            desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
             desc.AddInvoiceReferencedDocument("RE-12345", timestamp);
 
 

--- a/ZUGFeRD-Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD20Tests.cs
@@ -196,7 +196,7 @@ namespace ZUGFeRD_Test
             d.AddDebitorFinancialAccount(
                 "DE21860000000086001055",
                 null);
-            d.SetTradePaymentTerms(
+            d.AddTradePaymentTerms(
                 "Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.");
             d.SetTotals(
                 473.00m,

--- a/ZUGFeRD-Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD22Tests.cs
@@ -932,7 +932,7 @@ namespace ZUGFeRD_Test
             d.AddDebitorFinancialAccount(
                 "DE21860000000086001055",
                 null);
-            d.SetTradePaymentTerms(
+            d.AddTradePaymentTerms(
                 "Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.");
             d.SetTotals(
                 473.00m,
@@ -2228,7 +2228,8 @@ namespace ZUGFeRD_Test
             // Arrange
             DateTime timestamp = DateTime.Now.Date;
             var desc = InvoiceProvider.CreateInvoice();
-            desc.SetTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
+            desc.GetTradePaymentTerms().Clear();
+            desc.AddTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
             desc.AddTradePaymentTerms("3% Skonto innerhalb 10 Tagen bis 15.03.2018", new DateTime(2018, 3, 15), PaymentTermsType.Skonto, 10, 3m);
             desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
 
@@ -2269,7 +2270,8 @@ namespace ZUGFeRD_Test
             // Arrange
             DateTime timestamp = DateTime.Now.Date;
             var desc = InvoiceProvider.CreateInvoice();
-            desc.SetTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
+            desc.GetTradePaymentTerms().Clear();
+            desc.AddTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
             desc.AddTradePaymentTerms("3% Skonto innerhalb 10 Tagen bis 15.03.2018", new DateTime(2018, 3, 15), percentage: 3m);
             desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
 

--- a/ZUGFeRD-Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD22Tests.cs
@@ -872,7 +872,8 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
             Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
 
-            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", invoiceDescriptor.PaymentTerms.FirstOrDefault().Description.Trim());
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", 
+                invoiceDescriptor.GetTradePaymentTerms().FirstOrDefault().Description.Trim());
         } // !TestLoadingSepaPreNotification()
 
 
@@ -1445,7 +1446,7 @@ namespace ZUGFeRD_Test
             desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m);
             desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
 
-            desc.PaymentTerms.FirstOrDefault().DueDate = timestamp.AddDays(14);
+            desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
             desc.AddInvoiceReferencedDocument("RE-12345", timestamp);
 
 
@@ -1985,7 +1986,7 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(desc.Taxes[1].TypeCode, (TaxTypes)53);
             Assert.AreEqual(desc.Taxes[1].CategoryCode, (TaxCategoryCodes)19);
 
-            Assert.AreEqual(desc.PaymentTerms.FirstOrDefault().DueDate, new DateTime(2020, 6, 21));
+            Assert.AreEqual(desc.GetTradePaymentTerms().FirstOrDefault().DueDate, new DateTime(2020, 6, 21));
 
             Assert.AreEqual(desc.CreditorBankAccounts[0].IBAN, "DE12500105170648489890");
             Assert.AreEqual(desc.CreditorBankAccounts[0].BIC, "INGDDEFFXXX");
@@ -2229,7 +2230,7 @@ namespace ZUGFeRD_Test
             var desc = InvoiceProvider.CreateInvoice();
             desc.SetTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
             desc.AddTradePaymentTerms("3% Skonto innerhalb 10 Tagen bis 15.03.2018", new DateTime(2018, 3, 15), PaymentTermsType.Skonto, 10, 3m);
-            desc.PaymentTerms.FirstOrDefault().DueDate = timestamp.AddDays(14);
+            desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
 
             MemoryStream ms = new MemoryStream();
             desc.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);
@@ -2270,7 +2271,7 @@ namespace ZUGFeRD_Test
             var desc = InvoiceProvider.CreateInvoice();
             desc.SetTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
             desc.AddTradePaymentTerms("3% Skonto innerhalb 10 Tagen bis 15.03.2018", new DateTime(2018, 3, 15), percentage: 3m);
-            desc.PaymentTerms.FirstOrDefault().DueDate = timestamp.AddDays(14);
+            desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
 
             MemoryStream ms = new MemoryStream();
             desc.Save(ms, ZUGFeRDVersion.Version23, Profile.Comfort);
@@ -2303,10 +2304,10 @@ namespace ZUGFeRD_Test
             // Arrange
             DateTime timestamp = DateTime.Now.Date;
             var desc = InvoiceProvider.CreateInvoice();
-            desc.PaymentTerms.Clear();
+            desc.GetTradePaymentTerms().Clear();
             desc.AddTradePaymentTerms("", null, PaymentTermsType.Skonto, 14, 2.25m);
             desc.AddTradePaymentTerms("", null, PaymentTermsType.Skonto, 28, 1m);
-            desc.PaymentTerms.FirstOrDefault().DueDate = timestamp.AddDays(14);
+            desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
 
             MemoryStream ms = new MemoryStream();
             desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung);

--- a/ZUGFeRD-Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD22Tests.cs
@@ -2329,7 +2329,7 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(1, paymentTerms.Count);
             var paymentTerm = loadedInvoice.GetTradePaymentTerms().FirstOrDefault();
             Assert.IsNotNull(paymentTerm);
-            Assert.AreEqual($"#SKONTO#TAGE=14#PROZENT=2.25#{Environment.NewLine}#SKONTO#TAGE=28#PROZENT=1.00#", paymentTerm.Description);
+            Assert.AreEqual($"#SKONTO#TAGE=14#PROZENT=2.25#{Environment.NewLine}#SKONTO#TAGE=28#PROZENT=1.00#{Environment.NewLine}", paymentTerm.Description);
             Assert.AreEqual(timestamp.AddDays(14), paymentTerm.DueDate);
             //Assert.AreEqual(PaymentTermsType.Skonto, paymentTerm.PaymentTermsType);
             //Assert.AreEqual(10, paymentTerm.DueDays);

--- a/ZUGFeRD-Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD22Tests.cs
@@ -2293,7 +2293,7 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(1, paymentTerms.Count);
             var paymentTerm = loadedInvoice.GetTradePaymentTerms().FirstOrDefault();
             Assert.IsNotNull(paymentTerm);
-            Assert.AreEqual("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018\r\n3% Skonto innerhalb 10 Tagen bis 15.03.2018", paymentTerm.Description);
+            Assert.AreEqual($"Zahlbar innerhalb 30 Tagen netto bis 04.04.2018{Environment.NewLine}3% Skonto innerhalb 10 Tagen bis 15.03.2018", paymentTerm.Description);
             Assert.AreEqual(timestamp.AddDays(14), paymentTerm.DueDate);
         }
 
@@ -2329,7 +2329,7 @@ namespace ZUGFeRD_Test
             Assert.AreEqual(1, paymentTerms.Count);
             var paymentTerm = loadedInvoice.GetTradePaymentTerms().FirstOrDefault();
             Assert.IsNotNull(paymentTerm);
-            Assert.AreEqual("#SKONTO#TAGE=14#PROZENT=2.25#\r\n#SKONTO#TAGE=28#PROZENT=1.00#", paymentTerm.Description);
+            Assert.AreEqual($"#SKONTO#TAGE=14#PROZENT=2.25#{Environment.NewLine}#SKONTO#TAGE=28#PROZENT=1.00#", paymentTerm.Description);
             Assert.AreEqual(timestamp.AddDays(14), paymentTerm.DueDate);
             //Assert.AreEqual(PaymentTermsType.Skonto, paymentTerm.PaymentTermsType);
             //Assert.AreEqual(10, paymentTerm.DueDays);

--- a/ZUGFeRD-Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD22Tests.cs
@@ -2222,7 +2222,7 @@ namespace ZUGFeRD_Test
 		} // !TestDesignatedProductClassificationWithoutClassCode()
 
         [TestMethod]
-        public void TestTradePaymentTermsMultiCardinality()
+        public void TestPaymentTermsMultiCardinality()
         {
             // Arrange
             DateTime timestamp = DateTime.Now.Date;

--- a/ZUGFeRD/EnumerationExtensions.cs
+++ b/ZUGFeRD/EnumerationExtensions.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+
+namespace s2industries.ZUGFeRD
+{
+    internal static class EnumerationExtensions
+    {
+        internal static string AsString<T>(this T value) where T : Enum
+        {
+            return Enum.GetName(typeof(T), value);
+        }
+
+        internal static T AsEnum<T>(this int value) where T : Enum
+        {
+            if (Enum.IsDefined(typeof(T), value))
+            {
+                return (T)Enum.ToObject(typeof(T), value);
+            }
+            else
+            {
+                throw new ArgumentException($"{value} is not a valid value for enum {typeof(T).Name}");
+            }
+        }
+
+        internal static int AsInt<T>(this T value) where T : Enum
+        {
+            return (int)(object)value;
+        }
+    }
+}

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -300,7 +300,7 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Detailed information about payment terms               
         /// </summary>
-        public List<PaymentTerms> PaymentTerms { get; set; } = new List<PaymentTerms>();
+        internal List<PaymentTerms> PaymentTerms { get; set; } = new List<PaymentTerms>();
 
         /// <summary>
         /// A group of business terms providing information about a preceding invoices.

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -856,6 +856,7 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         /// <param name="description"></param>
         /// <param name="dueDate"></param>
+        [Obsolete("The method has been made redundant and will be removed in a future release. Please use 'AddTradePaymentTerms' instead.", false)]
         public void SetTradePaymentTerms(string description, DateTime? dueDate = null)
         {
             this._PaymentTerms.Clear();

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -20,8 +20,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace s2industries.ZUGFeRD
 {
@@ -94,8 +92,8 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         public CurrencyCodes Currency { get; set; }
 
-		/// <summary>
-		/// The VAT total amount expressed in the accounting currency accepted or 
+        /// <summary>
+        /// The VAT total amount expressed in the accounting currency accepted or 
         /// required in the country of the seller. 
         /// 
         /// Note: Shall be used in combination with the invoice total VAT amount 
@@ -110,14 +108,14 @@ namespace s2industries.ZUGFeRD
         /// of the Council Directive 2006/112/EC [2] for further information.
         /// 
         /// BT-6
-		/// </summary>
-		public CurrencyCodes? TaxCurrency { get; set; }
+        /// </summary>
+        public CurrencyCodes? TaxCurrency { get; set; }
 
 
-		/// <summary>
-		/// Information about the buyer
-		/// </summary>
-		public Party Buyer { get; set; }
+        /// <summary>
+        /// Information about the buyer
+        /// </summary>
+        public Party Buyer { get; set; }
 
         /// <summary>
         /// Buyer contact information
@@ -132,29 +130,29 @@ namespace s2industries.ZUGFeRD
         public List<TaxRegistration> SellerTaxRegistration { get; set; } = new List<TaxRegistration>();
         public ElectronicAddress SellerElectronicAddress { get; set; }
 
-		/// <summary>
-		/// Given seller reference number for routing purposes after biliteral agreement
+        /// <summary>
+        /// Given seller reference number for routing purposes after biliteral agreement
         /// 
         /// This field seems not to be used in common scenarios.
-		/// </summary>
-		public string SellerReferenceNo { get; set; } = "";
+        /// </summary>
+        public string SellerReferenceNo { get; set; } = "";
 
-		/// <summary>
-		/// This party is optional and only relevant for Extended profile
-		/// </summary>
-		public Party Invoicee { get; set; }
+        /// <summary>
+        /// This party is optional and only relevant for Extended profile
+        /// </summary>
+        public Party Invoicee { get; set; }
 
-		/// <summary>
-		/// This party is optional and only relevant for Extended profile.
+        /// <summary>
+        /// This party is optional and only relevant for Extended profile.
         /// 
         /// It seems to be used under rate condition only.
-		/// </summary>
-		public Party Invoicer { get; set; }
+        /// </summary>
+        public Party Invoicer { get; set; }
 
-		/// <summary>
-		/// This party is optional and only relevant for Extended profile
-		/// </summary>
-		public Party ShipTo { get; set; }
+        /// <summary>
+        /// This party is optional and only relevant for Extended profile
+        /// </summary>
+        public Party ShipTo { get; set; }
 
         /// <summary>
         /// This party is optional and only relevant for Extended profile
@@ -201,10 +199,10 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         public string Name { get; set; }
 
-		/// <summary>
-		/// Indicates the type of the document, if it represents an invoice, a credit note or one of the available 'sub types'
-		/// </summary>
-		public InvoiceType Type { get; set; } = InvoiceType.Invoice;
+        /// <summary>
+        /// Indicates the type of the document, if it represents an invoice, a credit note or one of the available 'sub types'
+        /// </summary>
+        public InvoiceType Type { get; set; } = InvoiceType.Invoice;
 
         /// <summary>
         /// The identifier is defined by the buyer (e.g. contact ID, department, office ID, project code), but provided by the seller in the invoice. 
@@ -302,7 +300,7 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Detailed information about payment terms               
         /// </summary>
-        public PaymentTerms PaymentTerms { get; set; }
+        public List<PaymentTerms> PaymentTerms { get; set; } = new List<PaymentTerms>();
 
         /// <summary>
         /// A group of business terms providing information about a preceding invoices.
@@ -852,14 +850,48 @@ namespace s2industries.ZUGFeRD
             return this._TradeAllowanceCharges;
         } // !GetTradeAllowanceCharges()
 
-
+        /// <summary>
+        /// Clears the current trade payment terms and sets the initial payment terms
+        /// </summary>
+        /// <param name="description"></param>
+        /// <param name="dueDate"></param>
         public void SetTradePaymentTerms(string description, DateTime? dueDate = null)
         {
-            this.PaymentTerms = new PaymentTerms()
+            this.PaymentTerms.Clear();
+            AddTradePaymentTerms(description, dueDate);
+        }
+
+        /// <summary>
+        /// Adds a trade payment term.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <param name="dueDate"></param>
+        /// <param name="paymentTermsType"></param>
+        /// <param name="dueDays"></param>
+        /// <param name="percentage"></param>
+        /// <param name="baseAmount"></param>
+        public void AddTradePaymentTerms(string description, DateTime? dueDate = null,
+            PaymentTermsType? paymentTermsType = null, int? dueDays = null, 
+            decimal? percentage = null, decimal? baseAmount = null)
+        {
+            PaymentTerms.Add(new PaymentTerms()
             {
                 Description = description,
-                DueDate = dueDate
-            };
+                DueDate = dueDate,
+                PaymentTermsType = paymentTermsType,
+                DueDays = dueDays,
+                Percentage = percentage,
+                BaseAmount = baseAmount
+            });
+        }
+
+        /// <summary>
+        /// Returns all existing trade payment terms.
+        /// </summary>
+        /// <returns></returns>
+        public IList<PaymentTerms> GetTradePaymentTerms()
+        {
+            return PaymentTerms;
         }
 
         /// <summary>
@@ -981,7 +1013,7 @@ namespace s2industries.ZUGFeRD
         {
             this.Profile = profile;
             IInvoiceDescriptorWriter writer = _selectInvoiceDescriptorWriter(version);
-            writer.Save(this, stream,format);
+            writer.Save(this, stream, format);
         } // !Save()
 
 
@@ -1033,7 +1065,7 @@ namespace s2industries.ZUGFeRD
             }
 
             TradeLineItem item = new TradeLineItem(lineID)
-            {                
+            {
                 GrossUnitPrice = 0m,
                 NetUnitPrice = 0m,
                 BilledQuantity = 0m,

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -300,7 +300,8 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Detailed information about payment terms               
         /// </summary>
-        internal List<PaymentTerms> PaymentTerms { get; set; } = new List<PaymentTerms>();
+        /// <remarks>BT-20</remarks>
+        private List<PaymentTerms> _PaymentTerms { get; set; } = new List<PaymentTerms>();
 
         /// <summary>
         /// A group of business terms providing information about a preceding invoices.
@@ -857,7 +858,7 @@ namespace s2industries.ZUGFeRD
         /// <param name="dueDate"></param>
         public void SetTradePaymentTerms(string description, DateTime? dueDate = null)
         {
-            this.PaymentTerms.Clear();
+            this._PaymentTerms.Clear();
             AddTradePaymentTerms(description, dueDate);
         }
 
@@ -874,7 +875,7 @@ namespace s2industries.ZUGFeRD
             PaymentTermsType? paymentTermsType = null, int? dueDays = null, 
             decimal? percentage = null, decimal? baseAmount = null)
         {
-            PaymentTerms.Add(new PaymentTerms()
+            _PaymentTerms.Add(new PaymentTerms()
             {
                 Description = description,
                 DueDate = dueDate,
@@ -891,7 +892,7 @@ namespace s2industries.ZUGFeRD
         /// <returns></returns>
         public IList<PaymentTerms> GetTradePaymentTerms()
         {
-            return PaymentTerms;
+            return _PaymentTerms;
         }
 
         /// <summary>

--- a/ZUGFeRD/InvoiceDescriptor1Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Reader.cs
@@ -18,11 +18,8 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Xml;
-using System.Xml.XPath;
 using System.IO;
+using System.Xml;
 
 namespace s2industries.ZUGFeRD
 {
@@ -222,11 +219,11 @@ namespace s2industries.ZUGFeRD
                                                  XmlUtils.NodeAsDecimal(node, ".//ram:AppliedTradeTax/ram:ApplicablePercent", nsmgr, 0).Value);
             }
 
-            retval.PaymentTerms = new PaymentTerms()
+            foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedTradePaymentTerms", nsmgr))
             {
-                Description = XmlUtils.NodeAsString(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:Description", nsmgr),
-                DueDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime", nsmgr)
-            };
+                retval.AddTradePaymentTerms(XmlUtils.NodeAsString(node, ".//ram:Description", nsmgr),
+                                            XmlUtils.NodeAsDateTime(node, ".//ram:DueDateDateTime", nsmgr));
+            }
 
             retval.LineTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementMonetarySummation/ram:LineTotalAmount", nsmgr, 0).Value;
             retval.ChargeTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementMonetarySummation/ram:ChargeTotalAmount", nsmgr, null);
@@ -305,7 +302,7 @@ namespace s2industries.ZUGFeRD
             if (tradeLineItem.SelectSingleNode(".//ram:AssociatedDocumentLineDocument", nsmgr) != null)
             {
                 XmlNodeList noteNodes = tradeLineItem.SelectNodes(".//ram:AssociatedDocumentLineDocument/ram:IncludedNote", nsmgr);
-                foreach(XmlNode noteNode in noteNodes)
+                foreach (XmlNode noteNode in noteNodes)
                 {
                     item.AssociatedDocument.Notes.Add(new Note(
                                 content: XmlUtils.NodeAsString(noteNode, ".//ram:Content", nsmgr),
@@ -379,8 +376,8 @@ namespace s2industries.ZUGFeRD
                 item.AddAdditionalReferencedDocument(
                     id: XmlUtils.NodeAsString(referenceNode, "ram:ID", nsmgr),
                     code: default(ReferenceTypeCodes).FromString(_code),
-					issueDateTime: XmlUtils.NodeAsDateTime(referenceNode, "ram:IssueDateTime", nsmgr)
-				);
+                    issueDateTime: XmlUtils.NodeAsDateTime(referenceNode, "ram:IssueDateTime", nsmgr)
+                );
             }
 
             return item;

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -18,12 +18,10 @@
  */
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
-using System.Globalization;
-using System.IO;
-using System.Diagnostics.Contracts;
 
 
 namespace s2industries.ZUGFeRD
@@ -360,17 +358,47 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteEndElement();
             }
 
-            if (this.Descriptor.PaymentTerms != null)
+            //  The cardinality depends on the profile.
+            switch (Descriptor.Profile)
             {
-                Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
-                Writer.WriteOptionalElementString("ram:Description", this.Descriptor.PaymentTerms.Description);
-                if (this.Descriptor.PaymentTerms.DueDate.HasValue)
-                {
-                    Writer.WriteStartElement("ram:DueDateDateTime");
-                    _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(this.Descriptor.PaymentTerms.DueDate.Value));
-                    Writer.WriteEndElement(); // !ram:DueDateDateTime
-                }
-                Writer.WriteEndElement();
+                case Profile.Unknown:
+                case Profile.Minimum:
+                    break;
+                case Profile.Extended:
+                    foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                    {
+                        Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
+                        Writer.WriteOptionalElementString("ram:Description", paymentTerms.Description);
+                        if (paymentTerms.DueDate.HasValue)
+                        {
+                            Writer.WriteStartElement("ram:DueDateDateTime");
+                            _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
+                            Writer.WriteEndElement(); // !ram:DueDateDateTime
+                        }
+                        Writer.WriteEndElement();
+                    }
+                    break;
+                default:
+                    if (Descriptor.PaymentTerms.Count > 0)
+                    {
+                        Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
+                        var sbPaymentNotes = new StringBuilder();
+                        var setDueDate = true;
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        {
+                            sbPaymentNotes.AppendLine(paymentTerms.Description);
+                            if (paymentTerms.DueDate.HasValue && setDueDate)
+                            {
+                                Writer.WriteStartElement("ram:DueDateDateTime");
+                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
+                                Writer.WriteEndElement(); // !ram:DueDateDateTime
+                                setDueDate = false;
+                            }
+                        }
+                        Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        Writer.WriteEndElement();
+                    }
+                    break;
             }
 
             Writer.WriteStartElement("ram:SpecifiedTradeSettlementMonetarySummation");

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -383,19 +383,19 @@ namespace s2industries.ZUGFeRD
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
-                        var setDueDate = true;
+                        DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
                         {
                             sbPaymentNotes.AppendLine(paymentTerms.Description);
-                            if (paymentTerms.DueDate.HasValue && setDueDate)
-                            {
-                                Writer.WriteStartElement("ram:DueDateDateTime");
-                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
-                                Writer.WriteEndElement(); // !ram:DueDateDateTime
-                                setDueDate = false;
-                            }
+                            dueDate = dueDate ?? paymentTerms.DueDate;
                         }
                         Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        if (dueDate.HasValue)
+                        {
+                            Writer.WriteStartElement("ram:DueDateDateTime");
+                            _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(dueDate.Value));
+                            Writer.WriteEndElement(); // !ram:DueDateDateTime
+                        }
                         Writer.WriteEndElement();
                     }
                     break;

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -365,7 +365,7 @@ namespace s2industries.ZUGFeRD
                 case Profile.Minimum:
                     break;
                 case Profile.Extended:
-                    foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                    foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         Writer.WriteOptionalElementString("ram:Description", paymentTerms.Description);
@@ -379,12 +379,12 @@ namespace s2industries.ZUGFeRD
                     }
                     break;
                 default:
-                    if (Descriptor.PaymentTerms.Count > 0)
+                    if (Descriptor.GetTradePaymentTerms().Count > 0)
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
                         DateTime? dueDate = null;
-                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                         {
                             sbPaymentNotes.AppendLine(paymentTerms.Description);
                             dueDate = dueDate ?? paymentTerms.DueDate;

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -272,11 +272,25 @@ namespace s2industries.ZUGFeRD
                                                  XmlUtils.NodeAsDecimal(node, ".//ram:AppliedTradeTax/ram:RateApplicablePercent", nsmgr, 0).Value);
             }
 
-            retval.PaymentTerms = new PaymentTerms()
+            foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedTradePaymentTerms", nsmgr))
             {
-                Description = XmlUtils.NodeAsString(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:Description", nsmgr),
-                DueDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//ram:SpecifiedTradePaymentTerms/ram:DueDateDateTime", nsmgr)
-            };
+                decimal? discountPercent = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:CalculationPercent", nsmgr, null);
+                int? discountDueDays = null; // XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure", nsmgr);
+                decimal? discountAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount", nsmgr, null);
+                decimal? penaltyPercent = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent", nsmgr, null);
+                int? penaltyDueDays = null; // XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure", nsmgr);
+                decimal? penaltyAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount", nsmgr, null);
+                PaymentTermsType? paymentTermsType = discountPercent.HasValue ? PaymentTermsType.Skonto :
+                    penaltyPercent.HasValue ? PaymentTermsType.Verzug :
+                    (PaymentTermsType?)null;
+
+                retval.AddTradePaymentTerms(XmlUtils.NodeAsString(node, ".//ram:Description", nsmgr),
+                                            XmlUtils.NodeAsDateTime(node, ".//ram:DueDateDateTime", nsmgr),
+                                            paymentTermsType,
+                                            discountDueDays ?? penaltyDueDays,
+                                            discountPercent ?? penaltyPercent,
+                                            discountAmount ?? penaltyAmount);
+            }
 
             retval.LineTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:LineTotalAmount", nsmgr, 0).Value;
             retval.ChargeTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:ChargeTotalAmount", nsmgr, null);

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -723,12 +723,12 @@ namespace s2industries.ZUGFeRD
                 case Profile.Minimum:
                     break;
                 case Profile.XRechnung:
-                    if (Descriptor.PaymentTerms.Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    if (Descriptor.GetTradePaymentTerms().Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
                         DateTime? dueDate = null;
-                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
                             {
@@ -756,7 +756,7 @@ namespace s2industries.ZUGFeRD
                     }
                     break;
                 case Profile.Extended:
-                    foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                    foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         Writer.WriteOptionalElementString("ram:Description", paymentTerms.Description);
@@ -786,7 +786,7 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }
-                    if (this.Descriptor.PaymentTerms.Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    if (this.Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
@@ -794,12 +794,12 @@ namespace s2industries.ZUGFeRD
                     }
                     break;
                 default:
-                    if (Descriptor.PaymentTerms.Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    if (Descriptor.GetTradePaymentTerms().Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
                         DateTime? dueDate = null;
-                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
                             {

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -744,7 +744,7 @@ namespace s2industries.ZUGFeRD
                             }
                             dueDate = dueDate ?? paymentTerms.DueDate;
                         }
-                        Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString());
                         if (dueDate.HasValue)
                         {
                             Writer.WriteStartElement("ram:DueDateDateTime");

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -727,7 +727,7 @@ namespace s2industries.ZUGFeRD
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
-                        var setDueDate = true;
+                        DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
@@ -742,15 +742,15 @@ namespace s2industries.ZUGFeRD
                             {
                                 sbPaymentNotes.AppendLine(paymentTerms.Description);
                             }
-                            if (paymentTerms.DueDate.HasValue && setDueDate)
-                            {
-                                Writer.WriteStartElement("ram:DueDateDateTime");
-                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
-                                Writer.WriteEndElement(); // !ram:DueDateDateTime
-                                setDueDate = false;
-                            }
+                            dueDate = dueDate ?? paymentTerms.DueDate;
                         }
                         Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        if (dueDate.HasValue)
+                        {
+                            Writer.WriteStartElement("ram:DueDateDateTime");
+                            _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(dueDate.Value));
+                            Writer.WriteEndElement(); // !ram:DueDateDateTime
+                        }
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }
@@ -798,7 +798,7 @@ namespace s2industries.ZUGFeRD
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
-                        var setDueDate = true;
+                        DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
@@ -822,15 +822,15 @@ namespace s2industries.ZUGFeRD
                             {
                                 sbPaymentNotes.AppendLine(paymentTerms.Description);
                             }
-                            if (paymentTerms.DueDate.HasValue && setDueDate)
-                            {
-                                Writer.WriteStartElement("ram:DueDateDateTime");
-                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
-                                Writer.WriteEndElement(); // !ram:DueDateDateTime
-                                setDueDate = false;
-                            }
+                            dueDate = dueDate ?? paymentTerms.DueDate;
                         }
                         Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        if (dueDate.HasValue)
+                        {
+                            Writer.WriteStartElement("ram:DueDateDateTime");
+                            _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(dueDate.Value));
+                            Writer.WriteEndElement(); // !ram:DueDateDateTime
+                        }
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -297,11 +297,11 @@ namespace s2industries.ZUGFeRD
             }
 
             // PaymentTerms (optional)
-            if (this.Descriptor.PaymentTerms.Count > 0)
+            if (this.Descriptor.GetTradePaymentTerms().Count > 0)
             {
                 Writer.WriteStartElement("cac:PaymentTerms");
                 var sbPaymentNotes = new StringBuilder();
-                foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                 {
                     sbPaymentNotes.AppendLine(paymentTerms.Description);
                 }

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -296,13 +297,17 @@ namespace s2industries.ZUGFeRD
             }
 
             // PaymentTerms (optional)
-            if (this.Descriptor.PaymentTerms != null)
+            if (this.Descriptor.PaymentTerms.Count > 0)
             {
                 Writer.WriteStartElement("cac:PaymentTerms");
-                Writer.WriteOptionalElementString("cbc:Note", this.Descriptor.PaymentTerms?.Description);
+                var sbPaymentNotes = new StringBuilder();
+                foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                {
+                    sbPaymentNotes.AppendLine(paymentTerms.Description);
+                }
+                Writer.WriteOptionalElementString("cbc:Note", sbPaymentNotes.ToString().TrimEnd());
                 Writer.WriteEndElement();
             }
-
 
             // Tax Total
             Writer.WriteStartElement("cac:TaxTotal");

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -327,11 +327,10 @@ namespace s2industries.ZUGFeRD
                 break; // only one occurrence allowed in UBL
             }
 
-            retval.PaymentTerms.Add(new PaymentTerms()
-            {
-                Description = XmlUtils.NodeAsString(doc.DocumentElement, "//cac:PaymentTerms/cbc:Note", nsmgr),
-                DueDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//cbc:DueDate", nsmgr)
-            });
+            retval.AddTradePaymentTerms(
+                description: XmlUtils.NodeAsString(doc.DocumentElement, "//cac:PaymentTerms/cbc:Note", nsmgr),
+                dueDate: XmlUtils.NodeAsDateTime(doc.DocumentElement, "//cbc:DueDate", nsmgr)
+            );
 
             retval.LineTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:LineExtensionAmount", nsmgr, 0).Value;
             retval.ChargeTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:ChargeTotalAmount", nsmgr, null);

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -327,12 +327,11 @@ namespace s2industries.ZUGFeRD
                 break; // only one occurrence allowed in UBL
             }
 
-
-            retval.PaymentTerms = new PaymentTerms()
+            retval.PaymentTerms.Add(new PaymentTerms()
             {
                 Description = XmlUtils.NodeAsString(doc.DocumentElement, "//cac:PaymentTerms/cbc:Note", nsmgr),
                 DueDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//cbc:DueDate", nsmgr)
-            };
+            });
 
             retval.LineTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:LineExtensionAmount", nsmgr, 0).Value;
             retval.ChargeTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:ChargeTotalAmount", nsmgr, null);

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -964,7 +964,7 @@ namespace s2industries.ZUGFeRD
                             }
                             dueDate = dueDate ?? paymentTerms.DueDate;
                         }
-                        Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString());
                         if (dueDate.HasValue)
                         {
                             Writer.WriteStartElement("ram:DueDateDateTime");

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -18,7 +18,6 @@
  */
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -173,9 +172,9 @@ namespace s2industries.ZUGFeRD
 
                 if (tradeLineItem.GetDesignatedProductClassifications().Any())
                 {
-                    foreach(var designatedProductClassification in tradeLineItem.GetDesignatedProductClassifications())
+                    foreach (var designatedProductClassification in tradeLineItem.GetDesignatedProductClassifications())
                     {
-                        Writer.WriteStartElement("ram:DesignatedProductClassification");                        
+                        Writer.WriteStartElement("ram:DesignatedProductClassification");
 
                         if (designatedProductClassification.ClassCode.HasValue)
                         {
@@ -188,8 +187,8 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteValue(designatedProductClassification.ClassCode.Value.ToString());
                             Writer.WriteEndElement(); // !ram::ClassCode
                         }
-						Writer.WriteOptionalElementString("ram:ClassName", designatedProductClassification.ClassName);
-						Writer.WriteEndElement(); // !ram:DesignatedProductClassification
+                        Writer.WriteOptionalElementString("ram:ClassName", designatedProductClassification.ClassName);
+                        Writer.WriteEndElement(); // !ram:DesignatedProductClassification
                     }
                 }
 
@@ -211,7 +210,7 @@ namespace s2industries.ZUGFeRD
 
                         //Bestellnummer
                         Writer.WriteOptionalElementString("ram:IssuerAssignedID", tradeLineItem.BuyerOrderReferencedDocument.ID, Profile.Extended);
-                        
+
                         // reference to the order position
                         Writer.WriteOptionalElementString("ram:LineID", tradeLineItem.BuyerOrderReferencedDocument.LineID);
 
@@ -626,7 +625,7 @@ namespace s2industries.ZUGFeRD
                 foreach (AdditionalReferencedDocument document in this.Descriptor.AdditionalReferencedDocuments)
                 {
                     _writeAdditionalReferencedDocument(document, Profile.Comfort | Profile.Extended | Profile.XRechnung); // BG-24         
-				}
+                }
             }
             #endregion
 
@@ -746,17 +745,17 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteElementString("ram:TaxCurrencyCode", this.Descriptor.TaxCurrency.Value.EnumToString(), profile: Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
             }
 
-			//   4. InvoiceCurrencyCode (optional)
-			Writer.WriteElementString("ram:InvoiceCurrencyCode", this.Descriptor.Currency.EnumToString());
+            //   4. InvoiceCurrencyCode (optional)
+            Writer.WriteElementString("ram:InvoiceCurrencyCode", this.Descriptor.Currency.EnumToString());
 
-			//   5. InvoiceIssuerReference (optional)
-			Writer.WriteElementString("ram:InvoiceIssuerReference", this.Descriptor.SellerReferenceNo, profile: Profile.Extended);
+            //   5. InvoiceIssuerReference (optional)
+            Writer.WriteElementString("ram:InvoiceIssuerReference", this.Descriptor.SellerReferenceNo, profile: Profile.Extended);
 
-			//   6. InvoicerTradeParty (optional)
-			_writeOptionalParty(Writer, PartyTypes.InvoicerTradeParty, this.Descriptor.Invoicer);
+            //   6. InvoicerTradeParty (optional)
+            _writeOptionalParty(Writer, PartyTypes.InvoicerTradeParty, this.Descriptor.Invoicer);
 
-			//   7. InvoiceeTradeParty (optional)
-			_writeOptionalParty(Writer, PartyTypes.InvoiceeTradeParty, this.Descriptor.Invoicee);
+            //   7. InvoiceeTradeParty (optional)
+            _writeOptionalParty(Writer, PartyTypes.InvoiceeTradeParty, this.Descriptor.Invoicee);
 
             //   8. PayeeTradeParty (optional)
             _writeOptionalParty(Writer, PartyTypes.PayeeTradeParty, this.Descriptor.Payee);
@@ -937,18 +936,125 @@ namespace s2industries.ZUGFeRD
             }
 
             //  15. SpecifiedTradePaymentTerms (optional)
-            if (this.Descriptor.PaymentTerms != null || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+            //  The cardinality depends on the profile.
+            switch (Descriptor.Profile)
             {
-                Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
-                Writer.WriteOptionalElementString("ram:Description", this.Descriptor.PaymentTerms?.Description);
-                if (this.Descriptor.PaymentTerms?.DueDate.HasValue ?? false)
-                {
-                    Writer.WriteStartElement("ram:DueDateDateTime");
-                    _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(this.Descriptor.PaymentTerms.DueDate.Value));
-                    Writer.WriteEndElement(); // !ram:DueDateDateTime
-                }
-                Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
-                Writer.WriteEndElement();
+                case Profile.Unknown:
+                case Profile.Minimum:
+                    break;
+                case Profile.XRechnung:
+                    if (Descriptor.PaymentTerms.Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    {
+                        Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
+                        var sbPaymentNotes = new StringBuilder();
+                        var setDueDate = true;
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        {
+                            if (paymentTerms.PaymentTermsType.HasValue)
+                            {
+                                sbPaymentNotes.Append($"#{((PaymentTermsType)paymentTerms.PaymentTermsType).AsString<PaymentTermsType>().ToUpper()}");
+                                sbPaymentNotes.Append($"#TAGE={paymentTerms.DueDays}");
+                                sbPaymentNotes.Append($"#PROZENT={_formatDecimal(paymentTerms.Percentage)}");
+                                sbPaymentNotes.Append(paymentTerms.BaseAmount.HasValue ? $"#BASISBETRAG={_formatDecimal(paymentTerms.BaseAmount)}" : "");
+                                sbPaymentNotes.AppendLine("#");
+                            }
+                            else
+                            {
+                                sbPaymentNotes.AppendLine(paymentTerms.Description);
+                            }
+                            if (paymentTerms.DueDate.HasValue && setDueDate)
+                            {
+                                Writer.WriteStartElement("ram:DueDateDateTime");
+                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
+                                Writer.WriteEndElement(); // !ram:DueDateDateTime
+                                setDueDate = false;
+                            }
+                        }
+                        Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
+                        Writer.WriteEndElement();
+                    }
+                    break;
+                case Profile.Extended:
+                    foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                    {
+                        Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
+                        Writer.WriteOptionalElementString("ram:Description", paymentTerms.Description);
+                        if (paymentTerms.DueDate.HasValue)
+                        {
+                            Writer.WriteStartElement("ram:DueDateDateTime");
+                            _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
+                            Writer.WriteEndElement(); // !ram:DueDateDateTime
+                        }
+                        if (paymentTerms.PaymentTermsType.HasValue)
+                        {
+                            if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
+                            {
+                                Writer.WriteStartElement("ram:ApplicableTradePaymentDiscountTerms");
+                                _writeOptionalAmount(Writer, "ram:BasisAmount", paymentTerms.BaseAmount, forceCurrency: true);
+                                Writer.WriteOptionalElementString("ram:CalculationPercent", _formatDecimal(paymentTerms.Percentage));
+                                Writer.WriteEndElement(); // !ram:ApplicableTradePaymentDiscountTerms
+                            }
+                            if (paymentTerms.PaymentTermsType == PaymentTermsType.Verzug)
+                            {
+                                Writer.WriteStartElement("ram:ApplicableTradePaymentPenaltyTerms");
+                                _writeOptionalAmount(Writer, "ram:BasisAmount", paymentTerms.BaseAmount, forceCurrency: true);
+                                Writer.WriteOptionalElementString("ram:CalculationPercent", _formatDecimal(paymentTerms.Percentage));
+                                Writer.WriteEndElement(); // !ram:ApplicableTradePaymentPenaltyTerms
+                            }
+                        }
+                        Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
+                        Writer.WriteEndElement();
+                    }
+                    if (this.Descriptor.PaymentTerms.Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    {
+                        Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
+                        Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
+                        Writer.WriteEndElement();
+                    }
+                    break;
+                default:
+                    if (Descriptor.PaymentTerms.Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    {
+                        Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
+                        var sbPaymentNotes = new StringBuilder();
+                        var setDueDate = true;
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        {
+                            if (paymentTerms.PaymentTermsType.HasValue)
+                            {
+                                if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
+                                {
+                                    Writer.WriteStartElement("ram:ApplicableTradePaymentDiscountTerms");
+                                    _writeOptionalAmount(Writer, "ram:BasisAmount", paymentTerms.BaseAmount, forceCurrency: true);
+                                    Writer.WriteOptionalElementString("ram:CalculationPercent", _formatDecimal(paymentTerms.Percentage));
+                                    Writer.WriteEndElement(); // !ram:ApplicableTradePaymentDiscountTerms
+                                }
+                                if (paymentTerms.PaymentTermsType == PaymentTermsType.Verzug)
+                                {
+                                    Writer.WriteStartElement("ram:ApplicableTradePaymentPenaltyTerms");
+                                    _writeOptionalAmount(Writer, "ram:BasisAmount", paymentTerms.BaseAmount, forceCurrency: true);
+                                    Writer.WriteOptionalElementString("ram:CalculationPercent", _formatDecimal(paymentTerms.Percentage));
+                                    Writer.WriteEndElement(); // !ram:ApplicableTradePaymentPenaltyTerms
+                                }
+                            }
+                            else
+                            {
+                                sbPaymentNotes.AppendLine(paymentTerms.Description);
+                            }
+                            if (paymentTerms.DueDate.HasValue && setDueDate)
+                            {
+                                Writer.WriteStartElement("ram:DueDateDateTime");
+                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
+                                Writer.WriteEndElement(); // !ram:DueDateDateTime
+                                setDueDate = false;
+                            }
+                        }
+                        Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
+                        Writer.WriteEndElement();
+                    }
+                    break;
             }
 
             #region SpecifiedTradeSettlementHeaderMonetarySummation
@@ -1047,43 +1153,43 @@ namespace s2industries.ZUGFeRD
             stream.Seek(streamPosition, SeekOrigin.Begin);
         } // !Save()
 
-		private void _writeAdditionalReferencedDocument(AdditionalReferencedDocument document, Profile profile)
-		{
-			Writer.WriteStartElement("ram:AdditionalReferencedDocument", profile);
-			Writer.WriteElementString("ram:IssuerAssignedID", document.ID);
-			Writer.WriteElementString("ram:TypeCode", document.TypeCode.EnumValueToString());
+        private void _writeAdditionalReferencedDocument(AdditionalReferencedDocument document, Profile profile)
+        {
+            Writer.WriteStartElement("ram:AdditionalReferencedDocument", profile);
+            Writer.WriteElementString("ram:IssuerAssignedID", document.ID);
+            Writer.WriteElementString("ram:TypeCode", document.TypeCode.EnumValueToString());
 
-			if (document.ReferenceTypeCode != ReferenceTypeCodes.Unknown)
-			{
-				Writer.WriteElementString("ram:ReferenceTypeCode", document.ReferenceTypeCode.EnumToString());
-			}
+            if (document.ReferenceTypeCode != ReferenceTypeCodes.Unknown)
+            {
+                Writer.WriteElementString("ram:ReferenceTypeCode", document.ReferenceTypeCode.EnumToString());
+            }
 
-			Writer.WriteOptionalElementString("ram:Name", document.Name);
+            Writer.WriteOptionalElementString("ram:Name", document.Name);
 
-			if (document.AttachmentBinaryObject != null)
-			{
-				Writer.WriteStartElement("ram:AttachmentBinaryObject");
-				Writer.WriteAttributeString("filename", document.Filename); 
-				Writer.WriteAttributeString("mimeCode", MimeTypeMapper.GetMimeType(document.Filename)); 
-				Writer.WriteValue(Convert.ToBase64String(document.AttachmentBinaryObject));
-				Writer.WriteEndElement(); // !AttachmentBinaryObject()
-			}
+            if (document.AttachmentBinaryObject != null)
+            {
+                Writer.WriteStartElement("ram:AttachmentBinaryObject");
+                Writer.WriteAttributeString("filename", document.Filename);
+                Writer.WriteAttributeString("mimeCode", MimeTypeMapper.GetMimeType(document.Filename));
+                Writer.WriteValue(Convert.ToBase64String(document.AttachmentBinaryObject));
+                Writer.WriteEndElement(); // !AttachmentBinaryObject()
+            }
 
-			if (document.IssueDateTime.HasValue)
-			{
-				Writer.WriteStartElement("ram:FormattedIssueDateTime");
-				Writer.WriteStartElement("qdt:DateTimeString");
-				Writer.WriteAttributeString("format", "102");
-				Writer.WriteValue(_formatDate(document.IssueDateTime.Value));
-				Writer.WriteEndElement(); // !qdt:DateTimeString
-				Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
-			}
+            if (document.IssueDateTime.HasValue)
+            {
+                Writer.WriteStartElement("ram:FormattedIssueDateTime");
+                Writer.WriteStartElement("qdt:DateTimeString");
+                Writer.WriteAttributeString("format", "102");
+                Writer.WriteValue(_formatDate(document.IssueDateTime.Value));
+                Writer.WriteEndElement(); // !qdt:DateTimeString
+                Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+            }
 
-			Writer.WriteEndElement(); // !ram:AdditionalReferencedDocument
-		} // !_writeAdditionalReferencedDocument()
+            Writer.WriteEndElement(); // !ram:AdditionalReferencedDocument
+        } // !_writeAdditionalReferencedDocument()
 
 
-		private void _writeOptionalAmount(ProfileAwareXmlTextWriter writer, string tagName, decimal? value, int numDecimals = 2, bool forceCurrency = false, Profile profile = Profile.Unknown)
+        private void _writeOptionalAmount(ProfileAwareXmlTextWriter writer, string tagName, decimal? value, int numDecimals = 2, bool forceCurrency = false, Profile profile = Profile.Unknown)
         {
             if (value.HasValue)
             {
@@ -1184,7 +1290,7 @@ namespace s2industries.ZUGFeRD
                     // all profiles
                     break;
                 case PartyTypes.ShipToTradeParty:
-                    if (this.Descriptor.Profile == Profile.Minimum) { return;  } // it is also possible to add ShipToTradeParty() to a LineItem. In this case, the correct profile filter is different!
+                    if (this.Descriptor.Profile == Profile.Minimum) { return; } // it is also possible to add ShipToTradeParty() to a LineItem. In this case, the correct profile filter is different!
                     break;
                 case PartyTypes.UltimateShipToTradeParty:
                     if ((this.Descriptor.Profile != Profile.Extended) && (this.Descriptor.Profile != Profile.XRechnung1) && (this.Descriptor.Profile != Profile.XRechnung)) { return; } // extended, XRechnung1, XRechnung profile only
@@ -1237,8 +1343,8 @@ namespace s2industries.ZUGFeRD
 
 
                 // filter according to https://github.com/stephanstapel/ZUGFeRD-csharp/pull/221
-                if ((this.Descriptor.Profile == Profile.Minimum && partyType.In(PartyTypes.SellerTradeParty, PartyTypes.PayeeTradeParty,  PartyTypes.BuyerTradeParty)) ||
-                    (this.Descriptor.Profile == Profile.Extended)) /* remaining party types */                    
+                if ((this.Descriptor.Profile == Profile.Minimum && partyType.In(PartyTypes.SellerTradeParty, PartyTypes.PayeeTradeParty, PartyTypes.BuyerTradeParty)) ||
+                    (this.Descriptor.Profile == Profile.Extended)) /* remaining party types */
                 {
                     writer.WriteOptionalElementString("ram:TradingBusinessName", legalOrganization.TradingBusinessName, this.Descriptor.Profile);
                 }
@@ -1380,7 +1486,7 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram:CountryID", party.Country.EnumToString()); // buyer: BT-55
                     writer.WriteOptionalElementString("ram:CountrySubDivisionName", party.CountrySubdivisionName); // BT-79
                     writer.WriteEndElement(); // !PostalTradeAddress
-                }                
+                }
 
                 if (ElectronicAddress != null)
                 {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -943,12 +943,12 @@ namespace s2industries.ZUGFeRD
                 case Profile.Minimum:
                     break;
                 case Profile.XRechnung:
-                    if (Descriptor.PaymentTerms.Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    if (Descriptor.GetTradePaymentTerms().Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
                         DateTime? dueDate = null;
-                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
                             {
@@ -976,7 +976,7 @@ namespace s2industries.ZUGFeRD
                     }
                     break;
                 case Profile.Extended:
-                    foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                    foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         Writer.WriteOptionalElementString("ram:Description", paymentTerms.Description);
@@ -1006,7 +1006,7 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }
-                    if (this.Descriptor.PaymentTerms.Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    if (this.Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
@@ -1014,12 +1014,12 @@ namespace s2industries.ZUGFeRD
                     }
                     break;
                 default:
-                    if (Descriptor.PaymentTerms.Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
+                    if (Descriptor.GetTradePaymentTerms().Count > 0 || !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
                         DateTime? dueDate = null;
-                        foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
+                        foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
                             {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -947,7 +947,7 @@ namespace s2industries.ZUGFeRD
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
-                        var setDueDate = true;
+                        DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
@@ -962,15 +962,15 @@ namespace s2industries.ZUGFeRD
                             {
                                 sbPaymentNotes.AppendLine(paymentTerms.Description);
                             }
-                            if (paymentTerms.DueDate.HasValue && setDueDate)
-                            {
-                                Writer.WriteStartElement("ram:DueDateDateTime");
-                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
-                                Writer.WriteEndElement(); // !ram:DueDateDateTime
-                                setDueDate = false;
-                            }
+                            dueDate = dueDate ?? paymentTerms.DueDate;
                         }
                         Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        if (dueDate.HasValue)
+                        {
+                            Writer.WriteStartElement("ram:DueDateDateTime");
+                            _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(dueDate.Value));
+                            Writer.WriteEndElement(); // !ram:DueDateDateTime
+                        }
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }
@@ -1018,7 +1018,7 @@ namespace s2industries.ZUGFeRD
                     {
                         Writer.WriteStartElement("ram:SpecifiedTradePaymentTerms");
                         var sbPaymentNotes = new StringBuilder();
-                        var setDueDate = true;
+                        DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this.Descriptor.PaymentTerms)
                         {
                             if (paymentTerms.PaymentTermsType.HasValue)
@@ -1042,15 +1042,15 @@ namespace s2industries.ZUGFeRD
                             {
                                 sbPaymentNotes.AppendLine(paymentTerms.Description);
                             }
-                            if (paymentTerms.DueDate.HasValue && setDueDate)
-                            {
-                                Writer.WriteStartElement("ram:DueDateDateTime");
-                                _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
-                                Writer.WriteEndElement(); // !ram:DueDateDateTime
-                                setDueDate = false;
-                            }
+                            dueDate = dueDate ?? paymentTerms.DueDate;
                         }
                         Writer.WriteOptionalElementString("ram:Description", sbPaymentNotes.ToString().TrimEnd());
+                        if (dueDate.HasValue)
+                        {
+                            Writer.WriteStartElement("ram:DueDateDateTime");
+                            _writeElementWithAttribute(Writer, "udt:DateTimeString", "format", "102", _formatDate(dueDate.Value));
+                            Writer.WriteEndElement(); // !ram:DueDateDateTime
+                        }
                         Writer.WriteOptionalElementString("ram:DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }

--- a/ZUGFeRD/PaymentTerms.cs
+++ b/ZUGFeRD/PaymentTerms.cs
@@ -17,15 +17,14 @@
  * under the License.
  */
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 
 namespace s2industries.ZUGFeRD
 {
     /// <summary>
     /// Condition that surrounds the payment part of an invoice, describing the specific details and the due date of the invoice.
     /// </summary>
+    [DebuggerDisplay("{Description} - {DueDate,nq}")]
     public class PaymentTerms
     {
         /// <summary>
@@ -37,5 +36,25 @@ namespace s2industries.ZUGFeRD
         /// The date when the payment is due
         /// </summary>
         public DateTime? DueDate { get; set; } = null;
+
+        /// <summary>
+        /// Type whether it's a discount or a surcharge / interest
+        /// </summary>
+        public virtual PaymentTermsType? PaymentTermsType { get; set; }
+
+        /// <summary>
+        /// Number of days within terms are valid
+        /// </summary>
+        public virtual int? DueDays { get; set; }
+
+        /// <summary>
+        /// Percentage of discount or surcharge
+        /// </summary>
+        public virtual decimal? Percentage { get; set; }
+
+        /// <summary>
+        /// Base amount applied to percentage of discount or surcharge
+        /// </summary>
+        public virtual decimal? BaseAmount { get; set; }
     }
 }

--- a/ZUGFeRD/PaymentTermsType.cs
+++ b/ZUGFeRD/PaymentTermsType.cs
@@ -1,0 +1,36 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace s2industries.ZUGFeRD
+{
+    /// <summary>
+    /// Are there discounts or surcharges for an invoice.
+    /// </summary>
+    public enum PaymentTermsType
+    {
+        /// <summary>
+        /// Discount indicator
+        /// </summary>
+        Skonto,
+        /// <summary>
+        /// Surcharge indicator
+        /// </summary>
+        Verzug
+    }
+}


### PR DESCRIPTION
Following the conversation in issue #223, I modified the `PaymentTerms` from single type to List<>. 
Minor, necessary changes have been made to a few tests accessing the previous `PaymentTerms` property directly.

## Added
- method `InvoiceDescriptor.AddTradePaymentTerms`
- method `InvoiceDescriptor.GetTradePaymentTerms`
- enum `PaymentTermsType` to specify discount or surcharge
- tests to check cardinality and Profile
- `DebuggerMessageAttribute` to improve readability while coding

## Changed 
- method `InvoiceDescriptor.SetTradePaymentTerms` to re-set and initialise the `PaymentTerms` property.
- Writers/readers

During the conversation it turned out that the cardinality of `SpecifiedTradePaymentTerms` as well as its properties depend mainly on the `ZUGFeRD.Profile` classification. The Writer/Reader types have been amended / extended accordingly given best knowledge of the specifications.