### PR TITLE
write BaseQuantity as decimal format in UBL

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -506,7 +506,7 @@ namespace s2industries.ZUGFeRD
                 {
                     Writer.WriteStartElement("cbc", "BaseQuantity"); // BT-149
                     Writer.WriteAttributeString("unitCode", tradeLineItem.UnitCode.EnumToString()); // BT-150
-                    Writer.WriteValue(tradeLineItem.UnitQuantity.ToString());
+                    Writer.WriteValue(_formatDecimal(tradeLineItem.UnitQuantity));
                     Writer.WriteEndElement();
                 }
 


### PR DESCRIPTION
In operating systems in which decimal numbers are represented with a comma, the value of UnitQuantity/BaseQuantity is written to the XML with a comma.

currently get in german OS
`<cbc:BaseQuantity unitCode="P1">2,5</cbc:BaseQuantity>`

expected and resolved by PR
`<cbc:BaseQuantity unitCode="P1">2.50</cbc:BaseQuantity>`