### PR TITLE
Fixed bugs in 23CIIReader and 22UblReader related to LineId and BuyerOrderReference

### DIFF
--- a/ZUGFeRD-Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD-Test/XRechnungUBLTests.cs
@@ -453,5 +453,18 @@ namespace ZUGFeRD_Test
             // Assert that we entered and exited the <cbc:Note> block
             Assert.IsFalse(insideCbcNote, "We should have exited the <cbc:Note> block.");
         } // !TestMultiSkontoForCorrectIndention()
-    }
+
+		[TestMethod]
+		public void TestBuyerOrderReferenceLineId()
+		{
+			string path = @"..\..\..\..\demodata\xRechnung\xRechnung with LineId.xml";
+			path = _makeSurePathIsCrossPlatformCompatible(path);
+
+			Stream s = File.Open(path, FileMode.Open);
+			InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+			s.Close();
+
+			Assert.AreEqual(desc.TradeLineItems[0].BuyerOrderReferencedDocument.LineID, "6171175.1");
+		}
+	}
 }

--- a/ZUGFeRD-Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD-Test/ZUGFeRD22Tests.cs
@@ -2653,5 +2653,19 @@ namespace ZUGFeRD_Test
             //Assert.AreEqual(10, paymentTerm.DueDays);
             //Assert.AreEqual(3m, paymentTerm.Percentage);
         } // !TestPaymentTermsSingleCardinalityStructured()
+
+        [TestMethod]
+        public void TestBuyerOrderReferenceLineId()
+        {
+			string path = @"..\..\..\..\demodata\zugferd22\zugferd_2p2_EXTENDED_Fremdwaehrung-factur-x.xml";
+			path = _makeSurePathIsCrossPlatformCompatible(path);
+
+			Stream s = File.Open(path, FileMode.Open);
+			InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
+			s.Close();
+
+			Assert.AreEqual(desc.TradeLineItems[0].BuyerOrderReferencedDocument.LineID, "1");
+			Assert.AreEqual(desc.TradeLineItems[0].BuyerOrderReferencedDocument.ID, "ORDER84359");
+		}
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -502,61 +502,63 @@ namespace s2industries.ZUGFeRD
                 }
             }
 
-            //Read IncludedReferencedProducts
-            //TODO:
+			// Read BuyerOrderReferencedDocument
+			if (tradeLineItem.SelectSingleNode("cac:OrderLineReference", nsmgr) != null)
+			{
+				item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
+				{
+					ID = XmlUtils.NodeAsString(tradeLineItem, ".//cbc:IssuerAssignedID", nsmgr),
+					IssueDateTime = XmlUtils.NodeAsDateTime(tradeLineItem, ".//cac:FormattedIssueDateTime/cbc:DateTimeString", nsmgr),
+					LineID = XmlUtils.NodeAsString(tradeLineItem, ".//cbc:LineID", nsmgr),
+				};
+			}
 
-            // TODO: Find value //if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument", nsmgr) != null)
-            //{
-            //  item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
-            //  {
-            //    ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
-            //    IssueDateTime = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr)
-            //  };
-            //}
+			//Read IncludedReferencedProducts
+			//TODO:
 
-            // TODO: Find value //if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument", nsmgr) != null)
-            //{
-            //  item.ContractReferencedDocument = new ContractReferencedDocument()
-            //  {
-            //    ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
-            //    IssueDateTime = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr)
-            //  };
-            //}
+			// TODO: Find value //if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument", nsmgr) != null)
+			//{
+			//  item.ContractReferencedDocument = new ContractReferencedDocument()
+			//  {
+			//    ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
+			//    IssueDateTime = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr)
+			//  };
+			//}
 
