### PR TITLE
Fix X-Rechnung

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -89,7 +89,7 @@ namespace s2industries.ZUGFeRD
             #endregion
 
 
-            Writer.WriteElementString("cbc", "CustomizationID", "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_3.0");
+            Writer.WriteElementString("cbc", "CustomizationID", "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0");
             Writer.WriteElementString("cbc", "ProfileID", "urn:fdc:peppol.eu:2017:poacc:billing:01:1.0");
 
             Writer.WriteElementString("cbc", "ID", this.Descriptor.InvoiceNo); //Rechnungsnummer

--- a/ZUGFeRD/Tax.cs
+++ b/ZUGFeRD/Tax.cs
@@ -28,6 +28,7 @@ namespace s2industries.ZUGFeRD
     /// </summary>
     public class Tax
     {
+        private decimal taxAmount;
         /// <summary>
         /// Returns the amount of the tax (Percent * BasisAmount)
         /// 
@@ -37,8 +38,9 @@ namespace s2industries.ZUGFeRD
         {
             get
             {
-                return System.Math.Round(0.01m * this.Percent * this.BasisAmount, 2, MidpointRounding.AwayFromZero);
+                return taxAmount == 0 ? System.Math.Round(0.01m * this.Percent * this.BasisAmount, 2, MidpointRounding.AwayFromZero) : taxAmount;
             }
+            set { taxAmount = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
1.  fix localized UnitQuantity in tradeLineItem
2. write missing party name to the party (seller and buyer)
3. set precalculated tax amount instead always calculate it to avoid rounding problems
4. write orderreference only if not empty