### PR TITLE
Fix rule regressions for 2 line item elements

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -2320,9 +2320,12 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(allowanceCharge.ChargeIndicator, false);//false = discount
             //CurrencyCodes are not written bei InvoiceDescriptor22Writer
             //Assert.AreEqual(allowanceCharge.Currency, CurrencyCodes.EUR);
-            Assert.AreEqual(allowanceCharge.BasisAmount, 198m);
+            if (profile != Profile.Basic)
+            {
+                Assert.AreEqual(allowanceCharge.BasisAmount, 198m);
+                Assert.AreEqual(allowanceCharge.ChargePercentage, 10m);
+            }
             Assert.AreEqual(allowanceCharge.ActualAmount, 19.8m);
-            Assert.AreEqual(allowanceCharge.ChargePercentage, 10m);
             Assert.AreEqual(allowanceCharge.Reason, "Discount 10%");
         } // !SpecifiedTradeAllowanceCharge()
 
@@ -2618,7 +2621,7 @@ namespace s2industries.ZUGFeRD.Test
             paymentTerm = loadedInvoice.GetTradePaymentTerms().LastOrDefault();
             Assert.IsNotNull(paymentTerm);
             Assert.IsNull(paymentTerm.PaymentTermsType);
-            Assert.AreEqual("3% Skonto innerhalb 10 Tagen bis 15.03.2018", paymentTerm.Description);            
+            Assert.AreEqual("3% Skonto innerhalb 10 Tagen bis 15.03.2018", paymentTerm.Description);
             Assert.IsNull(paymentTerm.Percentage);
         } // !TestPaymentTermsMultiCardinalityWithBasic()
 
@@ -2663,7 +2666,7 @@ namespace s2industries.ZUGFeRD.Test
             DateTime timestamp = DateTime.Now.Date;
             var desc = _InvoiceProvider.CreateInvoice();
             desc.GetTradePaymentTerms().Clear();
-            desc.AddTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));            
+            desc.AddTradePaymentTerms("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", new DateTime(2018, 4, 4));
             desc.GetTradePaymentTerms().First().DueDate = timestamp.AddDays(14);
 
             MemoryStream ms = new MemoryStream();
@@ -2694,13 +2697,13 @@ namespace s2industries.ZUGFeRD.Test
 
         [TestMethod]
         public void TestPaymentTermsMultiCardinalityXRechnungStructured()