-            // TODO: Find value //if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeSettlement", nsmgr) != null)
-            //{
-            //  XmlNodeList LineTradeSettlementNodes = tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeSettlement", nsmgr).ChildNodes;
-            //  foreach (XmlNode LineTradeSettlementNode in LineTradeSettlementNodes)
-            //  {
-            //    switch (LineTradeSettlementNode.Name)
-            //    {
-            //      case "ram:ApplicableTradeTax":
-            //        //TODO
-            //        break;
-            //      case "ram:BillingSpecifiedPeriod":
-            //        //TODO
-            //        break;
-            //      case "ram:SpecifiedTradeAllowanceCharge":
-            //        //TODO
-            //        break;
-            //      case "ram:SpecifiedTradeSettlementLineMonetarySummation":
-            //        //TODO
-            //        break;
-            //      case "ram:AdditionalReferencedDocument":
-            //        //TODO
-            //        break;
-            //      case "ram:ReceivableSpecifiedTradeAccountingAccount":
-            //        // TODO: Find value //item.ReceivableSpecifiedTradeAccountingAccounts.Add(new ReceivableSpecifiedTradeAccountingAccount()
-            //        //{
-            //        //  TradeAccountID = XmlUtils.NodeAsString(LineTradeSettlementNode, "./ram:ID", nsmgr),
-            //        //  TradeAccountTypeCode = (AccountingAccountTypeCodes)_nodeAsInt(LineTradeSettlementNode, ".//ram:TypeCode", nsmgr)
-            //        //});
-            //        break;
-            //    }
-            //  }
-            //}            
+			// TODO: Find value //if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeSettlement", nsmgr) != null)
+			//{
+			//  XmlNodeList LineTradeSettlementNodes = tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeSettlement", nsmgr).ChildNodes;
+			//  foreach (XmlNode LineTradeSettlementNode in LineTradeSettlementNodes)
+			//  {
+			//    switch (LineTradeSettlementNode.Name)
+			//    {
+			//      case "ram:ApplicableTradeTax":
+			//        //TODO
+			//        break;
+			//      case "ram:BillingSpecifiedPeriod":
+			//        //TODO
+			//        break;
+			//      case "ram:SpecifiedTradeAllowanceCharge":
+			//        //TODO
+			//        break;
+			//      case "ram:SpecifiedTradeSettlementLineMonetarySummation":
+			//        //TODO
+			//        break;
+			//      case "ram:AdditionalReferencedDocument":
+			//        //TODO
+			//        break;
+			//      case "ram:ReceivableSpecifiedTradeAccountingAccount":
+			//        // TODO: Find value //item.ReceivableSpecifiedTradeAccountingAccounts.Add(new ReceivableSpecifiedTradeAccountingAccount()
+			//        //{
+			//        //  TradeAccountID = XmlUtils.NodeAsString(LineTradeSettlementNode, "./ram:ID", nsmgr),
+			//        //  TradeAccountTypeCode = (AccountingAccountTypeCodes)_nodeAsInt(LineTradeSettlementNode, ".//ram:TypeCode", nsmgr)
+			//        //});
+			//        break;
+			//    }
+			//  }
+			//}            
 
-            XmlNodeList noteNodes = tradeLineItem.SelectNodes(".//cbc:Note", nsmgr);
+			XmlNodeList noteNodes = tradeLineItem.SelectNodes(".//cbc:Note", nsmgr);
             foreach (XmlNode noteNode in noteNodes)
             {
                 item.AssociatedDocument.Notes.Add(new Note(

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -504,17 +504,17 @@ namespace s2industries.ZUGFeRD
                 }); 
             }
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument", nsmgr) != null)
-            {
-                item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
-                {
-                    ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(tradeLineItem, "//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime", nsmgr),
-                    LineID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID", nsmgr)
-                };
-            }
+			if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument", nsmgr) != null)
+			{
+				item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
+				{
+					ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
+					IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(tradeLineItem, "//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime", nsmgr),
+					LineID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:BuyerOrderReferencedDocument/ram:LineID", nsmgr)
+				};
+			}
 
