### PR TITLE
23CIIWriter: revised ReceivableSpecifiedTradeAccountingAccounts

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -891,7 +891,7 @@ namespace s2industries.ZUGFeRD
         /// <param name="dueDays"></param>
         /// <param name="percentage"></param>
         /// <param name="baseAmount"></param>
-        /// /// <param name="actualAmount"></param>
+        /// <param name="actualAmount"></param>
         public void AddTradePaymentTerms(string description, DateTime? dueDate = null,
             PaymentTermsType? paymentTermsType = null, int? dueDays = null,
             decimal? percentage = null, decimal? baseAmount = null, decimal? actualAmount = null)

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -116,12 +116,12 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteEndElement(); // !IssueDateTime
             }
 
-            //ToDo: CopyIndicator                // BT-X-3, Kopiekennzeichen, Extended
-            //ToDo: LanguageID                  // BT-X-4, Sprachkennzeichen, Extended
+            // TODO: CopyIndicator                // BT-X-3, Kopiekennzeichen, Extended
+            // TODO: LanguageID                  // BT-X-4, Sprachkennzeichen, Extended
 
             _writeNotes(Writer, this.Descriptor.Notes, ALL_PROFILES ^ Profile.Minimum); // BG-1, BT-X-5, BT-22, BT-21
 
-            //ToDo: EffectiveSpecifiedPeriod    // BT-X-6, Vertragliches Fälligkeitsdatum der Rechnung, Extended
+            // TODO: EffectiveSpecifiedPeriod    // BT-X-6, Vertragliches Fälligkeitsdatum der Rechnung, Extended
 
             Writer.WriteEndElement(); // !rsm:ExchangedDocument
             #endregion
@@ -166,7 +166,7 @@ namespace s2industries.ZUGFeRD
                 }
                 #endregion
 
-                // ToDo: IncludedNote            // BT-127, Detailinformationen zum Freitext zur Position, Basic+Comfort+Extended+XRechnung
+                // TODO: IncludedNote            // BT-127, Detailinformationen zum Freitext zur Position, Basic+Comfort+Extended+XRechnung
 
                 // handelt es sich um einen Kommentar?
                 bool isCommentItem = false;
