### PR TITLE
Fix UBL writer for debit payment

### DIFF
--- a/ZUGFeRD.Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD.Test/XRechnungUBLTests.cs
@@ -579,9 +579,9 @@ namespace s2industries.ZUGFeRD.Test
             // test the raw xml file
             string content = Encoding.UTF8.GetString(resultStream.ToArray());
             // PartyIdentification may only exist once
-            Assert.IsTrue(Regex.Matches(content, @"\<cac:PartyIdentification\>").Count == 1, "PartyIdentification should only contain once");
+            Assert.IsTrue(Regex.Matches(content, "<cac:PartyIdentification.*>").Count == 1, "PartyIdentification should only contain once");
             // PartyIdentification may only be contained in AccountingSupplierParty
-            Assert.IsTrue(Regex.IsMatch(content, "<cac:AccountingSupplierParty>.*<cac:Party>.*<cac:PartyIdentification>.*<cbc:ID.schemeID=\"SEPA\">DE75512108001245126199</cbc:ID>", RegexOptions.Singleline));
+            Assert.IsTrue(Regex.IsMatch(content, "<cac:AccountingSupplierParty.*>.*<cac:Party.*>.*<cac:PartyIdentification.*>.*<cbc:ID.schemeID=\"SEPA\">DE75512108001245126199</cbc:ID>", RegexOptions.Singleline));
         } // !TestPartyIdentificationForSeller()
         
         [TestMethod]
@@ -602,7 +602,7 @@ namespace s2industries.ZUGFeRD.Test
             string content = Encoding.UTF8.GetString(resultStream.ToArray());
             
             Assert.IsNotNull(content);
-            Assert.IsFalse(Regex.IsMatch(content, @"\<cac:PartyIdentification\>"), "PartyIdentification should not contain");
+            Assert.IsFalse(Regex.IsMatch(content, @"<cac:PartyIdentification.*>"), "PartyIdentification should not contain");
         } // !TestPartyIdentificationShouldNotExist()
 
         [TestMethod]
@@ -685,8 +685,8 @@ namespace s2industries.ZUGFeRD.Test
                 // test the raw xml file
                 string content = Encoding.UTF8.GetString(stream.ToArray());
 
-                Assert.IsFalse(Regex.IsMatch(content, @"<cac:PaymentMandate>.*<cbc:Name.*<\/cac:PaymentMandate>", RegexOptions.Singleline));
-                Assert.IsFalse(Regex.IsMatch(content, "<cac:PaymentMandate>.*<cac:FinancialInstitutionBranch.*</cac:PaymentMandate>", RegexOptions.Singleline));
+                Assert.IsFalse(Regex.IsMatch(content, @"<cac:PaymentMandate.*>.*<cbc:Name.*><\/cac:PaymentMandate>", RegexOptions.Singleline));
+                Assert.IsFalse(Regex.IsMatch(content, "<cac:PaymentMandate.*>.*<cac:FinancialInstitutionBranch.*></cac:PaymentMandate>", RegexOptions.Singleline));
             }
         } // !TestInDebitInvoiceTheFinancialAccountNameShouldNotExist()
 	}

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -355,17 +355,20 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteStartElement("cac", "PayerFinancialAccount");
 
                             Writer.WriteElementString("cbc", "ID", account.IBAN);
-                            Writer.WriteElementString("cbc", "Name", account.Name);
 
-                            Writer.WriteStartElement("cac", "FinancialInstitutionBranch");
-                            Writer.WriteElementString("cbc", "ID", account.BIC);
+                            //[UBL-CR-440]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount Name
+                            //Writer.WriteElementString("cbc", "Name", account.Name);
+
+                            //[UBL-CR-446]-A UBL invoice should not include the PaymentMeans PaymentMandate PayerFinancialAccount FinancialInstitutionBranch
+                            //Writer.WriteStartElement("cac", "FinancialInstitutionBranch");
+                            //Writer.WriteElementString("cbc", "ID", account.BIC);
 
                             //[UBL - CR - 664] - A UBL invoice should not include the FinancialInstitutionBranch FinancialInstitution
                             //Writer.WriteStartElement("cac", "FinancialInstitution");
                             //Writer.WriteElementString("cbc", "Name", account.BankName);
 
                             //Writer.WriteEndElement(); // !FinancialInstitution
-                            Writer.WriteEndElement(); // !FinancialInstitutionBranch
+                            //Writer.WriteEndElement(); // !FinancialInstitutionBranch
 
                             Writer.WriteEndElement(); // !PayerFinancialAccount
                             Writer.WriteEndElement(); // !PaymentMandate


### PR DESCRIPTION
Removal of obsolete debitor account details from UBL export to comply with CR-440 and CR-446.
Test was added.