### PR TITLE
(Fix) TradingBusinessName within legal organisation is independent of ID

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1472,16 +1472,14 @@ namespace s2industries.ZUGFeRD
                 {
                     writer.WriteElementString("ram", "ID", legalOrganization.ID.ID);
                 }
-
-
-                // filter according to https://github.com/stephanstapel/ZUGFeRD-csharp/pull/221
-                if ((this.Descriptor.Profile == Profile.Extended) ||
-                    ((partyType == PartyTypes.SellerTradeParty) && (this.Descriptor.Profile != Profile.Minimum) ) ||                    
-                    ((partyType == PartyTypes.BuyerTradeParty) && this.Descriptor.Profile.In(Profile.Comfort, Profile.XRechnung1, Profile.XRechnung, Profile.Extended)))
-                {
-                    writer.WriteOptionalElementString("ram", "TradingBusinessName", legalOrganization.TradingBusinessName, this.Descriptor.Profile);
-                }
             }
+			// filter according to https://github.com/stephanstapel/ZUGFeRD-csharp/pull/221
+			if ((this.Descriptor.Profile == Profile.Extended) ||
+				((partyType == PartyTypes.SellerTradeParty) && (this.Descriptor.Profile != Profile.Minimum)) ||
+				((partyType == PartyTypes.BuyerTradeParty) && this.Descriptor.Profile.In(Profile.Comfort, Profile.XRechnung1, Profile.XRechnung, Profile.Extended)))
+			{
+				writer.WriteOptionalElementString("ram", "TradingBusinessName", legalOrganization.TradingBusinessName, this.Descriptor.Profile);
+			}
             writer.WriteEndElement();
         } // !_writeOptionalLegalOrganization()
 


### PR DESCRIPTION
In `InvoiceDescriptor23CIIWriter`:
The **`TradingBusinessName`** element per documentation is independent of the legal organisations' ID,
which is fixed by this PR.