### PR TITLE
Added SellerOrderReferencedDocument

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -20,7 +20,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -95,6 +94,7 @@ namespace s2industries.ZUGFeRD
             // OrderReference
             Writer.WriteStartElement("cac:OrderReference");
             Writer.WriteElementString("cbc:ID", this.Descriptor.OrderNo);
+            Writer.WriteOptionalElementString("cbc:SalesOrderID", this.Descriptor.SellerOrderReferencedDocument?.ID);
             Writer.WriteEndElement(); // !OrderReference
 
             // BillingReference

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Xml;
 


### PR DESCRIPTION
http://www.datypic.com/sc/ubl20/e-cbc_SalesOrderID.html has an example at the bottom, showing this just as the ID-string. In https://www.deutschebahn.com/resource/blob/6892390/6f5d494886eedb0707fedbbe2b409fe6/XML-Xrechnung-data.pdf this is just a string, too.

What could be taken into consideration: https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-OrderReference/cbc-SalesOrderID/ 

Saying that the OrderReference ID should be set to "NA" if not available and not leave it empty, if a SalesOrderID is given.