### PR TITLE
Avoid Exception in InvoiceDescriptor22UBLWriter, satisfy validators for XRechnung with charges or allowances

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -599,7 +599,7 @@ namespace s2industries.ZUGFeRD
                     writer.WriteEndElement();
                 }
 
-                if (this.Descriptor.PaymentMeans.SEPAMandateReference != null)
+                if (this.Descriptor.PaymentMeans?.SEPAMandateReference != null)
                 {
                     writer.WriteStartElement("cac:PartyIdentification");
                     writer.WriteStartElement("cbc:ID");

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -431,11 +431,11 @@ namespace s2industries.ZUGFeRD
 
                 #region SpecifiedTradeAllowanceCharge (Basic, Comfort, Extended)
                 //Abschläge auf Ebene der Rechnungsposition (Basic, Comfort, Extended)
-                if (new Profile[] { Profile.Basic, Profile.Comfort, Profile.Extended }.Contains(descriptor.Profile))
+                if (new Profile[] { Profile.Basic, Profile.Comfort, Profile.Extended, Profile.XRechnung }.Contains(descriptor.Profile))
                 {
                     if (tradeLineItem.GetSpecifiedTradeAllowanceCharges().Count > 0)
                     {
-                        Writer.WriteStartElement("ram:SpecifiedTradeAllowanceCharge", Profile.Basic | Profile.Comfort | Profile.Extended);
+                        Writer.WriteStartElement("ram:SpecifiedTradeAllowanceCharge", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung);
 
                         foreach (TradeAllowanceCharge specifiedTradeAllowanceCharge in tradeLineItem.GetSpecifiedTradeAllowanceCharges()) // BT-147
                         {


### PR DESCRIPTION
- The ZUGFeRD/InvoiceDescriptor22UBLWriter.cs class crashes if there are no payment means set. Despite the result being unable to validate, the writer should not throw an exception here.
- The ZUGFeRD/InvoiceDescriptor23CIIWriter.cs does not create valid XRechnung output if there are charges or allowances. I think the conditions missed the XRechnung profile item.