### PR TITLE
Revised/extended AdditionalReferencedDocument handling

### DIFF
--- a/ZUGFeRD/AdditionalReferencedDocument.cs
+++ b/ZUGFeRD/AdditionalReferencedDocument.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,38 +26,56 @@ namespace s2industries.ZUGFeRD
 {
     /// <summary>
     /// Reference documents are supposed to hold additional data you might want to show on item level.
-    /// 
+    ///
     /// Reference documents are used e.g. for commissions on item level
     /// </summary>
     public class AdditionalReferencedDocument : BaseReferencedDocument
     {
         /// <summary>
+        /// External document location
+        /// BT-124, BT-X-28
+        /// </summary>
+        public string URIID { get; set; }
+
+        /// <summary>
+        /// Referenced position
+        /// BT-X-29
+        /// </summary>
+        public string LineID { get; set; }
+
+        /// <summary>
+        /// Type of the reference document
+        /// BT-17-0, BT-18-0, BT-122-0, BT-X-30
+        /// </summary>
+        public AdditionalReferencedDocumentTypeCode TypeCode { get; set; }
+
+        /// <summary>
         /// Reference documents are strongly typed, specify ReferenceTypeCode to allow easy processing by invoicee
+        /// BT-18-1
         /// </summary>
         public ReferenceTypeCodes ReferenceTypeCode { get; set; }
 
         /// <summary>
         /// Description of document
+        /// BT-123, BT-X-299
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
         /// An attached document embedded as binary object or sent together with the invoice.
+        /// BT-125
         /// </summary>
         public byte[] AttachmentBinaryObject { get; set; } = null;
 
         /// <summary>
         /// Filename of attachment
+        /// BT-125-2
         /// </summary>
         public string Filename { get; set; }
 
         /// <summary>
-        /// Type of the reference document
-        /// </summary>
-        public AdditionalReferencedDocumentTypeCode TypeCode { get; set; }
-
-        /// <summary>
         /// MimeType of the attached document embedded as binary object.
+        /// BT-125-1
         /// </summary>
         public string MimeType => MimeTypeMapper.GetMimeType(Filename);
     }

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -704,6 +704,7 @@ namespace s2industries.ZUGFeRD
 
         /// <summary>
         /// Add an additional reference document
+		/// Note: LineID is only on line item-level
         /// </summary>
         /// <param name="id">Document number such as delivery note no or credit memo no</param>
         /// <param name="typeCode"></param>
@@ -712,7 +713,10 @@ namespace s2industries.ZUGFeRD
         /// <param name="referenceTypeCode">Type of the referenced document</param>
         /// <param name="attachmentBinaryObject"></param>
         /// <param name="filename"></param>
-        public void AddAdditionalReferencedDocument(string id, AdditionalReferencedDocumentTypeCode typeCode, DateTime? issueDateTime = null, string name = null, ReferenceTypeCodes referenceTypeCode = ReferenceTypeCodes.Unknown, byte[] attachmentBinaryObject = null, string filename = null)
+        /// <param name="uriID"></param>
+        public void AddAdditionalReferencedDocument(string id, AdditionalReferencedDocumentTypeCode typeCode,
+			DateTime? issueDateTime = null, string name = null, ReferenceTypeCodes referenceTypeCode = ReferenceTypeCodes.Unknown,
+			byte[] attachmentBinaryObject = null, string filename = null, string uriID = null)
         {
             this.AdditionalReferencedDocuments.Add(new AdditionalReferencedDocument()
             {
@@ -722,7 +726,8 @@ namespace s2industries.ZUGFeRD
                 Name = name,
                 AttachmentBinaryObject = attachmentBinaryObject,
                 Filename = filename,
-                TypeCode = typeCode
+                TypeCode = typeCode,
+				URIID = uriID
             });
         } // !AddAdditionalReferencedDocument()
 
@@ -740,8 +745,8 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Sets detailed information about the corresponding despatch advice
         /// </summary>
-        /// <param name="deliveryNoteNo"></param>
-        /// <param name="deliveryNoteDate"></param>
+        /// <param name="despatchAdviceNo"></param>
+        /// <param name="despatchAdviceDate"></param>
         public void SetDespatchAdviceReferencedDocument(string despatchAdviceNo, DateTime? despatchAdviceDate = null)
         {
             this.DespatchAdviceReferencedDocument = new DespatchAdviceReferencedDocument()

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -135,49 +135,12 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
-
-            //Get all referenced and embedded documents (BG-24)
+            //Get all referenced and embedded documents, BG-24
             XmlNodeList referencedDocNodes = doc.SelectNodes(".//ram:ApplicableHeaderTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
             foreach (XmlNode referenceNode in referencedDocNodes)
             {
                 retval.AdditionalReferencedDocuments.Add(_readAdditionalReferencedDocument(referenceNode, nsmgr));
             }
-
-            //-------------------------------------------------
-            // hzi: With old implementation only the first document has been read instead of all documents
-            //-------------------------------------------------
-            //if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument", nsmgr) != null)
-            //{
-            //    string _issuerAssignedID = XmlUtils.NodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:IssuerAssignedID", nsmgr);
-            //    string _typeCode = XmlUtils.NodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:TypeCode", nsmgr);
-            //    string _referenceTypeCode = XmlUtils.NodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:ReferenceTypeCode", nsmgr);
-            //    string _name = XmlUtils.NodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:Name", nsmgr);
-            //    DateTime? _date = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//ram:AdditionalReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr);
-
-            //    if (doc.SelectSingleNode("//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject", nsmgr) != null)
-            //    {
-            //        string _filename = XmlUtils.NodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject/@filename", nsmgr);
-            //        byte[] data = Convert.FromBase64String(XmlUtils.NodeAsString(doc, "//ram:AdditionalReferencedDocument/ram:AttachmentBinaryObject", nsmgr));
-
-            //        retval.AddAdditionalReferencedDocument(id: _issuerAssignedID,
-            //                                               typeCode: default(AdditionalReferencedDocumentTypeCode).FromString(_typeCode),
-            //                                               issueDateTime: _date,
-            //                                               referenceTypeCode: default(ReferenceTypeCodes).FromString(_referenceTypeCode),
-            //                                               name: _name,
-            //                                               attachmentBinaryObject: data,
-            //                                               filename: _filename);
-            //    }
-            //    else
-            //    {
-            //        retval.AddAdditionalReferencedDocument(id: _issuerAssignedID,
-            //                                               typeCode: default(AdditionalReferencedDocumentTypeCode).FromString(_typeCode),
-            //                                               issueDateTime: _date,
-            //                                               referenceTypeCode: default(ReferenceTypeCodes).FromString(_referenceTypeCode),
-            //                                               name: _name);
-            //    }
-            //}
-            //-------------------------------------------------
-
 
             retval.ShipTo = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:ShipToTradeParty", nsmgr);
             retval.UltimateShipTo = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:UltimateShipToTradeParty", nsmgr);
@@ -575,8 +538,8 @@ namespace s2industries.ZUGFeRD
                         case "ram:SpecifiedTradeSettlementLineMonetarySummation":
                             //TODO
                             break;
-                        case "ram:AdditionalReferencedDocument":
-                            //TODO
+                        case "ram:AdditionalReferencedDocument": // BT-128-00
+                            item._AdditionalReferencedDocuments.Add(_readAdditionalReferencedDocument(lineTradeSettlementNode, nsmgr));
                             break;
                         case "ram:ReceivableSpecifiedTradeAccountingAccount":
                             item.ReceivableSpecifiedTradeAccountingAccounts.Add(new ReceivableSpecifiedTradeAccountingAccount()
@@ -649,13 +612,6 @@ namespace s2industries.ZUGFeRD
             //        IssueDateTime = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", nsmgr),
             //    };
             //}
-
-            //Get all referenced AND embedded documents
-            XmlNodeList referenceNodes = tradeLineItem.SelectNodes(".//ram:SpecifiedLineTradeAgreement/ram:AdditionalReferencedDocument", nsmgr);
-            foreach (XmlNode referenceNode in referenceNodes)
-            {
-                item._AdditionalReferencedDocuments.Add(_readAdditionalReferencedDocument(referenceNode, nsmgr));
-            }
 
             foreach (XmlNode designatedProductClassificationNode in tradeLineItem.SelectNodes(".//ram:DesignatedProductClassification", nsmgr))
             {
@@ -747,8 +703,10 @@ namespace s2industries.ZUGFeRD
                 IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(node, "ram:FormattedIssueDateTime", nsmgr),
                 AttachmentBinaryObject = !string.IsNullOrWhiteSpace(strBase64BinaryData) ? Convert.FromBase64String(strBase64BinaryData) : null,
                 Filename = XmlUtils.NodeAsString(node, "ram:AttachmentBinaryObject/@filename", nsmgr),
-                ReferenceTypeCode = default(ReferenceTypeCodes).FromString(XmlUtils.NodeAsString(node, "ram:ReferenceTypeCode", nsmgr))
-            };
+                ReferenceTypeCode = default(ReferenceTypeCodes).FromString(XmlUtils.NodeAsString(node, "ram:ReferenceTypeCode", nsmgr)),
+                URIID = XmlUtils.NodeAsString(node, "ram:URIID", nsmgr, null),
+                LineID = XmlUtils.NodeAsString(node, "ram:LineID", nsmgr, null)
+			};
         } // !_readAdditionalReferencedDocument()
 
     }

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -574,7 +574,6 @@ namespace s2industries.ZUGFeRD
                 // TODO: InvoiceReferencedDocument, BG-X-48
 
                 #region AdditionalReferencedDocument
-<<<<<<< HEAD
                 //Objektkennung auf Ebene der Rechnungsposition, BT-128-00
                 if (tradeLineItem.GetAdditionalReferencedDocuments().Count > 0)
                 {
@@ -593,10 +592,6 @@ namespace s2industries.ZUGFeRD
                         }
                     }
                 }
