### PR TITLE
(Fix) LineID handling for line item's BuyerOrderReferencedDocument (CII)

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD20Tests.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -195,7 +195,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
             Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
 
-            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", 
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.",
                 invoiceDescriptor.GetTradePaymentTerms().FirstOrDefault().Description.Trim());
         } // !TestLoadingSepaPreNotification()
 
@@ -219,7 +219,8 @@ namespace s2industries.ZUGFeRD.Test
                 grossUnitPrice: 9.9m,
                 categoryCode: TaxCategoryCodes.S,
                 taxPercent: 19.0m,
-                taxType: TaxTypes.VAT);
+                taxType: TaxTypes.VAT,
+                buyerOrderLineID: "1");
             d.AddTradeLineItem(
                 lineID: "2",
                 id: new GlobalID(GlobalIDSchemeIdentifiers.EAN, "4000050986428"),
@@ -574,7 +575,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.IsNotNull(lineItem);
             lineItem.Description = "This is line item TB100A4";
             lineItem.BuyerAssignedID = "0815";
-            lineItem.SetOrderReferencedDocument("12345", timestamp);
+            lineItem.SetOrderReferencedDocument("12345", timestamp, "1");
             lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp);
             lineItem.SetContractReferencedDocument("12345", timestamp);
 
@@ -781,6 +782,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(TaxCategoryCodes.S, loadedLineItem.TaxCategoryCode);
             Assert.AreEqual(19m, loadedLineItem.TaxPercent);
 
+            Assert.AreEqual("1", loadedLineItem.BuyerOrderReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.BuyerOrderReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.BuyerOrderReferencedDocument.IssueDateTime);
             Assert.AreEqual("12345", loadedLineItem.DeliveryNoteReferencedDocument.ID);

--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,7 +37,7 @@ namespace s2industries.ZUGFeRD.Test
     public class ZUGFeRD22Tests : TestBase
     {
         private InvoiceProvider _InvoiceProvider = new InvoiceProvider();
-        
+
 
         [TestMethod]
         public void TestLineStatusCode()
@@ -560,7 +560,7 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
             Assert.AreEqual(loadedInvoice.OrderNo, uuid);
             Assert.AreEqual(loadedInvoice.OrderDate, orderDate); // explicitly not to be set in XRechnung, see separate test case
-        } // !TestBuyerOrderReferencedDocumentWithExtended() 
+        } // !TestBuyerOrderReferencedDocumentWithExtended()
 
 
         [TestMethod]
@@ -581,7 +581,7 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
             Assert.AreEqual(loadedInvoice.OrderNo, uuid);
             Assert.AreEqual(loadedInvoice.OrderDate, null); // explicitly not to be set in XRechnung, see separate test case
-        } // !TestBuyerOrderReferencedDocumentWithXRechnung() 
+        } // !TestBuyerOrderReferencedDocumentWithXRechnung()
 
 
         [TestMethod]
@@ -633,7 +633,7 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
             Assert.AreEqual(loadedInvoice.ContractReferencedDocument.ID, uuid);
             Assert.AreEqual(loadedInvoice.ContractReferencedDocument.IssueDateTime, issueDateTime); // explicitly not to be set in XRechnung, see separate test case
-        } // !TestContractReferencedDocumentWithExtended()        
+        } // !TestContractReferencedDocumentWithExtended()
 
 
         [TestMethod]
@@ -977,7 +977,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
             Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
 
-            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.", 
+            Assert.AreEqual("Der Betrag in Höhe von EUR 529,87 wird am 20.03.2018 von Ihrem Konto per SEPA-Lastschrift eingezogen.",
                 invoiceDescriptor.GetTradePaymentTerms().FirstOrDefault().Description.Trim());
         } // !TestLoadingSepaPreNotification()
 
@@ -1280,7 +1280,7 @@ namespace s2industries.ZUGFeRD.Test
                 AddressLine3 = "EG links",
                 CountrySubdivisionName = "Bayern",
                 Country = CountryCodes.DE
-            };            
+            };
 
             MemoryStream ms = new MemoryStream();
 
@@ -1291,7 +1291,7 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
             Assert.IsNull(loadedInvoice.Invoicee);
             Assert.IsNotNull(loadedInvoice.Seller);
-            Assert.IsNotNull(loadedInvoice.Payee);           
+            Assert.IsNotNull(loadedInvoice.Payee);
 
             Assert.AreEqual(loadedInvoice.Seller.Name, "Lieferant GmbH");
             Assert.AreEqual(loadedInvoice.Seller.Street, "Lieferantenstraße 20");
@@ -1337,7 +1337,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(loadedInvoice.Payee.CountrySubdivisionName, "Bayern");
             Assert.AreEqual(loadedInvoice.Payee.Country, CountryCodes.DE);
 
