### PR TITLE
fix Syntax of PaymentTerms description in CII export

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -2769,11 +2769,12 @@ namespace s2industries.ZUGFeRD.Test
         public void TestPaymentTermsSingleCardinalityStructured()
         {
             // Arrange
+            const string xmlNewLine = "&#10;";
             DateTime timestamp = DateTime.Now.Date;
             var desc = InvoiceProvider.CreateInvoice();
             desc.GetTradePaymentTerms().Clear();
             desc.AddTradePaymentTerms(String.Empty, null, PaymentTermsType.Skonto, 14, 2.25m);
-            desc.AddTradePaymentTerms(String.Empty, null, PaymentTermsType.Skonto, 28, 1m);
+            desc.AddTradePaymentTerms("Description2", null, PaymentTermsType.Skonto, 28, 1m);
             desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
 
             MemoryStream ms = new MemoryStream();
@@ -2797,7 +2798,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(1, paymentTerms.Count);
             var paymentTerm = loadedInvoice.GetTradePaymentTerms().FirstOrDefault();
             Assert.IsNotNull(paymentTerm);
-            Assert.AreEqual($"#SKONTO#TAGE=14#PROZENT=2.25#{Environment.NewLine}#SKONTO#TAGE=28#PROZENT=1.00#{Environment.NewLine}", paymentTerm.Description);
+            Assert.AreEqual($"#SKONTO#TAGE=14#PROZENT=2.25#{xmlNewLine}Description2{xmlNewLine}#SKONTO#TAGE=28#PROZENT=1.00#", paymentTerm.Description);
             Assert.AreEqual(timestamp.AddDays(14), paymentTerm.DueDate);
             //Assert.AreEqual(PaymentTermsType.Skonto, paymentTerm.PaymentTermsType);
             //Assert.AreEqual(10, paymentTerm.DueDays);

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -995,17 +995,31 @@ namespace s2industries.ZUGFeRD
                         DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this.Descriptor.GetTradePaymentTerms())
                         {
+                            // every line break must be a valid xml line break.
+                            // if a note already exists, append a valid line break.
+                            if (sbPaymentNotes.Length > 0)
+                            {
+                                sbPaymentNotes.Append("&#10;");
+                            }
+
                             if (paymentTerms.PaymentTermsType.HasValue)
                             {
+                                // also write the description if it exists.
+                                if (!string.IsNullOrWhiteSpace(paymentTerms.Description))
+                                {
+                                    sbPaymentNotes.Append(paymentTerms.Description);
+                                    sbPaymentNotes.Append("&#10;");
+                                }
+                                
                                 sbPaymentNotes.Append($"#{((PaymentTermsType)paymentTerms.PaymentTermsType).EnumToString<PaymentTermsType>().ToUpper()}");
                                 sbPaymentNotes.Append($"#TAGE={paymentTerms.DueDays}");
                                 sbPaymentNotes.Append($"#PROZENT={_formatDecimal(paymentTerms.Percentage)}");
                                 sbPaymentNotes.Append(paymentTerms.BaseAmount.HasValue ? $"#BASISBETRAG={_formatDecimal(paymentTerms.BaseAmount)}" : "");
-                                sbPaymentNotes.AppendLine("#");
+                                sbPaymentNotes.Append("#");
                             }
                             else
                             {
-                                sbPaymentNotes.AppendLine(paymentTerms.Description);
+                                sbPaymentNotes.Append(paymentTerms.Description);
                             }
                             dueDate = dueDate ?? paymentTerms.DueDate;
                         }

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -999,7 +999,7 @@ namespace s2industries.ZUGFeRD
                             // if a note already exists, append a valid line break.
                             if (sbPaymentNotes.Length > 0)
                             {
-                                sbPaymentNotes.Append("&#10;");
+                                sbPaymentNotes.Append(XmlUtils.XmlNewLine);
                             }
 
                             if (paymentTerms.PaymentTermsType.HasValue)
@@ -1008,7 +1008,7 @@ namespace s2industries.ZUGFeRD
                                 if (!string.IsNullOrWhiteSpace(paymentTerms.Description))
                                 {
                                     sbPaymentNotes.Append(paymentTerms.Description);
-                                    sbPaymentNotes.Append("&#10;");
+                                    sbPaymentNotes.Append(XmlUtils.XmlNewLine);
                                 }
                                 
                                 sbPaymentNotes.Append($"#{((PaymentTermsType)paymentTerms.PaymentTermsType).EnumToString<PaymentTermsType>().ToUpper()}");

--- a/ZUGFeRD/XmlUtils.cs
+++ b/ZUGFeRD/XmlUtils.cs
@@ -26,6 +26,8 @@ namespace s2industries.ZUGFeRD
 {
     internal class XmlUtils
     {
+        internal const string XmlNewLine = "&#10;";
+        
         internal static bool NodeAsBool(XmlNode node, string xpath, XmlNamespaceManager nsmgr = null, bool defaultValue = true)
         {
             if (node == null)


### PR DESCRIPTION
- replace Environment.NewLine by valid xml line break in description
- always write payment terms description text if it is set
- update test

Errormessage without valid xml line breaks
![grafik](https://github.com/user-attachments/assets/3e0f71b8-1569-4203-9166-65bd44ae25e8)