-            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument", nsmgr) != null)
+			if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument", nsmgr) != null)
             {
                 item.ContractReferencedDocument = new ContractReferencedDocument()
                 {

--- a/demodata/xRechnung/xRechnung with LineId.xml
+++ b/demodata/xRechnung/xRechnung with LineId.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ubl:Invoice xmlns:ubl="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+             xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+             xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+    <cbc:ID>123456XX</cbc:ID>
+    <cbc:IssueDate>2016-04-04</cbc:IssueDate>
+    <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+    <cbc:Note>#ADU#Es gelten unsere Allgem. Geschäftsbedingungen, die Sie unter […] finden.</cbc:Note>
+    <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+    <cbc:BuyerReference>04011000-12345-03</cbc:BuyerReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="EM">seller@email.de</cbc:EndpointID>
+            <cac:PartyName>
+                <cbc:Name>[Seller trading name]</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:StreetName>[Seller address line 1]</cbc:StreetName>
+                <cbc:CityName>[Seller city]</cbc:CityName>
+                <cbc:PostalZone>12345</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>DE 123456789</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>[Seller name]</cbc:RegistrationName>
+                <cbc:CompanyID>[HRA-Eintrag]</cbc:CompanyID>
+                <cbc:CompanyLegalForm>123/456/7890, HRA-Eintrag in […]</cbc:CompanyLegalForm>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:Name>nicht vorhanden</cbc:Name>
+                <cbc:Telephone>+49 1234-5678</cbc:Telephone>
+                <cbc:ElectronicMail>seller@email.de</cbc:ElectronicMail>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="EM">buyer@info.de</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID>[Buyer identifier]</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:StreetName>[Buyer address line 1]</cbc:StreetName>
+                <cbc:CityName>[Buyer city]</cbc:CityName>
+                <cbc:PostalZone>12345</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>DE</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>[Buyer name]</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode>58</cbc:PaymentMeansCode>
+        <cac:PayeeFinancialAccount>
+            <!-- dies ist eine nicht existerende aber valide IBAN als test dummy -->
+            <cbc:ID>DE75512108001245126199</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    <cac:PaymentTerms>
+        <cbc:Note>Zahlbar sofort ohne Abzug.</cbc:Note>
+    </cac:PaymentTerms>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="EUR">22.04</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="EUR">314.86</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="EUR">22.04</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>7</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="EUR">314.86</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="EUR">314.86</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="EUR">336.9</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="EUR">336.9</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>Zeitschrift [...]</cbc:ID>
+        <cbc:Note>Die letzte Lieferung im Rahmen des abgerechneten Abonnements erfolgt in 12/2016 Lieferung erfolgt / erfolgte direkt vom Verlag</cbc:Note>
+        <cbc:InvoicedQuantity unitCode="XPP">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">288.79</cbc:LineExtensionAmount>
+        <cac:InvoicePeriod>
+            <cbc:StartDate>2016-01-01</cbc:StartDate>
+            <cbc:EndDate>2016-12-31</cbc:EndDate>
+        </cac:InvoicePeriod>
+        <cac:OrderLineReference>
+            <cbc:LineID>6171175.1</cbc:LineID>
+        </cac:OrderLineReference>
+        <cac:Item>
+            <cbc:Description>Zeitschrift Inland</cbc:Description>
+            <cbc:Name>Zeitschrift [...]</cbc:Name>
+            <cac:SellersItemIdentification>
+                <cbc:ID>246</cbc:ID>
+            </cac:SellersItemIdentification>
+            <cac:CommodityClassification>
+                <cbc:ItemClassificationCode listID="IB">0721-880X</cbc:ItemClassificationCode>
+            </cac:CommodityClassification>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>7</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">288.79</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>Porto + Versandkosten</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="XPP">1</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="EUR">26.07</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>Porto + Versandkosten</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID>S</cbc:ID>
+                <cbc:Percent>7</cbc:Percent>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="EUR">26.07</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</ubl:Invoice>

--- a/demodata/zugferd22/zugferd_2p2_EXTENDED_Fremdwaehrung-factur-x.xml
+++ b/demodata/zugferd22/zugferd_2p2_EXTENDED_Fremdwaehrung-factur-x.xml
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- English disclaimer below.-->
+<!--Nutzungsrechte 
+ZUGFeRD Datenformat Version 2.2.0, 14.02.2022
+Beispiel Version 14.02.2022
+ 
+Zweck des Forums elektronisch Rechnung Deutschland, welches am 31. März 2010 unter der Arbeitsgemeinschaft für 
+wirtschaftliche Verwaltung e. V. gegründet wurde, ist u. a. die Schaffung und Spezifizierung eines offenen Datenformats 
+für strukturierten elektronischen Datenaustausch auf der Grundlage offener und nicht diskriminierender, standardisierter 
+Technologien („ZUGFeRD Datenformat“).
+ 
+Das ZUGFeRD Datenformat wird nach Maßgabe des FeRD sowohl Unternehmen als auch der öffentlichen Verwaltung 
+frei zugänglich gemacht. Hierfür bietet FeRD allen Unternehmen und Organisationen der öffentlichen Verwaltung eine 
+Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD-Datenformats zu fairen, sachgerechten und nicht 
+diskriminierenden Bedingungen an.
+ 
+Die Spezifikation des FeRD zur Implementierung des ZUGFeRD Datenformats ist in ihrer jeweils geltenden Fassung 
+abrufbar unter www.ferd-net.de.
+ 
+Im Einzelnen schließt die Nutzungsgewährung ein: 
+=====================================
+ 
+FeRD räumt eine Lizenz für die Nutzung des urheberrechtlich geschützten ZUGFeRD Datenformats in der jeweils 
+geltenden und akzeptierten Fassung (www.ferd-net.de) ein. 
+Die Lizenz beinhaltet ein unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, 
+Weiterbearbeitung und Verbindung mit anderen Produkten.
+Die Lizenz gilt insbesondere für die Entwicklung, die Gestaltung, die Herstellung, den Verkauf, die Nutzung oder 
+anderweitige Verwendung des ZUGFeRD Datenformats für Hardware- und/oder Softwareprodukte sowie sonstige 
+Anwendungen und Dienste. 
+Diese Lizenz schließt nicht die wesentlichen Patente der Mitglieder von FeRD ein. Als wesentliche Patente sind Patente 
+und Patentanmeldungen weltweit zu verstehen, die einen oder mehrere Patentansprüche beinhalten, bei denen es sich um 
+notwendige Ansprüche handelt. Notwendige Ansprüche sind lediglich jene Ansprüche der Wesentlichen Patente, die durch 
+die Implementierung des ZUGFeRD Datenformats notwendigerweise verletzt würden. 
+Der Lizenznehmer ist berechtigt, seinen jeweiligen Konzerngesellschaften ein unbefristetes, weltweites, nicht übertragbares, 
+unwiderrufliches Nutzungsrecht einschließlich des Rechts der Weiterentwicklung, Weiterbearbeitung und Verbindung mit 
+anderen Produkten einzuräumen. 
+ 
+Die Lizenz wird kostenfrei zur Verfügung gestellt. 
+ 
+Außer im Falle vorsätzlichen Verschuldens oder grober Fahrlässigkeit haftet FeRD weder für Nutzungsausfall, entgangenen 
+Gewinn, Datenverlust, Kommunikationsverlust, Einnahmeausfall, Vertragseinbußen, Geschäftsausfall oder für Kosten, 
+Schäden, Verluste oder Haftpflichten im Zusammenhang mit einer Unterbrechung der Geschäftstätigkeit, noch für konkrete, 
+beiläufig entstandene, mittelbare Schäden, Straf- oder Folgeschäden und zwar auch dann nicht, wenn die Möglichkeit der 
+Kosten, Verluste bzw. Schäden hätte normalerweise vorhergesehen werden können.-->
+ 
+ <!--Right of use 
+ZUGFeRD Data format version 2.2.0, February 14th, 2022
+ 
+The purpose of the Forum elektronische Rechnung Deutschland (FeRD), which was founded on March 31, 2010 under the 
+umbrella of Arbeitsgemeinschaft für wirtschaftliche Verwaltung e. V., is, among other things, to create and specify an 
+open data format for structured electronic data exchange on the basis of open and non discriminatory, standardised 
+technologies ("ZUGFeRD data format").
+ 
+The ZUGFeRD data format is used by both companies and public administration according to the FeRD 
+made freely accessible. For this purpose FeRD offers all companies and organisations of the public administration a 
+License to use the copyrighted ZUGFeRD data format in a fair, appropriate and non 
+discriminatory conditions.
+ 
+The specification of the FeRD for the implementation of the ZUGFeRD data format is, in its currently valid version 
+available at www.ferd-net.de.
+ 
+In detail, the grant of use includes 
+=====================================
+ 
+FeRD grants a license for the use of the copyrighted ZUGFeRD data format in the respective 
+valid and accepted version (www.ferd-net.de). 
+The license includes an irrevocable right of use including the right of further development, 
+Further processing and connection with other products.
+The license applies in particular to the development, design, production, sale, use or 
+other use of the ZUGFeRD data format for hardware and/or software products and other 
+applications and services. 
+This license does not include the essential patents of the members of FeRD. The essential patents are patents 
+and patent applications worldwide which contain one or more claims that are 
+necessary claims. Necessary claims are only those claims of the essential patents which are 
+the implementation of the ZUGFeRD data format would necessarily be violated. 
+The Licensee is entitled to provide its respective group companies with an unlimited, worldwide, non-transferable, 
+irrevocable right of use including the right of further development, further processing and connection with 
+other products. 
+ 
+The license is provided free of charge. 
+ 
+Except in the case of intentional fault or gross negligence, FeRD is not liable for loss of use, loss of 
+Profit, loss of data, loss of communication, loss of revenue, loss of contracts, loss of business or for costs 
+damages, losses or liabilities in connection with an interruption of business, nor for concrete, 
+incidental, indirect, punitive or consequential damages, even if the possibility of 
+costs, losses or damages could normally have been foreseen.-->
+
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+	<rsm:ExchangedDocumentContext>
+		<ram:BusinessProcessSpecifiedDocumentContextParameter>
+			<ram:ID>Beispielgeschäftsprozess</ram:ID>
+		</ram:BusinessProcessSpecifiedDocumentContextParameter>
+		<ram:GuidelineSpecifiedDocumentContextParameter>
+			<ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
+		</ram:GuidelineSpecifiedDocumentContextParameter>
+	</rsm:ExchangedDocumentContext>
+	<rsm:ExchangedDocument>
+		<ram:ID>47110815</ram:ID>
+		<ram:Name>RECHNUNG</ram:Name>
+		<ram:TypeCode>380</ram:TypeCode>
+		<ram:IssueDateTime>
+			<udt:DateTimeString format="102">20181031</udt:DateTimeString>
+		</ram:IssueDateTime>
+		<ram:IncludedNote>
+			<ram:Content>Mitglieder der Geschäftsleitung
+H. Meier Geschäftsführer
+T. Müller Prokurist
+HRB Braunschweig 12345</ram:Content>
+			<ram:SubjectCode>REG</ram:SubjectCode>
+		</ram:IncludedNote>
+		<ram:IncludedNote>
+			<ram:Content>Vom 17. Dezember 2018 bis 6. Januar 2019 haben wir Betriebsferien.</ram:Content>
+			<ram:SubjectCode>AAI</ram:SubjectCode>
+		</ram:IncludedNote>
+		<ram:IncludedNote>
+			<ram:Content>Aus konzern-internen Gründen wird der Steuerbetrag sowohl in der Rechungswährung (EUR) als auch in der Buchwährung (GBP) ausgegeben.</ram:Content>
+			<ram:SubjectCode>TXD</ram:SubjectCode>
+		</ram:IncludedNote>
+	</rsm:ExchangedDocument>
+	<rsm:SupplyChainTradeTransaction>
+		<ram:IncludedSupplyChainTradeLineItem>
+			<ram:AssociatedDocumentLineDocument>
+				<ram:LineID>1</ram:LineID>
+				<ram:IncludedNote>
+					<ram:Content>Materialzertifikat X-234 gem ISO XYZ.
+Ware bleibt bis zur vollständigen Bezahlung unser Eigentum.
+					</ram:Content>
+				</ram:IncludedNote>
+			</ram:AssociatedDocumentLineDocument>
+			<ram:SpecifiedTradeProduct>
+				<ram:SellerAssignedID>CO-123/V2A</ram:SellerAssignedID>
+				<ram:BuyerAssignedID>Toolbox 0815</ram:BuyerAssignedID>
+				<ram:Name>Stahlcoil</ram:Name>
+				<ram:OriginTradeCountry>
+					<ram:ID>DE</ram:ID>
+				</ram:OriginTradeCountry>
+			</ram:SpecifiedTradeProduct>
+			<ram:SpecifiedLineTradeAgreement>
+				<ram:BuyerOrderReferencedDocument>
+					<ram:IssuerAssignedID>ORDER84359</ram:IssuerAssignedID>
+					<ram:LineID>1</ram:LineID>
+				</ram:BuyerOrderReferencedDocument>
+				<ram:GrossPriceProductTradePrice>
+					<ram:ChargeAmount>100.00</ram:ChargeAmount>
+					<ram:BasisQuantity unitCode="H87">1</ram:BasisQuantity>
+				</ram:GrossPriceProductTradePrice>
+				<ram:NetPriceProductTradePrice>
+					<ram:ChargeAmount>100</ram:ChargeAmount>
+					<ram:BasisQuantity unitCode="H87">1</ram:BasisQuantity>
+				</ram:NetPriceProductTradePrice>
+			</ram:SpecifiedLineTradeAgreement>
+			<ram:SpecifiedLineTradeDelivery>
+				<ram:BilledQuantity unitCode="H87">10</ram:BilledQuantity>
+			</ram:SpecifiedLineTradeDelivery>
+			<ram:SpecifiedLineTradeSettlement>
+				<ram:ApplicableTradeTax>
+					<ram:TypeCode>VAT</ram:TypeCode>
+					<ram:CategoryCode>S</ram:CategoryCode>
+					<ram:RateApplicablePercent>19</ram:RateApplicablePercent>
+				</ram:ApplicableTradeTax>
+				<ram:SpecifiedTradeAllowanceCharge>
+					<ram:ChargeIndicator>
+						<udt:Indicator>false</udt:Indicator>
+					</ram:ChargeIndicator>
+					<ram:CalculationPercent>10</ram:CalculationPercent>
+					<ram:BasisAmount>1000</ram:BasisAmount>
+					<ram:ActualAmount>100</ram:ActualAmount>
+					<ram:ReasonCode>CAO</ram:ReasonCode>
+					<ram:Reason>Lagerware</ram:Reason>
+				</ram:SpecifiedTradeAllowanceCharge>
+				<ram:SpecifiedTradeAllowanceCharge>
+					<ram:ChargeIndicator>
+						<udt:Indicator>false</udt:Indicator>
+					</ram:ChargeIndicator>
+					<ram:BasisAmount>1000</ram:BasisAmount>
+					<ram:ActualAmount>50</ram:ActualAmount>
+					<ram:ReasonCode>ADZ</ram:ReasonCode>
+					<ram:Reason>Direktbelieferung</ram:Reason>
+				</ram:SpecifiedTradeAllowanceCharge>
+				<ram:SpecifiedTradeSettlementLineMonetarySummation>
+					<ram:LineTotalAmount>850</ram:LineTotalAmount>
+				</ram:SpecifiedTradeSettlementLineMonetarySummation>
+			</ram:SpecifiedLineTradeSettlement>
+		</ram:IncludedSupplyChainTradeLineItem>
+		<ram:ApplicableHeaderTradeAgreement>
+			<ram:SellerTradeParty>
+				<ram:ID>12345676</ram:ID>
+				<ram:Name>Rohstoff AG Salzgitter</ram:Name>
+				<ram:PostalTradeAddress>
+					<ram:PostcodeCode>38226</ram:PostcodeCode>
+					<ram:LineOne>Marktstr. 153</ram:LineOne>
+					<ram:CityName>Salzgitter</ram:CityName>
+					<ram:CountryID>DE</ram:CountryID>
+				</ram:PostalTradeAddress>
+				<ram:SpecifiedTaxRegistration>
+					<ram:ID schemeID="VA">DE123456789</ram:ID>
+				</ram:SpecifiedTaxRegistration>
+			</ram:SellerTradeParty>
+			<ram:BuyerTradeParty>
+				<ram:ID>75969813</ram:ID>
+				<ram:Name>Metallbau Leipzig GmbH &amp; Co. KG</ram:Name>
+				<ram:PostalTradeAddress>
+					<ram:PostcodeCode>12345</ram:PostcodeCode>
+					<ram:LineOne>Pappelallee 15</ram:LineOne>
+					<ram:LineTwo>Hof 3</ram:LineTwo>
+					<ram:CityName>Leipzig</ram:CityName>
+					<ram:CountryID>DE</ram:CountryID>
+				</ram:PostalTradeAddress>
+				<ram:URIUniversalCommunication>
+					<ram:URIID schemeID="9958">04 0 11 000 - 12345 12345 - 35</ram:URIID>
+				</ram:URIUniversalCommunication>
+			</ram:BuyerTradeParty>
+			<ram:SellerTaxRepresentativeTradeParty>
+				<ram:Name>Global Supplies Financial Services</ram:Name>
+				<ram:PostalTradeAddress>
+					<ram:PostcodeCode>12345</ram:PostcodeCode>
+					<ram:LineOne>Friedrichstraße 165</ram:LineOne>
+					<ram:CityName>Berlin</ram:CityName>
+					<ram:CountryID>DE</ram:CountryID>
+				</ram:PostalTradeAddress>
+				<ram:SpecifiedTaxRegistration>
+					<ram:ID schemeID="VA">DE1334567</ram:ID>
+				</ram:SpecifiedTaxRegistration>
+			</ram:SellerTaxRepresentativeTradeParty>
+		</ram:ApplicableHeaderTradeAgreement>
+		<ram:ApplicableHeaderTradeDelivery>
+			<ram:ShipToTradeParty>
+				<ram:ID>75969815</ram:ID>
+				<ram:Name>Metallbau Leipzig GmbH &amp; Co. KG</ram:Name>
+				<ram:PostalTradeAddress>
+					<ram:PostcodeCode>12347</ram:PostcodeCode>
+					<ram:LineOne>Eichenpromenade 37</ram:LineOne>
+					<ram:LineTwo>Tor 1</ram:LineTwo>
+					<ram:CityName>Metallstadt</ram:CityName>
+					<ram:CountryID>DE</ram:CountryID>
+				</ram:PostalTradeAddress>
+				<ram:URIUniversalCommunication>
+					<ram:URIID schemeID="0060">999999999</ram:URIID>
+				</ram:URIUniversalCommunication>
+			</ram:ShipToTradeParty>
+		</ram:ApplicableHeaderTradeDelivery>
+		<ram:ApplicableHeaderTradeSettlement>
+			<ram:TaxCurrencyCode>EUR</ram:TaxCurrencyCode>
+			<ram:InvoiceCurrencyCode>GBP</ram:InvoiceCurrencyCode>
+			<ram:PayeeTradeParty>
+				<ram:GlobalID schemeID="0060">432156789</ram:GlobalID>
+				<ram:Name>Global Supplies Financial Services</ram:Name>
+				<ram:PostalTradeAddress>
+					<ram:PostcodeCode>12345</ram:PostcodeCode>
+					<ram:LineOne>Friedrichstraße 165</ram:LineOne>
+					<ram:CityName>Berlin</ram:CityName>
+					<ram:CountryID>DE</ram:CountryID>
+				</ram:PostalTradeAddress>
+			</ram:PayeeTradeParty>
+			<ram:TaxApplicableTradeCurrencyExchange>
+				<ram:SourceCurrencyCode>GBP</ram:SourceCurrencyCode>
+				<ram:TargetCurrencyCode>EUR</ram:TargetCurrencyCode>
+				<ram:ConversionRate>1.12244</ram:ConversionRate>
+				<ram:ConversionRateDateTime>
+					<udt:DateTimeString format="102">20181031</udt:DateTimeString>
+				</ram:ConversionRateDateTime>
+			</ram:TaxApplicableTradeCurrencyExchange>
+			<ram:SpecifiedTradeSettlementPaymentMeans>
+				<ram:TypeCode>58</ram:TypeCode>
+				<ram:PayeePartyCreditorFinancialAccount>
+					<ram:IBANID>DE12 1234 4321 9876 00</ram:IBANID>
+					<ram:AccountName>Global Supplies Financial Services</ram:AccountName>
+				</ram:PayeePartyCreditorFinancialAccount>
+			</ram:SpecifiedTradeSettlementPaymentMeans>
+			<ram:ApplicableTradeTax>
+				<ram:CalculatedAmount>163.16</ram:CalculatedAmount>
+				<ram:TypeCode>VAT</ram:TypeCode>
+				<ram:BasisAmount>858.75</ram:BasisAmount>
+				<ram:LineTotalBasisAmount>850</ram:LineTotalBasisAmount>
+				<ram:AllowanceChargeBasisAmount>8.75</ram:AllowanceChargeBasisAmount>
+				<ram:CategoryCode>S</ram:CategoryCode>
+				<ram:RateApplicablePercent>19</ram:RateApplicablePercent>
+			</ram:ApplicableTradeTax>
+			<ram:BillingSpecifiedPeriod>
+					<ram:StartDateTime>
+						<udt:DateTimeString format="102">20181001</udt:DateTimeString>
+					</ram:StartDateTime>
+					<ram:EndDateTime>
+						<udt:DateTimeString format="102">20181031</udt:DateTimeString>
+					</ram:EndDateTime>
+				</ram:BillingSpecifiedPeriod>
+        <ram:SpecifiedTradeAllowanceCharge>
+				<ram:ChargeIndicator>
+					<udt:Indicator>true</udt:Indicator>
+				</ram:ChargeIndicator>
+				<ram:ActualAmount>30</ram:ActualAmount>
+				<ram:ReasonCode>ABK</ram:ReasonCode>
+				<ram:Reason>Einwegverpackung</ram:Reason>
+				<ram:CategoryTradeTax>
+					<ram:TypeCode>VAT</ram:TypeCode>
+					<ram:CategoryCode>S</ram:CategoryCode>
+					<ram:RateApplicablePercent>19</ram:RateApplicablePercent>
+				</ram:CategoryTradeTax>
+			</ram:SpecifiedTradeAllowanceCharge>
+			<ram:SpecifiedTradeAllowanceCharge>
+				<ram:ChargeIndicator>
+					<udt:Indicator>false</udt:Indicator>
+				</ram:ChargeIndicator>
+				<ram:CalculationPercent>2.5</ram:CalculationPercent>
+				<ram:BasisAmount>850</ram:BasisAmount>
+				<ram:ActualAmount>21.25</ram:ActualAmount>
+				<ram:ReasonCode>ABK</ram:ReasonCode>
+				<ram:Reason>Stammkundenrabatt</ram:Reason>
+				<ram:CategoryTradeTax>
+					<ram:TypeCode>VAT</ram:TypeCode>
+					<ram:CategoryCode>S</ram:CategoryCode>
+					<ram:RateApplicablePercent>19</ram:RateApplicablePercent>
+				</ram:CategoryTradeTax>
+			</ram:SpecifiedTradeAllowanceCharge>
+			<ram:SpecifiedTradePaymentTerms>
+				<ram:Description>Zahlbar ohne Abschlag bis </ram:Description>
+				<ram:DueDateDateTime>
+					<udt:DateTimeString format="102">20181120</udt:DateTimeString>
+				</ram:DueDateDateTime>
+			</ram:SpecifiedTradePaymentTerms>
+			<ram:SpecifiedTradePaymentTerms>
+				<ram:Description>Zahlbar mit 2% Skonto bis</ram:Description>
+				<ram:DueDateDateTime>
+					<udt:DateTimeString format="102">20181114</udt:DateTimeString>
+				</ram:DueDateDateTime>
+			</ram:SpecifiedTradePaymentTerms>
+			<ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+				<ram:LineTotalAmount>850</ram:LineTotalAmount>
+				<ram:ChargeTotalAmount>30</ram:ChargeTotalAmount>
+				<ram:AllowanceTotalAmount>21.25</ram:AllowanceTotalAmount>
+				<ram:TaxBasisTotalAmount>858.75</ram:TaxBasisTotalAmount>
+				<ram:TaxTotalAmount currencyID="GBP">163.16</ram:TaxTotalAmount>
+				<ram:TaxTotalAmount currencyID="EUR">183.14</ram:TaxTotalAmount>
+				<ram:GrandTotalAmount>1021.91</ram:GrandTotalAmount>
+				<ram:TotalPrepaidAmount>500</ram:TotalPrepaidAmount>
+				<ram:DuePayableAmount>521.91</ram:DuePayableAmount>
+			</ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+		</ram:ApplicableHeaderTradeSettlement>
+	</rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
23CIIReader: Fixed bug when reading the LineId of BuyerOrderReference.
22UblReader: Added functionality to read the BuyerOrderReference.
The reading of the LineId from the BuyerOrderReference was incorrect. I identified and fixed the relevant parts.

This sample file can be used to reproduce the issue.
[EXTENDED_Fremdwaehrung.pdf](https://github.com/user-attachments/files/17735218/EXTENDED_Fremdwaehrung.pdf)

Here is an example of how it looks in XML:
```xml
<ram:SpecifiedLineTradeAgreement>
	<ram:BuyerOrderReferencedDocument>
		<ram:IssuerAssignedID>ORDER84359</ram:IssuerAssignedID>
			<ram:LineID>1</ram:LineID>
	</ram:BuyerOrderReferencedDocument>
	<ram:GrossPriceProductTradePrice>
		<ram:ChargeAmount>100.00</ram:ChargeAmount>
			<ram:BasisQuantity unitCode="H87">1</ram:BasisQuantity>
	</ram:GrossPriceProductTradePrice>
	<ram:NetPriceProductTradePrice>
		<ram:ChargeAmount>100</ram:ChargeAmount>
		<ram:BasisQuantity unitCode="H87">1</ram:BasisQuantity>
	</ram:NetPriceProductTradePrice>
</ram:SpecifiedLineTradeAgreement>
```

I also added tests and test files. The test files are copies from the official ZUGFeRD/XRechnung specification.
The test for ZUGFeRD includes LineId and ID. The examples do not include an IssueDateTime.
The test for XRechnung includes only LineId for the same reason.