@@ -186,8 +186,8 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteOptionalElementString("ram", "SellerAssignedID", tradeLineItem.SellerAssignedID, Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
                 Writer.WriteOptionalElementString("ram", "BuyerAssignedID", tradeLineItem.BuyerAssignedID, Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
-                // ToDo: IndustryAssignedID     // BT-X-532, Von der Industrie zugewiesene Produktkennung
-                // ToDo: ModelID                // BT-X-533, Modelkennung des Artikels
+                // TODO: IndustryAssignedID     // BT-X-532, Von der Industrie zugewiesene Produktkennung
+                // TODO: ModelID                // BT-X-533, Modelkennung des Artikels
 
                 // BT-153
                 Writer.WriteOptionalElementString("ram", "Name", tradeLineItem.Name, Profile.Basic | Profile.Comfort | Profile.Extended);
@@ -195,9 +195,9 @@ namespace s2industries.ZUGFeRD
 
                 Writer.WriteOptionalElementString("ram", "Description", tradeLineItem.Description, Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
-                // ToDo: BatchID                // BT-X-534, Kennung der Charge (des Loses) des Artikels
-                // ToDo: BrandName              // BT-X-535, Markenname des Artikels
-                // ToDo: ModelName              // BT-X-536, Modellbezeichnung des Artikels
+                // TODO: BatchID                // BT-X-534, Kennung der Charge (des Loses) des Artikels
+                // TODO: BrandName              // BT-X-535, Markenname des Artikels
+                // TODO: ModelName              // BT-X-536, Modellbezeichnung des Artikels
 
                 // BG-32, Artikelattribute
                 if (tradeLineItem.ApplicableProductCharacteristics?.Any() == true)
@@ -205,9 +205,9 @@ namespace s2industries.ZUGFeRD
                     foreach (var productCharacteristic in tradeLineItem.ApplicableProductCharacteristics)
                     {
                         Writer.WriteStartElement("ram", "ApplicableProductCharacteristic");
-                        // ToDo: TypeCode        // BT-X-11, Art der Produkteigenschaft (Code), Extended
+                        // TODO: TypeCode        // BT-X-11, Art der Produkteigenschaft (Code), Extended
                         Writer.WriteOptionalElementString("ram", "Description", productCharacteristic.Description);
-                        // ToDo: ValueMeasure    // BT-X-12, Wert der Produkteigenschaft (numerische Messgröße), mit unitCode, Extended
+                        // TODO: ValueMeasure    // BT-X-12, Wert der Produkteigenschaft (numerische Messgröße), mit unitCode, Extended
                         Writer.WriteOptionalElementString("ram", "Value", productCharacteristic.Value); // BT-161
                         Writer.WriteEndElement(); // !ram:ApplicableProductCharacteristic
                     }
@@ -233,15 +233,15 @@ namespace s2industries.ZUGFeRD
                     }
                 }
 
-                // ToDo: IndividualTradeProductInstance, BG-X-84, Artikel (Handelsprodukt) Instanzen
-                // ToDo: OriginTradeCountry + ID, BT-159, Detailinformationen zur Produktherkunft, Comfort+Extended+XRechnung
+                // TODO: IndividualTradeProductInstance, BG-X-84, Artikel (Handelsprodukt) Instanzen
+                // TODO: OriginTradeCountry + ID, BT-159, Detailinformationen zur Produktherkunft, Comfort+Extended+XRechnung
 
                 if ((descriptor.Profile == Profile.Extended) && (tradeLineItem.IncludedReferencedProducts?.Any() == true)) // BG-X-1
                 {
                     foreach (var includedItem in tradeLineItem.IncludedReferencedProducts)
                     {
                         Writer.WriteStartElement("ram", "IncludedReferencedProduct");
-                        // ToDo: GlobalID, SellerAssignedID, BuyerAssignedID, IndustryAssignedID, Description
+                        // TODO: GlobalID, SellerAssignedID, BuyerAssignedID, IndustryAssignedID, Description
                         Writer.WriteOptionalElementString("ram", "Name", includedItem.Name); // BT-X-18
 
                         if (includedItem.UnitQuantity.HasValue)
@@ -402,7 +402,7 @@ namespace s2industries.ZUGFeRD
                     #endregion // !NetPriceProductTradePrice(Basic|Comfort|Extended|XRechnung)
 
                     #region UltimateCustomerOrderReferencedDocument
-                    //ToDo: UltimateCustomerOrderReferencedDocument
+                    // TODO: UltimateCustomerOrderReferencedDocument
                     #endregion
                     Writer.WriteEndElement(); // ram:SpecifiedLineTradeAgreement
                 }
@@ -565,50 +565,46 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteValue(_formatDecimal(total));
                 Writer.WriteEndElement(); // !ram:LineTotalAmount
 
-                //ToDo: TotalAllowanceChargeAmount
+                // TODO: TotalAllowanceChargeAmount
                 //Gesamtbetrag der Positionszu- und Abschläge
                 Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementMonetarySummation
                 #endregion
 
                 #region AdditionalReferencedDocument
                 //Objektkennung auf Ebene der Rechnungsposition
-                //ToDo: AdditionalReferencedDocument
+                // TODO: AdditionalReferencedDocument
                 #endregion
 
                 #region ReceivableSpecifiedTradeAccountingAccount
-                //Detailinformationen zur Buchungsreferenz
-                if ((descriptor.Profile == Profile.XRechnung1 || descriptor.Profile == Profile.XRechnung) && tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts.Count > 0)
+                // Detailinformationen zur Buchungsreferenz, BT-133-00
+                if (tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts?.Any() == true)
                 {
-                    //only one ReceivableSpecifiedTradeAccountingAccount (BT-133) is allowed in Profile XRechnung
-                    Writer.WriteStartElement("ram", "ReceivableSpecifiedTradeAccountingAccount", Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+                    foreach (var traceAccountingAccount in tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts)
                     {
-                        Writer.WriteStartElement("ram", "ID");
-                        Writer.WriteValue(tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts[0].TradeAccountID);  //BT-133
-                        Writer.WriteEndElement(); // !ram:ID
-                    }
-                    Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
-                }
-                else
-                {
-                    //multiple ReceivableSpecifiedTradeAccountingAccounts are allowed in other profiles
-                    foreach (ReceivableSpecifiedTradeAccountingAccount rsta in tradeLineItem.ReceivableSpecifiedTradeAccountingAccounts)
-                    {
-                        Writer.WriteStartElement("ram", "ReceivableSpecifiedTradeAccountingAccount", Profile.Comfort | Profile.Extended);
-
+                        if (string.IsNullOrWhiteSpace(traceAccountingAccount.TradeAccountID))
                         {
-                            Writer.WriteStartElement("ram", "ID");
-                            Writer.WriteValue(rsta.TradeAccountID);
-                            Writer.WriteEndElement(); // !ram:ID
+                            continue;
                         }
 
-                        if (rsta.TradeAccountTypeCode != AccountingAccountTypeCodes.Unknown)
+                        Writer.WriteStartElement("ram", "ReceivableSpecifiedTradeAccountingAccount", Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+                        Writer.WriteStartElement("ram", "ID");
+                        Writer.WriteValue(traceAccountingAccount.TradeAccountID); // BT-133
+                        Writer.WriteEndElement(); // !ram:ID
+
+                        if (traceAccountingAccount.TradeAccountTypeCode != AccountingAccountTypeCodes.Unknown)
                         {
                             Writer.WriteStartElement("ram", "TypeCode", Profile.Extended);
-                            Writer.WriteValue(((int)rsta.TradeAccountTypeCode).ToString());
+                            Writer.WriteValue(((int)traceAccountingAccount.TradeAccountTypeCode).ToString()); // BT-X-99
                             Writer.WriteEndElement(); // !ram:TypeCode
                         }
 
                         Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
+
+                        // Only Extended allows multiple accounts per line item, otherwise break
+                        if (descriptor.Profile != Profile.Extended)
+                        {
+                            break;
+                        }
                     }
                 }
                 #endregion
@@ -1177,46 +1173,40 @@ namespace s2industries.ZUGFeRD
             #endregion
 
             #region ReceivableSpecifiedTradeAccountingAccount
-            if (this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts != null && this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts.Count > 0)
+            // Detailinformationen zur Buchungsreferenz, BT-19-00
+            if (this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts?.Any() == true)
             {
-                if (descriptor.Profile == Profile.XRechnung1 || descriptor.Profile == Profile.XRechnung)
+                foreach (var traceAccountingAccount in this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts)
                 {
-                    if (!string.IsNullOrWhiteSpace(this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts[0].TradeAccountID))
+                    if (string.IsNullOrWhiteSpace(traceAccountingAccount.TradeAccountID))
                     {
-                        Writer.WriteStartElement("ram", "ReceivableSpecifiedTradeAccountingAccount");
-                        {
-                            //BT-19
-                            Writer.WriteStartElement("ram", "ID");
-                            Writer.WriteValue(this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts[0].TradeAccountID);
-                            Writer.WriteEndElement(); // !ram:ID
-                        }
-                        Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
+                        continue;
                     }
-                }
-                else
-                {
-                    foreach (ReceivableSpecifiedTradeAccountingAccount traceAccountingAccount in this.Descriptor.ReceivableSpecifiedTradeAccountingAccounts)
+
+                    Writer.WriteStartElement("ram", "ReceivableSpecifiedTradeAccountingAccount", ALL_PROFILES ^ Profile.Minimum);
+                    Writer.WriteStartElement("ram", "ID");
+                    Writer.WriteValue(traceAccountingAccount.TradeAccountID); // BT-19
+                    Writer.WriteEndElement(); // !ram:ID
+
+                    if (traceAccountingAccount.TradeAccountTypeCode != AccountingAccountTypeCodes.Unknown)
                     {
-                        Writer.WriteStartElement("ram", "ReceivableSpecifiedTradeAccountingAccount", Profile.BasicWL | Profile.Basic | Profile.Comfort | Profile.Extended);
+                        Writer.WriteStartElement("ram", "TypeCode", Profile.Extended);
+                        Writer.WriteValue(((int)traceAccountingAccount.TradeAccountTypeCode).ToString()); // BT-X-290
+                        Writer.WriteEndElement(); // !ram:TypeCode
+                    }
 
-                        {
-                            //BT-19
-                            Writer.WriteStartElement("ram", "ID", Profile.BasicWL | Profile.Basic | Profile.Comfort | Profile.Extended);
-                            Writer.WriteValue(traceAccountingAccount.TradeAccountID);
-                            Writer.WriteEndElement(); // !ram:ID
-                        }
+                    Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
 
-                        if (traceAccountingAccount.TradeAccountTypeCode != AccountingAccountTypeCodes.Unknown)
-                        {
-                            Writer.WriteStartElement("ram", "TypeCode", Profile.Extended);
-                            Writer.WriteValue(((int)traceAccountingAccount.TradeAccountTypeCode).ToString());
-                            Writer.WriteEndElement(); // !ram:TypeCode
-                        }
-
-                        Writer.WriteEndElement(); // !ram:ReceivableSpecifiedTradeAccountingAccount
+                    // Only BasicWL and Extended allow multiple accounts
+                    if (!this.Descriptor.Profile.In(Profile.BasicWL, Profile.Extended))
+                    {
+                        break;
                     }
                 }
             }
+
+            // TODO: SpecifiedAdvancePayment (0..unbounded), BG-X-45
+
             #endregion
             Writer.WriteEndElement(); // !ram:ApplicableHeaderTradeSettlement
 
@@ -1322,12 +1312,7 @@ namespace s2industries.ZUGFeRD
 
         private void _writeOptionalTaxes(ProfileAwareXmlTextWriter writer)
         {
-            if (this.Descriptor.Taxes?.Count == 0)
-            {
-                return;
-            }
-
-            foreach (Tax tax in this.Descriptor.Taxes)
+            this.Descriptor.Taxes?.ForEach (tax =>
             {
                 writer.WriteStartElement("ram", "ApplicableTradeTax");
 
@@ -1366,18 +1351,13 @@ namespace s2industries.ZUGFeRD
 
                 writer.WriteElementString("ram", "RateApplicablePercent", _formatDecimal(tax.Percent));
                 writer.WriteEndElement(); // !RateApplicablePercent
-            }
+            });
         } // !_writeOptionalTaxes()
 
 
         private void _writeNotes(ProfileAwareXmlTextWriter writer, List<Note> notes, Profile profile = Profile.Unknown)
         {
-            if (notes?.Count == 0)
-            {
-                return;
-            }
-
-            foreach (Note note in notes)
+            notes?.ForEach (note =>
             {
                 writer.WriteStartElement("ram", "IncludedNote", profile);
                 if (note.ContentCode != ContentCodes.Unknown)
@@ -1390,7 +1370,7 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram", "SubjectCode", note.SubjectCode.EnumToString());
                 }
                 writer.WriteEndElement();
-            }
+            });
         } // !_writeNotes()
 
 


### PR DESCRIPTION
`InvoiceDescriptor23CIIWriter`:
- Cleaner code for writing `ReceivableSpecifiedTradeAccountingAccounts` elements.
  I looked through the 2.3.2 documentation again and think to also have fixed some rules
  (e.g. different use count for different profiles)
- smaller tweaks like use of `Any()` instead of `Count`, changed `TODO` to uppercase (common practice)
- fixed my own issues about early returns in `_writeOptionalTaxes` and `_writeNotes`
- all tests successful

P.S.: @stephanstapel did you receive my email, btw? 😄 