### PR TITLE
fix wrong format UnitQuantity in TradeLineItem

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -407,7 +407,7 @@ namespace s2industries.ZUGFeRD
 
                 Writer.WriteStartElement("cbc:BaseQuantity"); // BT-149
                 Writer.WriteAttributeString("unitCode", tradeLineItem.UnitCode.EnumToString()); // BT-150
-                Writer.WriteValue(tradeLineItem.UnitQuantity.ToString());
+                Writer.WriteValue(_formatDecimal(tradeLineItem.UnitQuantity));
                 Writer.WriteEndElement();
 
                 IList<TradeAllowanceCharge> charges = tradeLineItem.GetTradeAllowanceCharges();


### PR DESCRIPTION
the ouput of UnitQuantity was localized.