### PR TITLE
Convert profile names to uppercase according to validator requirement for ConformanceLevel

### DIFF
--- a/ZUGFeRD/Profile.cs
+++ b/ZUGFeRD/Profile.cs
@@ -195,7 +195,7 @@ namespace s2industries.ZUGFeRD
                 case Profile.Comfort:
                 case Profile.XRechnung1:
                 case Profile.XRechnung: return "EN 16931";
-                default: return profile.ToString();
+                default: return profile.ToString().ToUpper();
             }
         } // !GetXMPName()
     }


### PR DESCRIPTION
[Java validator](https://github.com/ZUGFeRD/ZUV/blob/master/src/main/java/ZUV/PDFValidator.java#L182) expects XMP Profile Names to be in upper case. This change converts the Profiles Minimum, Basic and Extended to MINIMUM, BASIC and EXTENDED and leaves the others profile names untouched.

Generated invoices failed in [this](https://www.portinvoice.com/) validator, because the XMP profile name in XMP meta data xml was not all uppercase:

### Before:

```
<rdf:Description xmlns:fx="urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#" rdf:about="">
	<fx:DocumentType>INVOICE</fx:DocumentType>
	<fx:DocumentFileName>factur-x.xml</fx:DocumentFileName>
	<fx:Version>2.3</fx:Version>
	<fx:ConformanceLevel>Extended</fx:ConformanceLevel>
</rdf:Description>
```

### After:

```
<rdf:Description xmlns:fx="urn:factur-x:pdfa:CrossIndustryDocument:invoice:1p0#" rdf:about="">
	<fx:DocumentType>INVOICE</fx:DocumentType>
	<fx:DocumentFileName>factur-x.xml</fx:DocumentFileName>
	<fx:Version>2.3</fx:Version>
	<fx:ConformanceLevel>EXTENDED</fx:ConformanceLevel>
</rdf:Description>
```