### PR TITLE
Fix only the seller has a party identification in UBL

### DIFF
--- a/ZUGFeRD-Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD-Test/XRechnungUBLTests.cs
@@ -469,7 +469,7 @@ namespace ZUGFeRD_Test
         
         
         [TestMethod]
-        public void TestPartyIdentification_for_seller()
+        public void TestPartyIdentificationForSeller()
         {
             InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
             MemoryStream ms = new MemoryStream();
@@ -489,6 +489,27 @@ namespace ZUGFeRD_Test
             Assert.IsTrue(Regex.Matches(content, @"\<cac:PartyIdentification\>").Count == 1, "PartyIdentification should only contain once");
             // PartyIdentification may only be contained in AccountingSupplierParty
             Assert.IsTrue(Regex.IsMatch(content, "<cac:AccountingSupplierParty>.*<cac:Party>.*<cac:PartyIdentification>.*<cbc:ID.schemeID=\"SEPA\">DE75512108001245126199</cbc:ID>", RegexOptions.Singleline));
-        } // !TestInvoiceCreation()
+        } // !TestPartyIdentificationForSeller()
+        
+        [TestMethod]
+        public void TestPartyIdentificationShouldNotExist()
+        {
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            
+            MemoryStream resultStream = new MemoryStream();
+            loadedInvoice.Save(resultStream, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+ 
+            // test the raw xml file
+            string content = Encoding.UTF8.GetString(resultStream.ToArray());
+            
+            Assert.IsNotNull(content);
+            Assert.IsFalse(Regex.IsMatch(content, @"\<cac:PartyIdentification\>"), "PartyIdentification should not contain");
+        } // !TestPartyIdentificationShouldNotExist()
 	}
 }

--- a/ZUGFeRD-Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD-Test/XRechnungUBLTests.cs
@@ -18,8 +18,8 @@
  */
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using s2industries.ZUGFeRD;
-using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace ZUGFeRD_Test
 {
@@ -466,5 +466,29 @@ namespace ZUGFeRD_Test
 
 			Assert.AreEqual(desc.TradeLineItems[0].BuyerOrderReferencedDocument.LineID, "6171175.1");
 		}
+        
+        
+        [TestMethod]
+        public void TestPartyIdentification_for_seller()
+        {
+            InvoiceDescriptor desc = this.InvoiceProvider.CreateInvoice();
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            
+            loadedInvoice.SetPaymentMeans(PaymentMeansTypeCodes.SEPACreditTransfer, "Hier sind Informationen", "DE75512108001245126199", "[Mandate reference identifier]");
+            MemoryStream resultStream = new MemoryStream();
+            loadedInvoice.Save(resultStream, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+ 
+            // test the raw xml file
+            string content = Encoding.UTF8.GetString(resultStream.ToArray());
+            // PartyIdentification may only exist once
+            Assert.IsTrue(Regex.Matches(content, @"\<cac:PartyIdentification\>").Count == 1, "PartyIdentification should only contain once");
+            // PartyIdentification may only be contained in AccountingSupplierParty
+            Assert.IsTrue(Regex.IsMatch(content, "<cac:AccountingSupplierParty>.*<cac:Party>.*<cac:PartyIdentification>.*<cbc:ID.schemeID=\"SEPA\">DE75512108001245126199</cbc:ID>", RegexOptions.Singleline));
+        } // !TestInvoiceCreation()
 	}
 }

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -653,14 +653,18 @@ namespace s2industries.ZUGFeRD
                     writer.WriteEndElement();
                 }
 
-                if (this.Descriptor.PaymentMeans?.SEPAMandateReference != null)
+                if (party == this.Descriptor.Seller)
                 {
-                    writer.WriteStartElement("cac", "PartyIdentification");
-                    writer.WriteStartElement("cbc", "ID");
-                    writer.WriteAttributeString("schemeID", "SEPA");
-                    writer.WriteValue(this.Descriptor.PaymentMeans.SEPACreditorIdentifier);
-                    writer.WriteEndElement();//!ID
-                    writer.WriteEndElement();//!PartyIdentification
+                    // This is the identification of the seller, not the buyer
+                    if (this.Descriptor.PaymentMeans?.SEPAMandateReference != null)
+                    {
+                        writer.WriteStartElement("cac", "PartyIdentification");
+                        writer.WriteStartElement("cbc", "ID");
+                        writer.WriteAttributeString("schemeID", "SEPA");
+                        writer.WriteValue(this.Descriptor.PaymentMeans.SEPACreditorIdentifier);
+                        writer.WriteEndElement();//!ID
+                        writer.WriteEndElement();//!PartyIdentification
+                    }
                 }
 
                 if (!string.IsNullOrWhiteSpace(party.Name))

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -653,10 +653,10 @@ namespace s2industries.ZUGFeRD
                     writer.WriteEndElement();
                 }
 
-                if (party == this.Descriptor.Seller)
+                if (partyType == PartyTypes.SellerTradeParty)
                 {
                     // This is the identification of the seller, not the buyer
-                    if (this.Descriptor.PaymentMeans?.SEPAMandateReference != null)
+                    if (!string.IsNullOrWhiteSpace(this.Descriptor.PaymentMeans?.SEPACreditorIdentifier))
                     {
                         writer.WriteStartElement("cac", "PartyIdentification");
                         writer.WriteStartElement("cbc", "ID");


### PR DESCRIPTION
The PartyIdentification may only be contained in AccountingSupplierParty in XRechnung with UBL.
Fixed the UBL Writer.
Added Test for this Requirement.