### PR TITLE
Update export of AllowanceCharge fields in TradeLineItem for CII and UBL

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -558,10 +558,13 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteValue(_formatDecimal(charges[0].ActualAmount));
                 Writer.WriteEndElement();
 
-                Writer.WriteStartElement("cbc", "BaseAmount"); // BT-148
-                Writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
-                Writer.WriteValue(_formatDecimal(charges[0].BasisAmount));
-                Writer.WriteEndElement();
+                if (charges[0].BasisAmount != null) // BT-148 is optional
+                {
+                    Writer.WriteStartElement("cbc", "BaseAmount"); // BT-148
+                    Writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
+                    Writer.WriteValue(_formatDecimal(charges[0].BasisAmount));
+                    Writer.WriteEndElement();
+                }
 
                 Writer.WriteEndElement(); // !AllowanceCharge()
             }

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -492,7 +492,7 @@ namespace s2industries.ZUGFeRD
                             #region BasisAmount
                             if (specifiedTradeAllowanceCharge.BasisAmount.HasValue)
                             {
-                                Writer.WriteStartElement("ram", "BasisAmount", profile: Profile.Extended); // not in XRechnung, according to CII-SR-123
+                                Writer.WriteStartElement("ram", "BasisAmount", profile: Profile.Extended | Profile.XRechnung); // PEPPOL-EN16931-R041 Allowance/charge base amount MUST be provided when allowance/charge percentage is provided.
                                 Writer.WriteValue(_formatDecimal(specifiedTradeAllowanceCharge.BasisAmount.Value, 2));
                                 Writer.WriteEndElement();
                             }
@@ -504,7 +504,7 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteEndElement();
                             #endregion
 
-                            Writer.WriteOptionalElementString("ram", "Reason", specifiedTradeAllowanceCharge.Reason, Profile.Extended); // not in XRechnung according to CII-SR-128
+                            Writer.WriteOptionalElementString("ram", "Reason", specifiedTradeAllowanceCharge.Reason, Profile.Extended | Profile.XRechnung); // [BR-42]-Each Invoice line allowance (BG-27) shall have an Invoice line allowance reason (BT-139) or an Invoice line allowance reason code (BT-140).
                             Writer.WriteEndElement(); // !ram:SpecifiedTradeAllowanceCharge
                         }
                     }


### PR DESCRIPTION
Add fields BasisAmount and Reason of Region SpecifiedTradeAllowanceCharge to XRechnung-Profile because both are elemtens of XRechnung.