### PR TITLE
Update ElectronicAddressSchemeIdentifiers

### DIFF
--- a/ZUGFeRD/ElectronicAddressSchemeIdentifiers.cs
+++ b/ZUGFeRD/ElectronicAddressSchemeIdentifiers.cs
@@ -31,9 +31,139 @@ namespace s2industries.ZUGFeRD
     {
 
         /// <summary>
+        /// System Information et Repertoire des Entreprise et des Etablissements: SIRENE
+        /// </summary>
+        SystemInformationEtRepertoireDesEntrepriseEtDesEtablissementsSirene = 0002,
+
+        /// <summary>
+        /// Organisationsnummer (Swedish legal entities)
+        /// </summary>
+        OrganisationsnummerSwedishLegalEntities = 0007,
+
+        /// <summary>
+        /// SIRET-CODE
+        /// </summary>
+        SiretCode = 0009,
+
+        /// <summary>
+        /// LY-tunnus
+        /// </summary>
+        LyTunnus = 0037,
+
+        /// <summary>
+        /// Data Universal Numbering System (D-U-N-S Number)
+        /// </summary>
+        DataUniversalNumberingSystemDUNSNumber = 0060,
+
+        /// <summary>
         /// EAN Location Code
         /// </summary>
         EanLocationCode = 0088,
+
+        /// <summary>
+        /// DANISH CHAMBER OF COMMERCE Scheme (EDIRA compliant)
+        /// </summary>
+        DanishChamberOfCommerceSchemeEdiraCompliant = 0096,
+
+        /// <summary>
+        /// FTI - Ediforum Italia, (EDIRA compliant)
+        /// </summary>
+        FtiEdiforumItaliaEdiraCompliant = 0097,
+
+        /// <summary>
+        /// "Vereniging van Kamers van Koophandel en Fabrieken in Nederland (Association of Chambers of Commerce and Industry in the Netherlands), Scheme (EDIRA compliant)"
+        /// </summary>
+        VerenigingVanKamersVanKoophandelEnFabriekenInNederlandAssociationOfChambersOfCommerceAndIndustryInTheNetherlandsSchemeEdiraCompliant = 0106,
+
+        /// <summary>
+        /// Directorates of the European Commission
+        /// </summary>
+        DirectoratesOfTheEuropeanCommission = 0130,
+
+        /// <summary>
+        /// SIA Object Identifiers
+        /// </summary>
+        SiaObjectIdentifiers = 0135,
+
+        /// <summary>
+        /// SECETI Object Identifiers
+        /// </summary>
+        SecetiObjectIdentifiers = 0142,
+
+        /// <summary>
+        /// Australian Business Number (ABN) Scheme
+        /// </summary>
+        AustralianBusinessNumberAbnScheme = 0151,
+
+        /// <summary>
+        /// Numéro d'identification suisse des enterprises (IDE), Swiss Unique Business Identification Number (UIDB)
+        /// </summary>
+        NumRoDIdentificationSuisseDesEnterprisesIdeSwissUniqueBusinessIdentificationNumberUidb = 0183,
+
+        /// <summary>
+        /// DIGSTORG
+        /// </summary>
+        Digstorg = 0184,
+
+        /// <summary>
+        /// Corporate Number of The Social Security and Tax Number System
+        /// </summary>
+        CorporateNumberOfTheSocialSecurityAndTaxNumberSystem = 0188,
+
+        /// <summary>
+        /// Dutch Originator's Identification Number
+        /// </summary>
+        DutchOriginatorSIdentificationNumber = 0190,
+
+        /// <summary>
+        /// Centre of Registers and Information Systems of the Ministry of Justice
+        /// </summary>
+        CentreOfRegistersAndInformationSystemsOfTheMinistryOfJustice = 0191,
+
+        /// <summary>
+        /// Enhetsregisteret ved Bronnoysundregisterne
+        /// </summary>
+        EnhetsregisteretVedBronnoysundregisterne = 0192,
+
+        /// <summary>
+        /// UBL.BE party identifier
+        /// </summary>
+        UblBePartyIdentifier = 0193,
+
+        /// <summary>
+        /// Singapore UEN identifier
+        /// </summary>
+        SingaporeUenIdentifier = 0195,
+
+        /// <summary>
+        /// Kennitala - Iceland legal id for individuals and legal entities
+        /// </summary>
+        KennitalaIcelandLegalIdForIndividualsAndLegalEntities = 0196,
+
+        /// <summary>
+        /// ERSTORG
+        /// </summary>
+        Erstorg = 0198,
+
+        /// <summary>
+        /// Legal Entity Identifier (LEI)
+        /// </summary>
+        LegalEntityIdentifierLei = 0199,
+
+        /// <summary>
+        /// Legal entity code (Lithuania)
+        /// </summary>
+        LegalEntityCodeLithuania = 0200,
+
+        /// <summary>
+        /// Codice Univoco Unità Organizzativa iPA
+        /// </summary>
+        CodiceUnivocoUnitOrganizzativaIpa = 0201,
+
+        /// <summary>
+        /// Indirizzo di Posta Elettronica Certificata
+        /// </summary>
+        IndirizzoDiPostaElettronicaCertificata = 0202,
 
         /// <summary>
         /// Leitweg-ID
@@ -41,53 +171,138 @@ namespace s2industries.ZUGFeRD
         LeitwegID = 0204,
 
         /// <summary>
+        /// Numero d'entreprise / ondernemingsnummer / Unternehmensnummer
+        /// </summary>
+        NumeroDEntrepriseOndernemingsnummerUnternehmensnummer = 0208,
+
+        /// <summary>
+        /// GS1 identification keys
+        /// </summary>
+        Gs1IdentificationKeys = 0209,
+
+        /// <summary>
+        /// CODICE FISCALE
+        /// </summary>
+        CodiceFiscale = 0210,
+
+        /// <summary>
+        /// PARTITA IVA
+        /// </summary>
+        PartitaIva = 0211,
+
+        /// <summary>
+        /// Finnish Organization Identifier
+        /// </summary>
+        FinnishOrganizationIdentifier = 0212,
+
+        /// <summary>
+        /// Finnish Organization Value Add Tax Identifier
+        /// </summary>
+        FinnishOrganizationValueAddTaxIdentifier = 0213,
+
+        /// <summary>
+        /// Net service ID
+        /// </summary>
+        NetServiceId = 0215,
+
+        /// <summary>
+        /// OVTcode
+        /// </summary>
+        Ovtcode = 0216,
+
+        /// <summary>
+        /// Unified registration number (Latvia)
+        /// </summary>
+        UnifiedRegistrationNumberLatvia = 0218,
+
+        /// <summary>
+        /// The registered number of the qualified invoice issuer (Japan)
+        /// </summary>
+        TheRegisteredNumberOfTheQualifiedInvoiceIssuerJapan = 0221,
+
+        /// <summary>
+        /// National e-Invoicing Framework (Malaysia)
+        /// </summary>
+        NationalEInvoicingFrameworkMalaysia = 0230,
+
+        /// <summary>
+        /// Danish Ministry of the Interior and Health
+        /// </summary>
+        DanishMinistryOfTheInteriorAndHealth = 9901,
+
+        /// <summary>
         /// Hungary VAT number
-        /// </summary>      
+        /// </summary>
         HungaryVatNumber = 9910,
 
         /// <summary>
+        /// Business Registers Network
+        /// </summary>
+        BusinessRegistersNetwork = 9913,
+
+        /// <summary>
         /// Austria VAT number
-        /// </summary>      
+        /// </summary>
         AustriaVatNumber = 9914,
 
         /// <summary>
+        /// "Österreichisches Verwaltungs bzw. Organisationskennzeichen"
+        /// </summary>
+        OesterreichischesVerwaltungsBzwOrganisationskennzeichen = 9915,
+
+        /// <summary>
+        /// "SOCIETY FOR WORLDWIDE INTERBANK FINANCIAL, TELECOMMUNICATION S.W.I.F.T"
+        /// </summary>
+        SocietyForWorldwideInterbankFinancialTelecommunicationSWIFT = 9918,
+
+        /// <summary>
+        /// Kennziffer des Unternehmensregisters
+        /// </summary>
+        KennzifferDesUnternehmensregisters = 9919,
+
+        /// <summary>
+        /// Agencia Española de Administración Tributaria
+        /// </summary>
+        AgenciaEspaOlaDeAdministraciNTributaria = 9920,
+
+        /// <summary>
         /// Andorra VAT number
-        /// </summary>      
+        /// </summary>
         AndorraVatNumber = 9922,
 
         /// <summary>
         /// Albania VAT number
-        /// </summary>      
+        /// </summary>
         AlbaniaVatNumber = 9923,
 
         /// <summary>
         /// Bosnia and Herzegovina VAT number
-        /// </summary>      
+        /// </summary>
         BosniaAndHerzegovinaVatNumber = 9924,
 
         /// <summary>
         /// Belgium VAT number
-        /// </summary>      
+        /// </summary>
         BelgiumVatNumber = 9925,
 
         /// <summary>
         /// Bulgaria VAT number
-        /// </summary>      
+        /// </summary>
         BulgariaVatNumber = 9926,
 
         /// <summary>
         /// Switzerland VAT number
-        /// </summary>      
+        /// </summary>
         SwitzerlandVatNumber = 9927,
 
         /// <summary>
         /// Cyprus VAT number
-        /// </summary>      
+        /// </summary>
         CyprusVatNumber = 9928,
 
         /// <summary>
         /// Czech Republic VAT number
-        /// </summary>      
+        /// </summary>
         CzechRepublicVatNumber = 9929,
 
         /// <summary>
@@ -216,14 +431,14 @@ namespace s2industries.ZUGFeRD
         SwedishVatNumber = 9955,
 
         /// <summary>
+        /// Belgian Crossroad Bank of Enterprises
+        /// </summary>
+        BelgianCrossroad = 9956,
+
+        /// <summary>
         /// French VAT number
         /// </summary>
         FrenchVatNumber = 9957,
-
-        /// <summary>
-        /// Belgian Crossroad Bank of Enterprises 
-        /// </summary>
-        BelgianCrossroad = 9956,
 
         /// <summary>
         /// German Leitweg ID

--- a/tools/ElectronicAddressSchemeIdentifiers/Create-Enum.ps1
+++ b/tools/ElectronicAddressSchemeIdentifiers/Create-Enum.ps1
@@ -1,0 +1,467 @@
+function ConvertTo-UpperCamelCase
+{
+    param([string]$text)
+
+    # Split text into words and clean
+    $words = $text -split '\s+'
+
+    # Capitalize first letter of each word
+    $camelCase = foreach ($word in $words)
+    {
+        if ($word)
+        {
+            $word.Substring(0, 1).ToUpper() + $word.Substring(1).ToLower()
+        }
+    }
+
+    return [string]::Join("", $camelCase)
+}
+
+function Get-CleanSlug
+{
+    param([string]$text)
+    # Convert German umlauts to ASCII representation
+    $cleaned = $text -replace 'ä', 'ae' `
+        -replace 'ö', 'oe' `
+        -replace 'ü', 'ue' `
+        -replace 'Ä', 'Ae' `
+        -replace 'Ö', 'Oe' `
+        -replace 'Ü', 'Ue' `
+        -replace 'ß', 'ss'
+
+    # Remove special characters but keep spaces for word boundaries
+    # Also handle special case for VAT abbreviation
+    $cleaned = $cleaned -replace '[^a-zA-Z0-9\s]', ' ' `
+        -replace '\s+', ' '`
+        -replace 'VAT', 'Vat'
+
+    # Convert to UpperCamelCase
+    $cleaned = ConvertTo-UpperCamelCase -text $cleaned
+    return $cleaned
+}
+
+function ConvertFrom-HtmlEntities
+{
+    param([string]$text)
+
+    # Replace HTML entities with their corresponding characters
+    $text = $text -replace '&quot;', '"' `
+        -replace '&amp;', '&' `
+        -replace '&lt;', '<' `
+        -replace '&gt;', '>' `
+        -replace '&apos;', "'" `
+        -replace '&#39;', "'" `
+        -replace '&#34;', '"'`
+        -replace '\s+', ' '
+
+    return $text
+}
+
+function Get-PeppolEasItems
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[PSObject]])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$HtmlFilePath
+    )
+
+    try
+    {
+        # Load HTML file
+        $html = Get-Content -Path $HtmlFilePath -Raw
+
+        # Parse HTML using regex pattern to extract code, summary
+        $pattern = '<div id="(\d+)"[^>]*>.*?<code>(\d+)</code>.*?<strong>(.*?)</strong>'
+        $matches = [regex]::Matches($html, $pattern, [System.Text.RegularExpressions.RegexOptions]::Singleline)
+
+        # Create result list
+        $results = New-Object System.Collections.Generic.List[PSObject]
+
+        foreach ($match in $matches)
+        {
+            $codeInt = [int]$match.Groups[1].Value
+            [string]$code = '{0:D4}' -f ($codeInt)
+
+            # Check for manual override entries
+            $override = Get-ManualItemOverride -code $code
+            if ($override)
+            {
+                $results.Add($override)
+                continue
+            }
+
+            $summary = $match.Groups[3].Value.Trim()
+            $summary = ConvertFrom-HtmlEntities -text $summary
+
+            # Generate slug: clean special characters and format
+            $slug = Get-CleanSlug -text $summary
+
+            # Create and add object to results
+            $results.Add([PSCustomObject]@{
+                    code    = $code
+                    summary = $summary
+                    slug    = $slug
+                })
+        }
+
+        # Add manual items
+        $manualItems = Get-ManualItems
+        foreach ($manualItem in $manualItems)
+        {
+            $results.Add($manualItem)
+        }
+
+        # Order results by code
+        $results = $results | Sort-Object -Property code
+        return $results
+    }
+    catch
+    {
+        Write-Error "Error processing HTML file: $_"
+        return $null
+    }
+}
+
+function Get-ManualItems
+{
+    [OutputType([System.Collections.Generic.List[PSObject]])]
+    $result = New-Object System.Collections.Generic.List[PSObject]
+    $result.Add([PSCustomObject]@{
+        code    = "9955"
+        summary = "Swedish VAT number"
+        slug    = "SwedishVatNumber"
+    })
+    $result.Add([PSCustomObject]@{
+        code    = "9956"
+        summary = "Belgian Crossroad Bank of Enterprises"
+        slug    = "BelgianCrossroad"
+    })
+    $result.Add([PSCustomObject]@{
+        code    = "9958"
+        summary = "German Leitweg ID"
+        slug    = "GermanLeitwegID"
+    })
+
+    return $result
+}
+function Get-ManualItemOverride
+{
+    [OutputType([PSObject])]
+    param (
+        [string]$code,
+        [string]$slug
+    )
+
+    $manualItems = New-Object System.Collections.Generic.List[PSObject]
+    $manualItems.Add([PSCustomObject]@{
+            code    = "0088"
+            summary = "EAN Location Code"
+            slug    = "EanLocationCode"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "0204"
+            summary = "Leitweg-ID"
+            slug    = "LeitwegID"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9910"
+            summary = "Hungary VAT number"
+            slug    = "HungaryVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9914"
+            summary = "Austria VAT number"
+            slug    = "AustriaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9922"
+            summary = "Andorra VAT number"
+            slug    = "AndorraVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9923"
+            summary = "Albania VAT number"
+            slug    = "AlbaniaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9924"
+            summary = "Bosnia and Herzegovina VAT number"
+            slug    = "BosniaAndHerzegovinaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9925"
+            summary = "Belgium VAT number"
+            slug    = "BelgiumVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9926"
+            summary = "Bulgaria VAT number"
+            slug    = "BulgariaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9927"
+            summary = "Switzerland VAT number"
+            slug    = "SwitzerlandVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9928"
+            summary = "Cyprus VAT number"
+            slug    = "CyprusVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9929"
+            summary = "Czech Republic VAT number"
+            slug    = "CzechRepublicVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9930"
+            summary = "Germany VAT number"
+            slug    = "GermanyVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9931"
+            summary = "Estonia VAT number"
+            slug    = "EstoniaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9932"
+            summary = "United Kingdom VAT number"
+            slug    = "UnitedKingdomVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9933"
+            summary = "Greece VAT number"
+            slug    = "GreeceVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9934"
+            summary = "Croatia VAT number"
+            slug    = "CroatiaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9935"
+            summary = "Ireland VAT number"
+            slug    = "IrelandVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9936"
+            summary = "Liechtenstein VAT number"
+            slug    = "LiechtensteinVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9937"
+            summary = "Lithuania VAT number"
+            slug    = "LithuaniaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9938"
+            summary = "Luxemburg VAT number"
+            slug    = "LuxemburgVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9939"
+            summary = "Latvia VAT number"
+            slug    = "LatviaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9940"
+            summary = "Monaco VAT number"
+            slug    = "MonacoVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9941"
+            summary = "Montenegro VAT number"
+            slug    = "MontenegroVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9942"
+            summary = "Macedonia, of the former Yugoslav Republic VAT number"
+            slug    = "MacedoniaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9943"
+            summary = "Malta VAT number"
+            slug    = "MaltaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9944"
+            summary = "Netherlands VAT number"
+            slug    = "NetherlandsVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9945"
+            summary = "Poland VAT number"
+            slug    = "PolandVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9946"
+            summary = "Portugal VAT number"
+            slug    = "PortugalVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9947"
+            summary = "Romania VAT number"
+            slug    = "RomaniaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9948"
+            summary = "Serbia VAT number"
+            slug    = "SerbiaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9949"
+            summary = "Slovenia VAT number"
+            slug    = "SloveniaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9950"
+            summary = "Slovakia VAT number"
+            slug    = "SlovakiaVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9951"
+            summary = "San Marino VAT number"
+            slug    = "SanMarinoVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9952"
+            summary = "Turkey VAT number"
+            slug    = "TurkeyVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9953"
+            summary = "Holy See (Vatican City State) VAT number"
+            slug    = "HolySeeVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9955"
+            summary = "Swedish VAT number"
+            slug    = "SwedishVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9956"
+            summary = "Belgian Crossroad Bank of Enterprises"
+            slug    = "BelgianCrossroad"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9957"
+            summary = "French VAT number"
+            slug    = "FrenchVatNumber"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9958"
+            summary = "German Leitweg ID"
+            slug    = "GermanLeitwegID"
+        })
+    $manualItems.Add([PSCustomObject]@{
+            code    = "9959"
+            summary = "Employer Identification Number (EIN, USA)"
+            slug    = "EmployerIdentificationNumber"
+        })
+
+    return $manualItems | Where-Object { $_.code -eq $code }
+}
+
+function Get-PeppolEasCodelist
+{
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    try
+    {
+        # Create temporary file for download
+        $tempFile = [System.IO.Path]::GetTempFileName()
+        $tempFileHtml = [System.IO.Path]::ChangeExtension($tempFile, "html")
+        Rename-Item -Path $tempFile -NewName $tempFileHtml
+
+        # Download PEPPOL EAS codelist
+        $url = "https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/"
+        Invoke-WebRequest -Uri $url -OutFile $tempFileHtml
+
+        Write-Verbose "Downloaded to: $tempFileHtml"
+        return $tempFileHtml
+    }
+    catch
+    {
+        Write-Error "Failed to download PEPPOL EAS codelist: $_"
+        return $null
+    }
+}
+
+function Create-EnumFile
+{
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$FileName,
+
+        [Parameter(Mandatory = $true)]
+        [array]$Items,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Namespace = "s2industries.ZUGFeRD"
+    )
+
+    # Create C# enum file content
+    $enumContent = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace $Namespace
+{
+    /// <summary>
+    /// For a reference see:
+    /// https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/
+    /// </summary>
+    public enum ElectronicAddressSchemeIdentifiers
+    {
+"@
+
+    # Add enum entries
+    foreach ($item in $Items)
+    {
+        $enumContent += @"
+
+        /// <summary>
+        /// $($item.summary)
+        /// </summary>
+        $($item.slug) = $($item.code),
+
+"@
+    }
+    $enumContent += @"
+    }
+}
+"@
+    # Save enum content to file
+    Set-Content -Path $FileName -Value $enumContent -Encoding UTF8
+
+    Write-Output "Enum file created: $FileName"
+}
+
+# Main execution
+$tempFilePath = Get-PeppolEasCodelist
+if ($tempFilePath)
+{
+    try
+    {
+        $items = Get-PeppolEasItems -HtmlFilePath $tempFilePath
+        $items | Format-Table -AutoSize
+        Create-EnumFile -FileName "ElectronicAddressSchemeIdentifiers.cs" -Items $items -Namespace "s2industries.ZUGFeRD"
+    }
+    finally
+    {
+        # Cleanup temporary files
+        if (Test-Path $tempFilePath)
+        {
+            Remove-Item -Path $tempFilePath -Force
+        }
+    }
+}
+else
+{
+    Write-Error "Failed to download PEPPOL EAS codelist"
+}


### PR DESCRIPTION
I wanted to update the Electronic Address Scheme enum. The current one seems to be very out of date (or only required values were added?) and to be a bit more future-proof I created a PowerShell script to do the heavy-lifting.

Some names are long, but I thought I'd stick to the automatic naming. I've added a `Get-ManualItemOverride` function to stay compatible with existing enum entries. This would be the right place to add better names, and I'm happy for suggestions.

Another hiccup was, that some codes in the enum are missing now on https://docs.peppol.eu/poacc/billing/3.0/codelist/eas/ - those are listed in `Get-ManualItems` and are added on the way. I didn't want to introduce a breaking change by deleting those, but I think it may be the right thing to do.