-        {                        
+        {
             DateTime timestamp = DateTime.Now.Date;
             var desc = _InvoiceProvider.CreateInvoice();
             desc.GetTradePaymentTerms().Clear();
             desc.AddTradePaymentTerms(String.Empty, null, PaymentTermsType.Skonto, 14, 2.25m);
             desc.GetTradePaymentTerms().First().DueDate = timestamp.AddDays(14);
-            desc.AddTradePaymentTerms("Description2", null, PaymentTermsType.Skonto, 28, 1m);            
+            desc.AddTradePaymentTerms("Description2", null, PaymentTermsType.Skonto, 28, 1m);
 
             MemoryStream ms = new MemoryStream();
             desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung);

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -512,18 +512,18 @@ namespace s2industries.ZUGFeRD
                             #endregion
 
                             #region ChargePercentage
-                            if (specifiedTradeAllowanceCharge.ChargePercentage.HasValue && descriptor.Profile != Profile.Basic)
+                            if (specifiedTradeAllowanceCharge.ChargePercentage.HasValue)
                             {
-                                Writer.WriteStartElement("ram", "CalculationPercent"); // BT-138, BT-143
+                                Writer.WriteStartElement("ram", "CalculationPercent", ALL_PROFILES ^ Profile.Basic); // BT-138, BT-143
                                 Writer.WriteValue(_formatDecimal(specifiedTradeAllowanceCharge.ChargePercentage.Value, 2));
                                 Writer.WriteEndElement();
                             }
                             #endregion
 
                             #region BasisAmount
-                            if (specifiedTradeAllowanceCharge.BasisAmount.HasValue && descriptor.Profile != Profile.Basic)
+                            if (specifiedTradeAllowanceCharge.BasisAmount.HasValue)
                             {
-                                Writer.WriteStartElement("ram", "BasisAmount"); // BT-137, BT-142
+                                Writer.WriteStartElement("ram", "BasisAmount", ALL_PROFILES ^ Profile.Basic); // BT-137, BT-142
                                 Writer.WriteValue(_formatDecimal(specifiedTradeAllowanceCharge.BasisAmount.Value, 2));
                                 Writer.WriteEndElement();
                             }

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -263,8 +263,14 @@ namespace s2industries.ZUGFeRD
                     Writer.WriteStartElement("ram", "SpecifiedLineTradeAgreement", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
                     #region BuyerOrderReferencedDocument (Comfort, Extended, XRechnung)
-                    //Detailangaben zur zugehörigen Bestellung
-                    if (tradeLineItem.BuyerOrderReferencedDocument != null && (!string.IsNullOrWhiteSpace(tradeLineItem.BuyerOrderReferencedDocument.LineID) || descriptor.Profile == Profile.Extended))
+                    // Detailangaben zur zugehörigen Bestellung
+                    bool hasLineID = !string.IsNullOrWhiteSpace(tradeLineItem.BuyerOrderReferencedDocument?.LineID);
+                    bool hasIssuerAssignedID = !string.IsNullOrWhiteSpace(tradeLineItem.BuyerOrderReferencedDocument?.ID);
+                    bool hasIssueDateTime = tradeLineItem.BuyerOrderReferencedDocument?.IssueDateTime != null;
+
+                    if (tradeLineItem.BuyerOrderReferencedDocument != null &&
+                        (((descriptor.Profile != Profile.Extended) && hasLineID) ||
+                         ((descriptor.Profile == Profile.Extended) && (hasLineID || hasIssuerAssignedID || hasIssueDateTime))))
                     {
                         Writer.WriteStartElement("ram", "BuyerOrderReferencedDocument", Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
@@ -506,18 +512,18 @@ namespace s2industries.ZUGFeRD
                             #endregion
 
                             #region ChargePercentage
-                            if (specifiedTradeAllowanceCharge.ChargePercentage.HasValue)
+                            if (specifiedTradeAllowanceCharge.ChargePercentage.HasValue && descriptor.Profile != Profile.Basic)
                             {
-                                Writer.WriteStartElement("ram", "CalculationPercent"); // BT-143
+                                Writer.WriteStartElement("ram", "CalculationPercent"); // BT-138, BT-143
                                 Writer.WriteValue(_formatDecimal(specifiedTradeAllowanceCharge.ChargePercentage.Value, 2));
                                 Writer.WriteEndElement();
                             }
                             #endregion
 
                             #region BasisAmount
-                            if (specifiedTradeAllowanceCharge.BasisAmount.HasValue)
+                            if (specifiedTradeAllowanceCharge.BasisAmount.HasValue && descriptor.Profile != Profile.Basic)
                             {
-                                Writer.WriteStartElement("ram", "BasisAmount", profile: Profile.Basic| Profile.Comfort | Profile.Extended | Profile.XRechnung);
+                                Writer.WriteStartElement("ram", "BasisAmount"); // BT-137, BT-142
                                 Writer.WriteValue(_formatDecimal(specifiedTradeAllowanceCharge.BasisAmount.Value, 2));
                                 Writer.WriteEndElement();
                             }
@@ -529,7 +535,9 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteEndElement();
                             #endregion
 
-                            Writer.WriteOptionalElementString("ram", "Reason", specifiedTradeAllowanceCharge.Reason, Profile.Basic| Profile.Comfort | Profile.Extended | Profile.XRechnung);
+                            // TODO: ReasonCode, BT-140, BT-145 -> missing in TradeAllowanceCharge
+                            Writer.WriteOptionalElementString("ram", "Reason", specifiedTradeAllowanceCharge.Reason); // BT-139, BT-144
+
                             Writer.WriteEndElement(); // !ram:SpecifiedTradeAllowanceCharge
                         }
                     }


### PR DESCRIPTION
- `BuyerOrderReferencedDocument` (line item)
  Rule fixes to take into account all potential inner elements to prevent an empty section.
  Using extra vars, but these make the main `if` clause easier to read logically.
- `SpecifiedTradeAllowanceCharge` (line item)
  The 2 elements `CalculationPercent` and `BasisAmount` actually do not exist in the `Basic` profile,
  as can be seen in the original documentation (`7. ZUGFeRD_2.3.2_Technischer_Anhang_Profil_BASIC.pdf`),
  referencing the file from the German distribution.
  In addition, there are XSD rules like "_Element 'ram:CalculationPercent' is marked as not used in the given context_".
  Note: I applied an explicit comparison to exclude Basic as that is much less code than using a repeated list
  of all allowed profiles for the method parameters.