-=======
-                //Objektkennung auf Ebene der Rechnungsposition
-                // TODO: AdditionalReferencedDocument
->>>>>>> master
                 #endregion
 
                 #region ReceivableSpecifiedTradeAccountingAccount

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -318,7 +318,7 @@ namespace s2industries.ZUGFeRD
                     //Detailangaben zu einer zusätzlichen Dokumentenreferenz
                     foreach (AdditionalReferencedDocument document in tradeLineItem._AdditionalReferencedDocuments)
                     {
-                        _writeAdditionalReferencedDocument(document, Profile.Extended);
+                        _writeAdditionalReferencedDocument(document, Profile.Extended, "BG-X-3");
                     } // !foreach(document)
                     #endregion
 
@@ -570,9 +570,27 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementMonetarySummation
                 #endregion
 
+                // TODO: InvoiceReferencedDocument, BG-X-48
+
                 #region AdditionalReferencedDocument
-                //Objektkennung auf Ebene der Rechnungsposition
-                //ToDo: AdditionalReferencedDocument
+                //Objektkennung auf Ebene der Rechnungsposition, BT-128-00
+                if (tradeLineItem.GetAdditionalReferencedDocuments().Count > 0)
+                {
+                    foreach (var document in tradeLineItem.GetAdditionalReferencedDocuments())
+                    {
+                        if (string.IsNullOrWhiteSpace(document.ID))
+                        {
+                            continue;
+                        }
+
+                        _writeAdditionalReferencedDocument(document, Profile.Comfort | Profile.Extended | Profile.XRechnung | Profile.XRechnung1, "BT-128-00");
+                        // only Extended allows multiple entries
+                        if (this.Descriptor.Profile != Profile.Extended)
+                        {
+                            break;
+                        }
+                    }
+                }
                 #endregion
 
                 #region ReceivableSpecifiedTradeAccountingAccount
