### PR TITLE
Update InvoiceDescriptorHtmlRenderer.cs to fix a bug caused by todays namespace changes

### DIFF
--- a/ZUGFeRD.Render/InvoiceDescriptorHtmlRenderer.cs
+++ b/ZUGFeRD.Render/InvoiceDescriptorHtmlRenderer.cs
@@ -37,7 +37,7 @@ namespace s2industries.ZUGFeRD.Render
         public static string render(InvoiceDescriptor desc)
         {
             var assembly = Assembly.GetExecutingAssembly();
-            var resourceName = "ZUGFeRDRenderer.test.cshtml";
+            var resourceName = typeof(InvoiceDescriptorHtmlRenderer).Namespace + ".test.cshtml";
 
             string template = "";
             using (Stream stream = assembly.GetManifestResourceStream(resourceName))


### PR DESCRIPTION
Today the namespace of the renderer and multiple other classes/projects was changed from ZUGFeRD.XXX to s2industries.ZUGFeRD.XXX. 

So far the renderer tried to load the resource "test.cshtml" with a hardcoded namespace in the variable resourceName. Due todays namespace change loading the resource doesnt work anymore. This changeset changes the assignment of resourceName so the namspace is read in a dynamic way. This should fix the bug and should enable the renderer to automatically deal with future changes of the namespace.



