### PR TITLE
Add quantity code EA

### DIFF
--- a/ZUGFeRD/QuantityCodes.cs
+++ b/ZUGFeRD/QuantityCodes.cs
@@ -111,6 +111,11 @@ namespace s2industries.ZUGFeRD
         DMT,
 
         /// <summary>
+        /// each: A unit of count defining the number of items regarded as separate units.
+        /// </summary>
+        EA,
+
+        /// <summary>
         /// Piece: A unit of count defining the number of pieces (piece: a single item, article or exemplar).
         /// </summary>
         /// <seealso cref="QuantityCodes.C62"/>


### PR DESCRIPTION
Quantity code EA ("each") is commonly used meaning "A unit of count defining the number of items regarded as separate units".