@@ -698,11 +716,11 @@ namespace s2industries.ZUGFeRD
             #endregion
 
             #region 4. AdditionalReferencedDocument
-            if (this.Descriptor.AdditionalReferencedDocuments != null)
+            if (this.Descriptor.AdditionalReferencedDocuments != null) // BG-24
             {
-                foreach (AdditionalReferencedDocument document in this.Descriptor.AdditionalReferencedDocuments)
+                foreach (var document in this.Descriptor.AdditionalReferencedDocuments)
                 {
-                    _writeAdditionalReferencedDocument(document, Profile.Comfort | Profile.Extended | Profile.XRechnung); // BG-24
+                    _writeAdditionalReferencedDocument(document, Profile.Comfort | Profile.Extended | Profile.XRechnung | Profile.XRechnung1, "BG-24");
                 }
             }
             #endregion
@@ -1233,10 +1251,34 @@ namespace s2industries.ZUGFeRD
         } // !Save()
 
 
-        private void _writeAdditionalReferencedDocument(AdditionalReferencedDocument document, Profile profile)
+        private void _writeAdditionalReferencedDocument(AdditionalReferencedDocument document, Profile profile, string parentElement = "")
         {
+            if (string.IsNullOrWhiteSpace(document?.ID))
+            {
+                return;
+            }
+
             Writer.WriteStartElement("ram", "AdditionalReferencedDocument", profile);
             Writer.WriteElementString("ram", "IssuerAssignedID", document.ID);
+
+            var subProfile = profile;
+            switch (parentElement)
+            {
+                case "BG-24":
+                    subProfile = Profile.Comfort | Profile.Extended | Profile.XRechnung;
+                    break;
+                case "BG-X-3":
+                    subProfile = Profile.Extended;
+                    break;
+            }
+            if (parentElement == "BG-24" || parentElement == "BG-X-3")
+            {
+                Writer.WriteOptionalElementString("ram", "URIID", document.URIID, subProfile); // BT-124, BT-X-28
+            }
+            if (parentElement == "BG-X-3")
+            {
+                Writer.WriteOptionalElementString("ram", "LineID", document.LineID, subProfile); // BT-X-29
+            }
 
             if (document.TypeCode != AdditionalReferencedDocumentTypeCode.Unknown)
             {
@@ -1245,14 +1287,20 @@ namespace s2industries.ZUGFeRD
 
             if (document.ReferenceTypeCode != ReferenceTypeCodes.Unknown)
             {
-                Writer.WriteElementString("ram", "ReferenceTypeCode", document.ReferenceTypeCode.EnumToString());
+                if (parentElement == "BT-18-00" || parentElement == "BT-128-00" || parentElement == "BG-X-3")
+                {
+                    Writer.WriteOptionalElementString("ram", "ReferenceTypeCode", document.ReferenceTypeCode.EnumToString()); // BT-128-1, BT-18-1, BT-X-32
+                }
             }
 
-            Writer.WriteOptionalElementString("ram", "Name", document.Name);
+            if (parentElement == "BG-24" || parentElement == "BG-X-3")
+            {
+                Writer.WriteOptionalElementString("ram", "Name", document.Name, subProfile); // BT-123, BT-X-299
+            }
 
             if (document.AttachmentBinaryObject != null)
             {
-                Writer.WriteStartElement("ram", "AttachmentBinaryObject");
+                Writer.WriteStartElement("ram", "AttachmentBinaryObject", subProfile); // BT-125, BT-X-31
                 Writer.WriteAttributeString("filename", document.Filename);
                 Writer.WriteAttributeString("mimeCode", MimeTypeMapper.GetMimeType(document.Filename));
                 Writer.WriteValue(Convert.ToBase64String(document.AttachmentBinaryObject));
@@ -1261,7 +1309,7 @@ namespace s2industries.ZUGFeRD
 
             if (document.IssueDateTime.HasValue)
             {
-                Writer.WriteStartElement("ram", "FormattedIssueDateTime");
+                Writer.WriteStartElement("ram", "FormattedIssueDateTime", Profile.Extended);
                 Writer.WriteStartElement("qdt", "DateTimeString");
                 Writer.WriteAttributeString("format", "102");
                 Writer.WriteValue(_formatDate(document.IssueDateTime.Value));

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -390,7 +390,11 @@ namespace s2industries.ZUGFeRD
         /// <param name="referenceTypeCode">Type of the referenced document</param>
         /// <param name="attachmentBinaryObject"></param>
         /// <param name="filename"></param>
-        public void AddAdditionalReferencedDocument(string id, AdditionalReferencedDocumentTypeCode typeCode, DateTime? issueDateTime = null, string name = null, ReferenceTypeCodes referenceTypeCode = ReferenceTypeCodes.Unknown, byte[] attachmentBinaryObject = null, string filename = null)
+        /// <param name="uriID"></param>
+        /// <param name="lineID"></param>
+        public void AddAdditionalReferencedDocument(string id, AdditionalReferencedDocumentTypeCode typeCode, DateTime? issueDateTime = null,
+            string name = null, ReferenceTypeCodes referenceTypeCode = ReferenceTypeCodes.Unknown, byte[] attachmentBinaryObject = null,
+            string filename = null, string uriID = null, string lineID = null)
         {
             this._AdditionalReferencedDocuments.Add(new AdditionalReferencedDocument()
             {
@@ -400,7 +404,9 @@ namespace s2industries.ZUGFeRD
                 Name = name,
                 AttachmentBinaryObject = attachmentBinaryObject,
                 Filename = filename,
-                TypeCode = typeCode
+                TypeCode = typeCode,
+                URIID = uriID,
+                LineID = lineID
             });
         } // !AddAdditionalReferencedDocument()
 


### PR DESCRIPTION
Revised and extended the overall handling of AdditionalReferencedDocument entries.
Added support for LineID and UUID, incl. tests; removed some obsolete comments and
as usual my VS did some tab to spaces re-formatting.

@stephanstapel: I chose to add more rule checks to the `_writeAdditionalReferencedDocument` method
as in my point of view I'd like to prevent writing of (maybe accidentally assigned) values, that do not
belong to an element. But I think the use of actual BT/BG names within it makes it clear, what is happening.

I apologize in advance if this puts a lot of review time onto you! ☕ 