-            // 
+            //
             // Check the output in the XML for Comfort.
             // REM: In Comfort only ID, GlobalID, Name, and SpecifiedLegalOrganization are allowed.
 
@@ -1817,7 +1817,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.IsNotNull(lineItem);
             lineItem.Description = "This is line item TB100A4";
             lineItem.BuyerAssignedID = "0815";
-            lineItem.SetOrderReferencedDocument("12345", timestamp);
+            lineItem.SetOrderReferencedDocument("12345", timestamp, "1");
             lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp);
             lineItem.SetContractReferencedDocument("12345", timestamp);
 
@@ -1846,7 +1846,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(InvoiceDescriptor.GetVersion(ms), ZUGFeRDVersion.Version23);
 
             ms.Seek(0, SeekOrigin.Begin);
-            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);            
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
 
             Assert.AreEqual("471102", loadedInvoice.InvoiceNo);
             Assert.AreEqual(new DateTime(2018, 03, 05), loadedInvoice.InvoiceDate);
@@ -1883,8 +1883,8 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual("Project 123", loadedInvoice.SpecifiedProcuringProject.Name);
 
             Assert.AreEqual("Ultimate Ship To", loadedInvoice.UltimateShipTo.Name);
-            /** 
-             * @todo we can add further asserts for the remainder of properties 
+            /**
+             * @todo we can add further asserts for the remainder of properties
              */
 
             Assert.AreEqual<string>("123", loadedInvoice.ShipTo.ID.ID);
@@ -2026,6 +2026,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(TaxCategoryCodes.S, loadedLineItem.TaxCategoryCode);
             Assert.AreEqual(19m, loadedLineItem.TaxPercent);
 
+            Assert.AreEqual("1", loadedLineItem.BuyerOrderReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.BuyerOrderReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.BuyerOrderReferencedDocument.IssueDateTime);
             Assert.AreEqual("12345", loadedLineItem.DeliveryNoteReferencedDocument.ID);
@@ -2275,7 +2276,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(allowanceCharges[0].Amount, 10m);
             Assert.AreEqual(allowanceCharges[0].ChargePercentage, 12);
         } // !TestTradeAllowanceChargeWithExplicitPercentage()
-        
+
 
         [TestMethod]
         public void TestWriteAndReadDespatchAdviceDocumentReferenceXRechnung()
@@ -2301,7 +2302,7 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor invoice = _InvoiceProvider.CreateInvoice();
 
             invoice.TradeLineItems[0].AddSpecifiedTradeAllowanceCharge(true, CurrencyCodes.EUR, 198m, 19.8m, 10m, "Discount 10%");
-          
+
             MemoryStream ms = new MemoryStream();
             invoice.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);
             ms.Position = 0;
@@ -2432,7 +2433,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(DesignatedProductClassificationClassCodes.HS, loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ListID);
             Assert.AreEqual("List Version ID Value", loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ListVersionID);
             Assert.AreEqual("Class Code", loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassCode);
-            Assert.AreEqual("Class Name", loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassName);            
+            Assert.AreEqual("Class Name", loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassName);
 	    } // !TestDesignatedProductClassificationWithFullClassification()
 
 
@@ -2445,7 +2446,7 @@ namespace s2industries.ZUGFeRD.Test
                 DesignatedProductClassificationClassCodes.HS,
                 null,
                 "Class Code",
-                "Class Name"							
+                "Class Name"
 				);
 
 			MemoryStream ms = new MemoryStream();
@@ -2458,7 +2459,7 @@ namespace s2industries.ZUGFeRD.Test
 			Assert.AreEqual(DesignatedProductClassificationClassCodes.HS, desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ListID);
             Assert.IsNull(desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ListVersionID);
             Assert.AreEqual("Class Code", desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassCode);
-            Assert.AreEqual("Class Name", desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassName);					
+            Assert.AreEqual("Class Name", desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassName);
 		} // !TestDesignatedProductClassificationWithEmptyVersionId()
 
 
@@ -2486,7 +2487,7 @@ namespace s2industries.ZUGFeRD.Test
 
             Assert.AreEqual(DesignatedProductClassificationClassCodes.HS, loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ListID);
             Assert.AreEqual(String.Empty, loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ListVersionID);
-            Assert.AreEqual("Class Code", loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassCode);			
+            Assert.AreEqual("Class Code", loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassCode);
 			Assert.AreEqual(String.Empty, loadedInvoice.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassName);
 		} // !TestDesignatedProductClassificationWithEmptyListIdAndVersionId()
 
@@ -2508,7 +2509,7 @@ namespace s2industries.ZUGFeRD.Test
 			Assert.AreEqual(DesignatedProductClassificationClassCodes.HS, desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ListID);
             Assert.IsNull(desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ListVersionID);
             Assert.IsNull(desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassCode);
