### PR TITLE
Fix for UBL Invoice on document level allowance

### DIFF
--- a/ZUGFeRD.Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD.Test/XRechnungUBLTests.cs
@@ -219,6 +219,8 @@ namespace s2industries.ZUGFeRD.Test
 
             desc.AddTradeAllowanceCharge(isDiscount, basisAmount, currency, actualAmount, reason, taxTypeCode, taxCategoryCode, taxPercent);
 
+            desc.TradeLineItems[0].AddTradeAllowanceCharge(true, CurrencyCodes.EUR, 100, 10, "test");
+
             TradeAllowanceCharge? testAllowanceCharge = desc.GetTradeAllowanceCharges().FirstOrDefault();
 
             MemoryStream ms = new MemoryStream();

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -297,7 +297,10 @@ namespace s2industries.ZUGFeRD
                                              );
             }
 
-            foreach (XmlNode node in doc.SelectNodes("//cac:AllowanceCharge", nsmgr))
+            // As both document level and document item level element have same name
+            // only using the //cac:AllowanceCharge gives all the allowances from the file 
+            // so we specify the node with the parent node
+            foreach (XmlNode node in doc.DocumentElement.SelectNodes("/ubl:Invoice/cac:AllowanceCharge", nsmgr))
             {
                 retval.AddTradeAllowanceCharge(!XmlUtils.NodeAsBool(node, ".//cbc:ChargeIndicator", nsmgr), // wichtig: das not (!) beachten
                                                XmlUtils.NodeAsDecimal(node, ".//cbc:BaseAmount", nsmgr, 0).Value,


### PR DESCRIPTION
While reading the UBL related invoice, document level allowances also included the trade allowance from item level.