### PR TITLE
Invoice descriptor23 cii writer update

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -36,7 +36,7 @@ namespace s2industries.ZUGFeRD
 
         /// <summary>
         /// Saves the given invoice to the given stream.
-        /// Make sure that the stream is open and writeable. Otherwise, an IllegalStreamException will be thron.
+        /// Make sure that the stream is open and writeable. Otherwise, an IllegalStreamException will be thrown.
         /// </summary>
         /// <param name="descriptor">The invoice object that should be saved</param>
         /// <param name="stream">The target stream for saving the invoice</param>
@@ -79,7 +79,7 @@ namespace s2industries.ZUGFeRD
             Writer.WriteStartElement("rsm", "ExchangedDocumentContext");
             if (this.Descriptor.IsTest)
             {
-                Writer.WriteStartElement("ram", "TestIndicator");
+                Writer.WriteStartElement("ram", "TestIndicator", Profile.Extended);
                 Writer.WriteElementString("udt", "Indicator", "true");
                 Writer.WriteEndElement(); // !ram:TestIndicator
             }
@@ -102,10 +102,9 @@ namespace s2industries.ZUGFeRD
             //Gruppierung der Eigenschaften, die das gesamte Dokument betreffen.
             Writer.WriteStartElement("rsm", "ExchangedDocument");
             Writer.WriteElementString("ram", "ID", this.Descriptor.InvoiceNo); //Rechnungsnummer
-            Writer.WriteOptionalElementString("ram", "Name", this.Descriptor.Name, Profile.Extended); //Dokumentenart (Freitext)
+            Writer.WriteOptionalElementString("ram", "Name", this.Descriptor.Name, Profile.Extended); //Dokumentenart (Freitext), ISO 15000-5:2014, Anhang B
             Writer.WriteElementString("ram", "TypeCode", String.Format("{0}", _encodeInvoiceType(this.Descriptor.Type))); //Code für den Rechnungstyp
-                                                                                                                          //ToDo: LanguageID      //Sprachkennzeichen
-                                                                                                                          //ToDo: IncludedNote    //Freitext zur Rechnung
+
             if (this.Descriptor.InvoiceDate.HasValue)
             {
                 Writer.WriteStartElement("ram", "IssueDateTime");
@@ -115,16 +114,22 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteEndElement(); // !udt:DateTimeString
                 Writer.WriteEndElement(); // !IssueDateTime
             }
-            _writeNotes(Writer, this.Descriptor.Notes, ALL_PROFILES ^ Profile.Minimum);
+
+            //ToDo: CopyIndicator                // BT-X-3, Kopiekennzeichen, Extended
+            //ToDo: LanguageID                  // BT-X-4, Sprachkennzeichen, Extended
+
+            _writeNotes(Writer, this.Descriptor.Notes, ALL_PROFILES ^ Profile.Minimum); // BG-1, BT-X-5, BT-22, BT-21
+
+            //ToDo: EffectiveSpecifiedPeriod    // BT-X-6, Vertragliches Fälligkeitsdatum der Rechnung, Extended
+
             Writer.WriteEndElement(); // !rsm:ExchangedDocument
             #endregion
 
-
-            #region SpecifiedSupplyChainTradeTransaction
+            #region SupplyChainTradeTransaction
             //Gruppierung der Informationen zum Geschäftsvorfall
             Writer.WriteStartElement("rsm", "SupplyChainTradeTransaction");
 