-			Assert.IsNull(desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassName);			
+			Assert.IsNull(desc.TradeLineItems.First().GetDesignatedProductClassifications().First().ClassName);
         } // !TestDesignatedProductClassificationWithoutAnyOptionalInformation()
 
 
@@ -2594,7 +2595,7 @@ namespace s2industries.ZUGFeRD.Test
 
         [TestMethod]
         public void TestPaymentTermsSingleCardinalityStructured()
-        {                        
+        {
             DateTime timestamp = DateTime.Now.Date;
             var desc = _InvoiceProvider.CreateInvoice();
             desc.GetTradePaymentTerms().Clear();
@@ -2720,7 +2721,7 @@ namespace s2industries.ZUGFeRD.Test
             {
                 d.Save(stream, ZUGFeRDVersion.Version23, Profile.XRechnung);
                 stream.Seek(0, SeekOrigin.Begin);
-                
+
                 // test the raw xml file
                 string content = Encoding.UTF8.GetString(stream.ToArray());
 
@@ -2806,7 +2807,7 @@ namespace s2industries.ZUGFeRD.Test
             {
                 d.Save(stream, ZUGFeRDVersion.Version23, Profile.XRechnung);
                 stream.Seek(0, SeekOrigin.Begin);
-                
+
                 // test the raw xml file
                 string content = Encoding.UTF8.GetString(stream.ToArray());
 

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -1023,7 +1023,7 @@ namespace s2industries.ZUGFeRD
         /// <param name="categoryCode"></param>
         /// <param name="allowanceChargeBasisAmount"></param>
         /// <param name="exemptionReasonCode"></param>
-        /// <param name="exemptionReason"></param>        
+        /// <param name="exemptionReason"></param>
         /// <param name="lineTotalBasisAmount">A monetary value used as the line total basis on which this trade related tax, levy or duty is calculated</param>
         public void AddApplicableTradeTax(decimal basisAmount,
             decimal percent,
@@ -1196,7 +1196,8 @@ namespace s2industries.ZUGFeRD
         /// <param name="buyerAssignedID"></param>
         /// <param name="deliveryNoteID"></param>
         /// <param name="deliveryNoteDate"></param>
-        /// <param name="buyerOrderID"></param>
+        /// <param name="buyerOrderLineID"></param>
+        /// <param name="buyerOrderID">only Extended</param>
         /// <param name="buyerOrderDate"></param>
         /// <param name="billingPeriodStart"></param>
         /// <param name="billingPeriodEnd"></param>
@@ -1216,7 +1217,7 @@ namespace s2industries.ZUGFeRD
                                      GlobalID id = null,
                                      string sellerAssignedID = "", string buyerAssignedID = "",
                                      string deliveryNoteID = "", DateTime? deliveryNoteDate = null,
-                                     string buyerOrderID = "", DateTime? buyerOrderDate = null,
+                                     string buyerOrderLineID = "", string buyerOrderID = "", DateTime? buyerOrderDate = null,
                                      DateTime? billingPeriodStart = null, DateTime? billingPeriodEnd = null)
         {
             return AddTradeLineItem(lineID: _getNextLineId(),
@@ -1237,7 +1238,8 @@ namespace s2industries.ZUGFeRD
                              buyerAssignedID: buyerAssignedID,
                              deliveryNoteID: deliveryNoteID,
                              deliveryNoteDate: deliveryNoteDate,
-                             buyerOrderID: buyerOrderID,
+							 buyerOrderLineID: buyerOrderLineID,
+                             buyerOrderID: buyerOrderID, // Extended!
                              buyerOrderDate: buyerOrderDate,
                              billingPeriodStart: billingPeriodStart,
                              billingPeriodEnd: billingPeriodEnd);
@@ -1264,7 +1266,7 @@ namespace s2industries.ZUGFeRD
                                      GlobalID id = null,
                                      string sellerAssignedID = "", string buyerAssignedID = "",
                                      string deliveryNoteID = "", DateTime? deliveryNoteDate = null,
-                                     string buyerOrderID = "", DateTime? buyerOrderDate = null,
+                                     string buyerOrderLineID = "", string buyerOrderID = "", DateTime? buyerOrderDate = null,
                                      DateTime? billingPeriodStart = null, DateTime? billingPeriodEnd = null)
         {
             if (String.IsNullOrWhiteSpace(lineID))
@@ -1309,9 +1311,9 @@ namespace s2industries.ZUGFeRD
                 newItem.SetDeliveryNoteReferencedDocument(deliveryNoteID, deliveryNoteDate);
             }
 
-            if (!String.IsNullOrWhiteSpace(buyerOrderID) || buyerOrderDate.HasValue)
+            if (!String.IsNullOrWhiteSpace(buyerOrderLineID) || buyerOrderDate.HasValue || !String.IsNullOrWhiteSpace(buyerOrderID))
             {
-                newItem.SetOrderReferencedDocument(buyerOrderID, buyerOrderDate);
+                newItem.SetOrderReferencedDocument(buyerOrderID, buyerOrderDate, buyerOrderLineID);
             }
 
             this.TradeLineItems.Add(newItem);
@@ -1319,6 +1321,13 @@ namespace s2industries.ZUGFeRD
         } // !AddTradeLineItem()
 
 
+        /// <summary>
+        /// Sets up the payment means.
+        /// </summary>
+        /// <param name="paymentCode">Payment means type code.</param>
+        /// <param name="information">Additional information.</param>
+        /// <param name="identifikationsnummer">SEPA creditor identifier.</param>
+        /// <param name="mandatsnummer">SEPA mandate reference.</param>
         public void SetPaymentMeans(PaymentMeansTypeCodes paymentCode, string information = "", string identifikationsnummer = null, string mandatsnummer = null)
         {
             this.PaymentMeans = new PaymentMeans
@@ -1332,7 +1341,7 @@ namespace s2industries.ZUGFeRD
 
 
         /// <summary>
-        ///     Sets up the payment means for SEPA direct debit.
+        /// Sets up the payment means for SEPA direct debit.
         /// </summary>
         public void SetPaymentMeansSepaDirectDebit(string sepaCreditorIdentifier, string sepaMandateReference, string information = "")
         {

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -29,7 +29,7 @@ namespace s2industries.ZUGFeRD
     {
         /// <summary>
         /// Parses the ZUGFeRD invoice from the given stream.
-        /// 
+        ///
         /// Make sure that the stream is open, otherwise an IllegalStreamException exception is thrown.
         /// Important: the stream will not be closed by this function.
         /// </summary>
@@ -340,7 +340,7 @@ namespace s2industries.ZUGFeRD
 
             return retval;
 
-        } // !Load()        
+        } // !Load()
 
 
         public override bool IsReadableByThisReaderVersion(Stream stream)
@@ -352,7 +352,7 @@ namespace s2industries.ZUGFeRD
                     "urn:cen.eu:en16931:2017#compliant#urn:zugferd.de:2p0:comfort", // Profil COMFORT
                     "urn:cen.eu:EN16931:2017#compliant#urn:zugferd.de:2p0:basic", // Profil BASIC
                     "urn:zugferd.de:2p0:basicwl", // Profil BASIC WL
-                    "urn:zugferd.de:2p0:minimum" // Profil MINIMUM                    
+                    "urn:zugferd.de:2p0:minimum" // Profil MINIMUM
                 };
 
             return _IsReadableByThisReaderVersion(stream, validURIs);
@@ -464,8 +464,8 @@ namespace s2industries.ZUGFeRD
                 item.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
                 {
                     ID = XmlUtils.NodeAsString(buyerOrderReferencedDocumentNode, "ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(buyerOrderReferencedDocumentNode, "ram:FormattedIssueDateTime", nsmgr),
-                    LineID = XmlUtils.NodeAsString(buyerOrderReferencedDocumentNode, "ram:BuyerOrderReferencedDocument/ram:LineID", nsmgr)
+                    LineID = XmlUtils.NodeAsString(buyerOrderReferencedDocumentNode, "ram:LineID", nsmgr),
+                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(buyerOrderReferencedDocumentNode, "ram:FormattedIssueDateTime", nsmgr)
                 };
             }
 

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -419,12 +419,13 @@ namespace s2industries.ZUGFeRD
         /// Please note that XRechnung/ FacturX allows a maximum of one such reference and will only output the referenced order line id
         /// but not issuer assigned id and date
         /// </summary>
-        public void SetOrderReferencedDocument(string orderReferencedId, DateTime? orderReferencedDate)
+        public void SetOrderReferencedDocument(string orderReferencedId, DateTime? orderReferencedDate, string orderReferencedLineId)
         {
             this.BuyerOrderReferencedDocument = new BuyerOrderReferencedDocument()
             {
                 ID = orderReferencedId,
-                IssueDateTime = orderReferencedDate
+                IssueDateTime = orderReferencedDate,
+                LineID = orderReferencedLineId
             };
         } // !SetOrderReferencedDocument()
 


### PR DESCRIPTION
For the `BuyerOrderReferencedDocument` (in line item) there was no way to set the `LineID` correctly,
thus resulting in potentially empty section and causing validation errors.

Related methods (AddTradeLineItem, SetOrderReferencedDocument) got a corresponding parameter added for the LineID.

Tests were adapted and ran successfully.

Also fixed a bug to read the LineID in `InvoiceDescriptor20Reader` (wrong XML selector).

Should resolve discussion https://github.com/stephanstapel/ZUGFeRD-csharp/discussions/468