-            #region  IncludedSupplyChainTradeLineItem
+            #region IncludedSupplyChainTradeLineItem
             foreach (TradeLineItem tradeLineItem in this.Descriptor.TradeLineItems)
             {
                 Writer.WriteStartElement("ram", "IncludedSupplyChainTradeLineItem");
@@ -134,27 +139,33 @@ namespace s2industries.ZUGFeRD
                 if (tradeLineItem.AssociatedDocument != null)
                 {
                     Writer.WriteStartElement("ram", "AssociatedDocumentLineDocument", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+                    // Kennung der Rechnungsposition, BT-126
                     if (!String.IsNullOrWhiteSpace(tradeLineItem.AssociatedDocument.LineID))
                     {
                         Writer.WriteElementString("ram", "LineID", tradeLineItem.AssociatedDocument.LineID);
                     }
+                    // ID der übergeordneten Zeile, BT-X-304, Extended
                     // It is necessary that Parent Line Id be written directly under LineId
                     if (!String.IsNullOrWhiteSpace(tradeLineItem.AssociatedDocument.ParentLineID))
                     {
-                        Writer.WriteElementString("ram", "ParentLineID", tradeLineItem.AssociatedDocument.ParentLineID);
+                        Writer.WriteElementString("ram", "ParentLineID", tradeLineItem.AssociatedDocument.ParentLineID, Profile.Extended);
                     }
+                    // Typ der Rechnungsposition (Code), BT-X-7, Extended
                     if (tradeLineItem.AssociatedDocument.LineStatusCode.HasValue)
                     {
-                        Writer.WriteElementString("ram", "LineStatusCode", tradeLineItem.AssociatedDocument.LineStatusCode.Value.EnumValueToString());
+                        Writer.WriteElementString("ram", "LineStatusCode", tradeLineItem.AssociatedDocument.LineStatusCode.Value.EnumValueToString(), Profile.Extended);
                     }
+                    // Untertyp der Rechnungsposition, BT-X-8, Extended
                     if (tradeLineItem.AssociatedDocument.LineStatusReasonCode.HasValue)
                     {
-                        Writer.WriteElementString("ram", "LineStatusReasonCode", tradeLineItem.AssociatedDocument.LineStatusReasonCode.Value.EnumToString());
+                        Writer.WriteElementString("ram", "LineStatusReasonCode", tradeLineItem.AssociatedDocument.LineStatusReasonCode.Value.EnumToString(), Profile.Extended);
                     }
                     _writeNotes(Writer, tradeLineItem.AssociatedDocument.Notes, ALL_PROFILES ^ Profile.Minimum ^ Profile.BasicWL);
                     Writer.WriteEndElement(); // ram:AssociatedDocumentLineDocument(Basic|Comfort|Extended|XRechnung)
                 }
                 #endregion
+
+                // ToDo: IncludedNote            // BT-127, Detailinformationen zum Freitext zur Position, Basic+Comfort+Extended+XRechnung
 
                 // handelt es sich um einen Kommentar?
                 bool isCommentItem = false;
@@ -174,35 +185,30 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteOptionalElementString("ram", "SellerAssignedID", tradeLineItem.SellerAssignedID, Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
                 Writer.WriteOptionalElementString("ram", "BuyerAssignedID", tradeLineItem.BuyerAssignedID, Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
+                // ToDo: IndustryAssignedID     // BT-X-532, Von der Industrie zugewiesene Produktkennung
+                // ToDo: ModelID                // BT-X-533, Modelkennung des Artikels
+
                 // BT-153
                 Writer.WriteOptionalElementString("ram", "Name", tradeLineItem.Name, Profile.Basic | Profile.Comfort | Profile.Extended);
                 Writer.WriteOptionalElementString("ram", "Name", isCommentItem ? "TEXT" : tradeLineItem.Name, Profile.XRechnung1 | Profile.XRechnung); // XRechnung erfordert einen Item-Namen (BR-25)
 
                 Writer.WriteOptionalElementString("ram", "Description", tradeLineItem.Description, Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
-                if (tradeLineItem.ApplicableProductCharacteristics != null && tradeLineItem.ApplicableProductCharacteristics.Any())
+                // ToDo: BatchID                // BT-X-534, Kennung der Charge (des Loses) des Artikels
+                // ToDo: BrandName              // BT-X-535, Markenname des Artikels
+                // ToDo: ModelName              // BT-X-536, Modellbezeichnung des Artikels
+
+                // BG-32, Artikelattribute
+                if (tradeLineItem.ApplicableProductCharacteristics?.Any() == true)
                 {
                     foreach (var productCharacteristic in tradeLineItem.ApplicableProductCharacteristics)
                     {
                         Writer.WriteStartElement("ram", "ApplicableProductCharacteristic");
+                        // ToDo: TypeCode        // BT-X-11, Art der Produkteigenschaft (Code), Extended
                         Writer.WriteOptionalElementString("ram", "Description", productCharacteristic.Description);
-                        Writer.WriteOptionalElementString("ram", "Value", productCharacteristic.Value);
+                        // ToDo: ValueMeasure    // BT-X-12, Wert der Produkteigenschaft (numerische Messgröße), mit unitCode, Extended
+                        Writer.WriteOptionalElementString("ram", "Value", productCharacteristic.Value); // BT-161
                         Writer.WriteEndElement(); // !ram:ApplicableProductCharacteristic
-                    }
-                }
-
-                if (tradeLineItem.IncludedReferencedProducts != null && tradeLineItem.IncludedReferencedProducts.Any())
-                {
-                    foreach (var includedItem in tradeLineItem.IncludedReferencedProducts)
-                    {
-                        Writer.WriteStartElement("ram", "IncludedReferencedProduct");
-                        Writer.WriteOptionalElementString("ram", "Name", includedItem.Name);
-
-                        if (includedItem.UnitQuantity.HasValue)
-                        {
-                            _writeElementWithAttributeWithPrefix(Writer, "ram", "UnitQuantity", "unitCode", includedItem.UnitCode.Value.EnumToString(), _formatDecimal(includedItem.UnitQuantity, 4));
-                        }
-                        Writer.WriteEndElement(); // !ram:IncludedReferencedProduct
                     }
                 }
 
@@ -223,6 +229,25 @@ namespace s2industries.ZUGFeRD
                         Writer.WriteEndElement(); // !ram::ClassCode
                         Writer.WriteOptionalElementString("ram", "ClassName", designatedProductClassification.ClassName);
                         Writer.WriteEndElement(); // !ram:DesignatedProductClassification
+                    }
+                }
+
+                // ToDo: IndividualTradeProductInstance, BG-X-84, Artikel (Handelsprodukt) Instanzen
+                // ToDo: OriginTradeCountry + ID, BT-159, Detailinformationen zur Produktherkunft, Comfort+Extended+XRechnung
+
+                if ((descriptor.Profile == Profile.Extended) && (tradeLineItem.IncludedReferencedProducts?.Any() == true)) // BG-X-1
+                {
+                    foreach (var includedItem in tradeLineItem.IncludedReferencedProducts)
+                    {
+                        Writer.WriteStartElement("ram", "IncludedReferencedProduct");
+                        // ToDo: GlobalID, SellerAssignedID, BuyerAssignedID, IndustryAssignedID, Description
+                        Writer.WriteOptionalElementString("ram", "Name", includedItem.Name); // BT-X-18
+
+                        if (includedItem.UnitQuantity.HasValue)
+                        {
+                            _writeElementWithAttributeWithPrefix(Writer, "ram", "UnitQuantity", "unitCode", includedItem.UnitCode.Value.EnumToString(), _formatDecimal(includedItem.UnitQuantity, 4));
+                        }
+                        Writer.WriteEndElement(); // !ram:IncludedReferencedProduct
                     }
                 }
 
@@ -428,13 +453,12 @@ namespace s2industries.ZUGFeRD
 
                 #region SpecifiedLineTradeSettlement
                 Writer.WriteStartElement("ram", "SpecifiedLineTradeSettlement", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+
                 #region ApplicableTradeTax
                 Writer.WriteStartElement("ram", "ApplicableTradeTax", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
                 Writer.WriteElementString("ram", "TypeCode", tradeLineItem.TaxType.EnumToString());
                 Writer.WriteOptionalElementString("ram", "ExemptionReason", _translateTaxCategoryCode(tradeLineItem.TaxCategoryCode), Profile.Extended);
                 Writer.WriteElementString("ram", "CategoryCode", tradeLineItem.TaxCategoryCode.EnumToString()); // BT-151
-
-
 
                 if (tradeLineItem.TaxCategoryCode != TaxCategoryCodes.O) // notwendig, damit die Validierung klappt
                 {
@@ -669,7 +693,7 @@ namespace s2industries.ZUGFeRD
             {
                 foreach (AdditionalReferencedDocument document in this.Descriptor.AdditionalReferencedDocuments)
                 {
-                    _writeAdditionalReferencedDocument(document, Profile.Comfort | Profile.Extended | Profile.XRechnung); // BG-24         
+                    _writeAdditionalReferencedDocument(document, Profile.Comfort | Profile.Extended | Profile.XRechnung); // BG-24
                 }
             }
             #endregion
@@ -1209,7 +1233,7 @@ namespace s2industries.ZUGFeRD
 
             #endregion
 
-            Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeTransaction
+            Writer.WriteEndElement(); // !ram:SupplyChainTradeTransaction
             #endregion
 
             Writer.WriteEndElement(); // !ram:Invoice
@@ -1218,6 +1242,7 @@ namespace s2industries.ZUGFeRD
 
             stream.Seek(streamPosition, SeekOrigin.Begin);
         } // !Save()
+
 
         private void _writeAdditionalReferencedDocument(AdditionalReferencedDocument document, Profile profile)
         {
@@ -1261,16 +1286,18 @@ namespace s2industries.ZUGFeRD
 
         private void _writeOptionalAmount(ProfileAwareXmlTextWriter writer, string prefix, string tagName, decimal? value, int numDecimals = 2, bool forceCurrency = false, Profile profile = Profile.Unknown)
         {
-            if (value.HasValue)
+            if (!value.HasValue)
             {
-                writer.WriteStartElement(prefix, tagName, profile);
-                if (forceCurrency)
-                {
-                    writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
-                }
-                writer.WriteValue(_formatDecimal(value.Value, numDecimals));
-                writer.WriteEndElement(); // !tagName
+                return;
             }
+
+            writer.WriteStartElement(prefix, tagName, profile);
+            if (forceCurrency)
+            {
+                writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
+            }
+            writer.WriteValue(_formatDecimal(value.Value, numDecimals));
+            writer.WriteEndElement(); // !tagName
         } // !_writeOptionalAmount()
 
 
@@ -1312,6 +1339,11 @@ namespace s2industries.ZUGFeRD
 
         private void _writeOptionalTaxes(ProfileAwareXmlTextWriter writer)
         {
+            if (this.Descriptor.Taxes?.Count == 0)
+            {
+                return;
+            }
+
             foreach (Tax tax in this.Descriptor.Taxes)
             {
                 writer.WriteStartElement("ram", "ApplicableTradeTax");
@@ -1326,13 +1358,13 @@ namespace s2industries.ZUGFeRD
                 writer.WriteValue(_formatDecimal(tax.BasisAmount));
                 writer.WriteEndElement(); // !BasisAmount
 
-                if (tax.AllowanceChargeBasisAmount.HasValue && tax.AllowanceChargeBasisAmount.Value != 0)
+                if (tax.AllowanceChargeBasisAmount.HasValue && (tax.AllowanceChargeBasisAmount.Value != 0))
                 {
                     writer.WriteStartElement("ram", "AllowanceChargeBasisAmount", Profile.Extended);
                     writer.WriteValue(_formatDecimal(tax.AllowanceChargeBasisAmount));
                     writer.WriteEndElement(); // !AllowanceChargeBasisAmount
                 }
-                if (tax.LineTotalBasisAmount.HasValue && tax.LineTotalBasisAmount.Value != 0)
+                if (tax.LineTotalBasisAmount.HasValue && (tax.LineTotalBasisAmount.Value != 0))
                 {
                     writer.WriteStartElement("ram", "LineTotalBasisAmount", Profile.Extended);
                     writer.WriteValue(_formatDecimal(tax.LineTotalBasisAmount));
@@ -1357,22 +1389,24 @@ namespace s2industries.ZUGFeRD
 
         private void _writeNotes(ProfileAwareXmlTextWriter writer, List<Note> notes, Profile profile = Profile.Unknown)
         {
-            if (notes.Count > 0)
+            if (notes?.Count == 0)
             {
-                foreach (Note note in notes)
+                return;
+            }
+
+            foreach (Note note in notes)
+            {
+                writer.WriteStartElement("ram", "IncludedNote", profile);
+                if (note.ContentCode != ContentCodes.Unknown)
                 {
-                    writer.WriteStartElement("ram", "IncludedNote", profile);
-                    if (note.ContentCode != ContentCodes.Unknown)
-                    {
-                        writer.WriteElementString("ram", "ContentCode", note.ContentCode.EnumToString());
-                    }
-                    writer.WriteOptionalElementString("ram", "Content", note.Content);
-                    if (note.SubjectCode != SubjectCodes.Unknown)
-                    {
-                        writer.WriteElementString("ram", "SubjectCode", note.SubjectCode.EnumToString());
-                    }
-                    writer.WriteEndElement();
+                    writer.WriteElementString("ram", "ContentCode", note.ContentCode.EnumToString());
                 }
+                writer.WriteOptionalElementString("ram", "Content", note.Content);
+                if (note.SubjectCode != SubjectCodes.Unknown)
+                {
+                    writer.WriteElementString("ram", "SubjectCode", note.SubjectCode.EnumToString());
+                }
+                writer.WriteEndElement();
             }
         } // !_writeNotes()
 
@@ -1521,7 +1555,7 @@ namespace s2industries.ZUGFeRD
                 }
             }
 
-            if ((party.GlobalID != null) && !String.IsNullOrWhiteSpace(party.GlobalID.ID) && party.GlobalID.SchemeID.HasValue && (party.GlobalID.SchemeID.Value != GlobalIDSchemeIdentifiers.Unknown))
+            if (!String.IsNullOrWhiteSpace(party.GlobalID?.ID) && party.GlobalID.SchemeID.HasValue && (party.GlobalID.SchemeID.Value != GlobalIDSchemeIdentifiers.Unknown))
             {
                 writer.WriteStartElement("ram", "GlobalID");
                 writer.WriteAttributeString("schemeID", party.GlobalID.SchemeID.Value.EnumToString());
@@ -1541,7 +1575,10 @@ namespace s2industries.ZUGFeRD
                 writer.WriteStartElement("ram", "PostalTradeAddress");
                 writer.WriteOptionalElementString("ram", "PostcodeCode", party.Postcode); // buyer: BT-53
                 writer.WriteOptionalElementString("ram", "LineOne", string.IsNullOrWhiteSpace(party.ContactName) ? party.Street : party.ContactName); // buyer: BT-50
-                if (!string.IsNullOrWhiteSpace(party.ContactName)) { writer.WriteOptionalElementString("ram", "LineTwo", party.Street); } // buyer: BT-51
+                if (!string.IsNullOrWhiteSpace(party.ContactName))
+                {
+                    writer.WriteOptionalElementString("ram", "LineTwo", party.Street); // buyer: BT-51
+                }
                 writer.WriteOptionalElementString("ram", "LineThree", party.AddressLine3); // buyer: BT-163
                 writer.WriteOptionalElementString("ram", "CityName", party.City); // buyer: BT-52
 
@@ -1554,36 +1591,31 @@ namespace s2industries.ZUGFeRD
                 writer.WriteEndElement(); // !PostalTradeAddress
             }
 
-            if (electronicAddress != null)
+            if (!String.IsNullOrWhiteSpace(electronicAddress?.Address))
             {
-                if (!String.IsNullOrWhiteSpace(electronicAddress.Address))
+                writer.WriteStartElement("ram", "URIUniversalCommunication");
+                writer.WriteStartElement("ram", "URIID");
+                writer.WriteAttributeString("schemeID", electronicAddress.ElectronicAddressSchemeID.EnumToString());
+                writer.WriteValue(electronicAddress.Address);
+                writer.WriteEndElement();
+                writer.WriteEndElement();
+            }
+
+            if (taxRegistrations?.Count > 0)
+            {
+                // for seller: BT-31
+                // for buyer : BT-48
+                foreach (TaxRegistration _reg in taxRegistrations.Where(tr => !String.IsNullOrWhiteSpace(tr.No)))
                 {
-                    writer.WriteStartElement("ram", "URIUniversalCommunication");
-                    writer.WriteStartElement("ram", "URIID");
-                    writer.WriteAttributeString("schemeID", electronicAddress.ElectronicAddressSchemeID.EnumToString());
-                    writer.WriteValue(electronicAddress.Address);
+                    writer.WriteStartElement("ram", "SpecifiedTaxRegistration");
+                    writer.WriteStartElement("ram", "ID");
+                    writer.WriteAttributeString("schemeID", _reg.SchemeID.EnumToString());
+                    writer.WriteValue(_reg.No);
                     writer.WriteEndElement();
                     writer.WriteEndElement();
                 }
             }
 
-            if (taxRegistrations != null)
-            {
-                // for seller: BT-31
-                // for buyer : BT-48
-                foreach (TaxRegistration _reg in taxRegistrations)
-                {
-                    if (!String.IsNullOrWhiteSpace(_reg.No))
-                    {
-                        writer.WriteStartElement("ram", "SpecifiedTaxRegistration");
-                        writer.WriteStartElement("ram", "ID");
-                        writer.WriteAttributeString("schemeID", _reg.SchemeID.EnumToString());
-                        writer.WriteValue(_reg.No);
-                        writer.WriteEndElement();
-                        writer.WriteEndElement();
-                    }
-                }
-            }
             writer.WriteEndElement(); // !*Party
         } // !_writeOptionalParty()
 
@@ -1594,7 +1626,6 @@ namespace s2industries.ZUGFeRD
             {
                 return;
             }
-
 
             writer.WriteStartElement(prefix, contactTag, profile);
 
@@ -1718,7 +1749,7 @@ namespace s2industries.ZUGFeRD
 
 
         /// <summary>
-        /// This function is implemented in class InvoiceDescriptor22Writer.
+        /// This function is implemented in class InvoiceDescriptor23Writer.
         /// </summary>
         internal override bool Validate(InvoiceDescriptor descriptor, bool throwExceptions = true)
         {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1339,7 +1339,7 @@ namespace s2industries.ZUGFeRD
 
         private void _writeOptionalTaxes(ProfileAwareXmlTextWriter writer)
         {
-            if (this.Descriptor.Taxes?.Count == 0)
+            if (this.Descriptor.Taxes?.Any() != true)
             {
                 return;
             }
@@ -1389,7 +1389,7 @@ namespace s2industries.ZUGFeRD
 
         private void _writeNotes(ProfileAwareXmlTextWriter writer, List<Note> notes, Profile profile = Profile.Unknown)
         {
-            if (notes?.Count == 0)
+            if (notes?.Any() != true)
             {
                 return;
             }


### PR DESCRIPTION
Updates for InvoiceDescriptor23CIIWriter.cs (`ZUGFeRD` folder)
- Fixed TestIndicator: added Extended param
- Fixed AssociatedDocumentLineDocument: some elements were missing Extended param
- Fixed order: IncludedReferencedProducts after DesignatedProductClassification (within SpecifiedTradeProduct)
- A couple of early returns to reduce nesting
- Added ToDo's for some more not-implemented Extended elements
- Added some element comments incl. the BT name/numbers
- Fixed some typos