### PR TITLE
fix: added ReasonCode to trade allowances; updated tests

### DIFF
--- a/ZUGFeRD.Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD.Test/XRechnungUBLTests.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -261,13 +261,14 @@ namespace s2industries.ZUGFeRD.Test
             CurrencyCodes currency = CurrencyCodes.EUR;
             decimal actualAmount = 12.34m;
             string reason = "Gutschrift";
+            AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Packaging;
             TaxTypes taxTypeCode = TaxTypes.VAT;
             TaxCategoryCodes taxCategoryCode = TaxCategoryCodes.AA;
             decimal taxPercent = 19.0m;
 
-            desc.AddTradeAllowanceCharge(isDiscount, basisAmount, currency, actualAmount, reason, taxTypeCode, taxCategoryCode, taxPercent);
+            desc.AddTradeAllowanceCharge(isDiscount, basisAmount, currency, actualAmount, reason, taxTypeCode, taxCategoryCode, taxPercent, reasonCode);
 
-            desc.TradeLineItems[0].AddTradeAllowanceCharge(true, CurrencyCodes.EUR, 100, 10, "test");
+            desc.TradeLineItems[0].AddTradeAllowanceCharge(true, CurrencyCodes.EUR, 100, 10, "test", reasonCode);
 
             TradeAllowanceCharge? testAllowanceCharge = desc.GetTradeAllowanceCharges().FirstOrDefault();
 
@@ -286,6 +287,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(loadedAllowanceCharge.Currency, currency, message: "currency");
             Assert.AreEqual(loadedAllowanceCharge.Amount, actualAmount, message: "actualAmount");
             Assert.AreEqual(loadedAllowanceCharge.Reason, reason, message: "reason");
+            Assert.AreEqual(loadedAllowanceCharge.ReasonCode, reasonCode, message: "reasonCode");
             Assert.AreEqual(loadedAllowanceCharge.Tax.TypeCode, taxTypeCode, message: "taxTypeCode");
             Assert.AreEqual(loadedAllowanceCharge.Tax.CategoryCode, taxCategoryCode, message: "taxCategoryCode");
             Assert.AreEqual(loadedAllowanceCharge.Tax.Percent, taxPercent, message: "taxPercent");
@@ -1202,7 +1204,7 @@ namespace s2industries.ZUGFeRD.Test
 
             Assert.IsTrue(invoiceAsString.Contains($">{Math.Round(duePayableAmount, 2, MidpointRounding.AwayFromZero).ToString("F2", CultureInfo.InvariantCulture)}<"));
             Assert.IsFalse(invoiceAsString.Contains($">{Math.Round(duePayableAmount, 4, MidpointRounding.AwayFromZero).ToString("F4", CultureInfo.InvariantCulture)}<"));
-            Assert.AreEqual(desc.DuePayableAmount, Math.Round(duePayableAmount, 2, MidpointRounding.AwayFromZero));            
+            Assert.AreEqual(desc.DuePayableAmount, Math.Round(duePayableAmount, 2, MidpointRounding.AwayFromZero));
         } // !TestDecimals()
     }
 }

--- a/ZUGFeRD.Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD20Tests.cs
@@ -565,7 +565,7 @@ namespace s2industries.ZUGFeRD.Test
             desc.BillingPeriodStart = timestamp;
             desc.BillingPeriodEnd = timestamp.AddDays(14);
 
-            desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m);
+            desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m, AllowanceReasonCodes.Packaging);
             desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
 
             desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
@@ -596,7 +596,7 @@ namespace s2industries.ZUGFeRD.Test
             lineItem.BillingPeriodEnd = timestamp.AddDays(10);
 
             lineItem.AddReceivableSpecifiedTradeAccountingAccount("987654");
-            lineItem.AddTradeAllowanceCharge(false, CurrencyCodes.EUR, 10m, 50m, "Reason: UnitTest");
+            lineItem.AddTradeAllowanceCharge(false, CurrencyCodes.EUR, 10m, 50m, "Reason: UnitTest", AllowanceReasonCodes.Packaging);
 
 
             MemoryStream ms = new MemoryStream();

--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -693,7 +693,7 @@ namespace s2industries.ZUGFeRD.Test
 
             loadedInvoice = InvoiceDescriptor.Load(msBasic);
             Assert.IsNull(loadedInvoice.RoundingAmount);
-        } // !TestTotalRoundingExtended()   
+        } // !TestTotalRoundingExtended()
 
 
 
@@ -1807,7 +1807,7 @@ namespace s2industries.ZUGFeRD.Test
             desc.BillingPeriodStart = timestamp;
             desc.BillingPeriodEnd = timestamp.AddDays(14);
 
-            desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m);
+            desc.AddTradeAllowanceCharge(false, 5m, CurrencyCodes.EUR, 15m, "Reason for charge", TaxTypes.AAB, TaxCategoryCodes.AB, 19m, AllowanceReasonCodes.Packaging);
             desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
 
             desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
@@ -1838,7 +1838,7 @@ namespace s2industries.ZUGFeRD.Test
             lineItem.BillingPeriodEnd = timestamp.AddDays(10);
 
             lineItem.AddReceivableSpecifiedTradeAccountingAccount("987654");
-            lineItem.AddTradeAllowanceCharge(false, CurrencyCodes.EUR, 10m, 50m, "Reason: UnitTest");
+            lineItem.AddTradeAllowanceCharge(false, CurrencyCodes.EUR, 10m, 50m, "Reason: UnitTest", AllowanceReasonCodes.Packaging);
 
 
             MemoryStream ms = new MemoryStream();
@@ -2244,7 +2244,7 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor invoice = _InvoiceProvider.CreateInvoice();
 
             // fake values, does not matter for our test case
-            invoice.AddTradeAllowanceCharge(true, 100, CurrencyCodes.EUR, 10, String.Empty, TaxTypes.VAT, TaxCategoryCodes.S, 19);
+            invoice.AddTradeAllowanceCharge(true, 100, CurrencyCodes.EUR, 10, String.Empty, TaxTypes.VAT, TaxCategoryCodes.S, 19, AllowanceReasonCodes.Packaging);
 
             MemoryStream ms = new MemoryStream();
             invoice.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);
@@ -2266,7 +2266,7 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor invoice = _InvoiceProvider.CreateInvoice();
 
             // fake values, does not matter for our test case
-            invoice.AddTradeAllowanceCharge(true, 100, CurrencyCodes.EUR, 10, 12, String.Empty, TaxTypes.VAT, TaxCategoryCodes.S, 19);
+            invoice.AddTradeAllowanceCharge(true, 100, CurrencyCodes.EUR, 10, 12, String.Empty, TaxTypes.VAT, TaxCategoryCodes.S, 19, AllowanceReasonCodes.Packaging);
 
             MemoryStream ms = new MemoryStream();
             invoice.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);
@@ -2574,7 +2574,7 @@ namespace s2industries.ZUGFeRD.Test
             var paymentTerm = loadedInvoice.GetTradePaymentTerms().FirstOrDefault(i => i.Description.StartsWith("Zahlbar"));
             Assert.IsNotNull(paymentTerm);
             Assert.AreEqual("Zahlbar innerhalb 30 Tagen netto bis 04.04.2018", paymentTerm.Description);
-            Assert.AreEqual(timestamp.AddDays(14), paymentTerm.DueDate);            
+            Assert.AreEqual(timestamp.AddDays(14), paymentTerm.DueDate);
 
             paymentTerm = loadedInvoice.GetTradePaymentTerms().FirstOrDefault(i => i.PaymentTermsType == PaymentTermsType.Skonto);
             Assert.IsNotNull(paymentTerm);

--- a/ZUGFeRD/AllowanceReasonCodes.cs
+++ b/ZUGFeRD/AllowanceReasonCodes.cs
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.ComponentModel;
+
+
+namespace s2industries.ZUGFeRD
+{
+    /// <summary>
+    /// Reason codes according to UN/EDIFACT UNTDID 7161 code list
+    /// </summary>
+	public enum AllowanceReasonCodes
+	{
+		/// <summary>
+		/// Unknown
+		/// </summary>
+		Unknown = 0,
+
+		/// <summary>
+		/// Advertising
+		/// </summary>
+		[Description("AA")]
+		Advertising = 1,
+
+		/// <summary>
+		/// Off-premises discount
+		/// </summary>
+		[Description("ABL")]
+		OffPremisesDiscount = 2,
+
+		/// <summary>
+		/// Customer discount
+		/// </summary>
+		[Description("ADR")]
+		CustomerDiscount = 3,
+
+		/// <summary>
+		/// Damaged goods
+		/// </summary>
+		[Description("ADT")]
+		DamagedGoods = 4,
+
+		/// <summary>
+		/// Early payment allowance
+		/// </summary>
+		[Description("FC")]
+		EarlyPaymentAllowance = 66,
+
+		/// <summary>
+		/// Discount
+		/// </summary>
+		[Description("95")]
+		Discount = 95,
+
+		/// <summary>
+		/// Volume discount
+		/// </summary>
+		[Description("100")]
+		VolumeDiscount = 100,
+
+		/// <summary>
+		/// Special agreement
+		/// </summary>
+		[Description("102")]
+		SpecialAgreement = 102,
+
+		/// <summary>
+		/// Freight charge
+		/// </summary>
+		[Description("FC")]
+		FreightCharge = 30, // FC
+
+		/// <summary>
+		/// Insurance
+		/// </summary>
+		[Description("FI")]
+		Insurance = 31, // INS
+
+		/// <summary>
+		/// Packaging
+		/// </summary>
+		[Description("PAC")]
+		Packaging = 32, // PAC
+
+		/// <summary>
+		/// Pallet charge
+		/// </summary>
+		[Description("PC")]
+		PalletCharge = 33, // PC
+
+		/// <summary>
+		/// Handling service
+		/// </summary>
+		[Description("SH")]
+		HandlingService = 34, // SH
+
+		/// <summary>
+		/// Transport costs
+		/// </summary>
+		[Description("TC")]
+		TransportCosts = 35, // TC
+
+		/// <summary>
+		/// Miscellaneous service
+		/// </summary>
+		[Description("ZZZ")]
+		MiscellaneousService = 99 // ZZZ
+	}
+}

--- a/ZUGFeRD/EnumExtensions.cs
+++ b/ZUGFeRD/EnumExtensions.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -18,6 +18,9 @@
  */
 
 using System;
+using System.ComponentModel;
+using System.Reflection;
+
 
 namespace s2industries.ZUGFeRD
 {
@@ -59,5 +62,30 @@ namespace s2industries.ZUGFeRD
         {
             return (int)(object)value;
         } // !EnumToInt()
+
+
+        internal static string GetDescriptionAttribute<T>(this T value) where T : Enum
+        {
+            FieldInfo field = value.GetType().GetField(value.ToString());
+            DescriptionAttribute attribute = field.GetCustomAttribute<DescriptionAttribute>();
+            return attribute?.Description ?? value.ToString();
+        } // !GetDescriptionAttribute()
+
+
+        internal static T FromDescription<T>(string code) where T : Enum
+        {
+            if (string.IsNullOrEmpty(code))
+            {
+                return default(T);
+            }
+            foreach (T value in Enum.GetValues(typeof(T)))
+            {
+                if (value.GetDescriptionAttribute().Equals(code, StringComparison.OrdinalIgnoreCase))
+                {
+                    return value;
+                }
+            }
+            return default(T);
+        } // !FromDescription()
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -813,15 +813,19 @@ namespace s2industries.ZUGFeRD
         /// <param name="currency">Curency of the allowance</param>
         /// <param name="actualAmount">Actual allowance charge amount</param>
         /// <param name="reason">Reason for the allowance</param>
+        /// <param name="reasonCode">Reason code for the allowance</param>
         /// <param name="taxTypeCode">VAT type code for document level allowance/ charge</param>
         /// <param name="taxCategoryCode">VAT type code for document level allowance/ charge</param>
         /// <param name="taxPercent">VAT rate for the allowance</param>
-        public void AddTradeAllowanceCharge(bool isDiscount, decimal? basisAmount, CurrencyCodes currency, decimal actualAmount, string reason, TaxTypes taxTypeCode, TaxCategoryCodes taxCategoryCode, decimal taxPercent)
+        public void AddTradeAllowanceCharge(bool isDiscount, decimal? basisAmount, CurrencyCodes currency, decimal actualAmount,
+                                            string reason, TaxTypes taxTypeCode, TaxCategoryCodes taxCategoryCode, decimal taxPercent,
+                                            AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Unknown)
         {
             this._TradeAllowanceCharges.Add(new TradeAllowanceCharge()
             {
                 ChargeIndicator = !isDiscount,
                 Reason = reason,
+                ReasonCode = reasonCode,
                 BasisAmount = basisAmount,
                 ActualAmount = actualAmount,
                 Currency = currency,
@@ -851,12 +855,14 @@ namespace s2industries.ZUGFeRD
         /// <param name="taxTypeCode">VAT type code for document level allowance/ charge</param>
         /// <param name="taxCategoryCode">VAT type code for document level allowance/ charge</param>
         /// <param name="taxPercent">VAT rate for the allowance</param>
-        public void AddTradeAllowanceCharge(bool isDiscount, decimal? basisAmount, CurrencyCodes currency, decimal actualAmount, decimal? chargePercentage, string reason, TaxTypes taxTypeCode, TaxCategoryCodes taxCategoryCode, decimal taxPercent)
+        /// <param name="reasonCode">Reason code for the allowance</param>
+        public void AddTradeAllowanceCharge(bool isDiscount, decimal? basisAmount, CurrencyCodes currency, decimal actualAmount, decimal? chargePercentage, string reason, TaxTypes taxTypeCode, TaxCategoryCodes taxCategoryCode, decimal taxPercent, AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Unknown)
         {
             this._TradeAllowanceCharges.Add(new TradeAllowanceCharge()
             {
                 ChargeIndicator = !isDiscount,
                 Reason = reason,
+                ReasonCode = reasonCode,
                 BasisAmount = basisAmount,
                 ActualAmount = actualAmount,
                 Currency = currency,
@@ -1210,7 +1216,7 @@ namespace s2industries.ZUGFeRD
                              buyerAssignedID: buyerAssignedID,
                              deliveryNoteID: deliveryNoteID,
                              deliveryNoteDate: deliveryNoteDate,
-							 buyerOrderLineID: buyerOrderLineID,
+                             buyerOrderLineID: buyerOrderLineID,
                              buyerOrderID: buyerOrderID, // Extended!
                              buyerOrderDate: buyerOrderDate,
                              billingPeriodStart: billingPeriodStart,

--- a/ZUGFeRD/InvoiceDescriptor1Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Reader.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,7 +27,7 @@ namespace s2industries.ZUGFeRD
     {
         /// <summary>
         /// Parses the ZUGFeRD invoice from the given stream.
-        /// 
+        ///
         /// Make sure that the stream is open, otherwise an IllegalStreamException exception is thrown.
         /// Important: the stream will not be closed by this function.
         /// </summary>
@@ -210,7 +210,8 @@ namespace s2industries.ZUGFeRD
                                                XmlUtils.NodeAsString(node, ".//ram:Reason", nsmgr),
                                                default(TaxTypes).FromString(XmlUtils.NodeAsString(node, ".//ram:CategoryTradeTax/ram:TypeCode", nsmgr)),
                                                default(TaxCategoryCodes).FromString(XmlUtils.NodeAsString(node, ".//ram:CategoryTradeTax/ram:CategoryCode", nsmgr)),
-                                               XmlUtils.NodeAsDecimal(node, ".//ram:CategoryTradeTax/ram:ApplicablePercent", nsmgr, 0).Value);
+                                               XmlUtils.NodeAsDecimal(node, ".//ram:CategoryTradeTax/ram:ApplicablePercent", nsmgr, 0).Value,
+                                               EnumExtensions.FromDescription<AllowanceReasonCodes>(XmlUtils.NodeAsString(node, "./ram:ReasonCode", nsmgr)));
             }
 
             foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedLogisticsServiceCharge", nsmgr))
@@ -392,7 +393,7 @@ namespace s2industries.ZUGFeRD
             foreach (XmlNode referenceNode in referenceNodes)
             {
                 string typeCodeAsString = XmlUtils.NodeAsString(referenceNode, "ram:TypeCode", nsmgr);
-                string codeAsString = XmlUtils.NodeAsString(referenceNode, "ram:ReferenceTypeCode", nsmgr);                
+                string codeAsString = XmlUtils.NodeAsString(referenceNode, "ram:ReferenceTypeCode", nsmgr);
 
                 item.AddAdditionalReferencedDocument(
                     id: XmlUtils.NodeAsString(referenceNode, "ram:ID", nsmgr),

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml.Linq;
 
 namespace s2industries.ZUGFeRD
 {
@@ -32,7 +33,7 @@ namespace s2industries.ZUGFeRD
 
         /// <summary>
         /// Saves the given invoice to the given stream.
-        /// Make sure that the stream is open and writeable. Otherwise, an IllegalStreamException will be thron.        
+        /// Make sure that the stream is open and writeable. Otherwise, an IllegalStreamException will be thron.
         /// </summary>
         /// <param name="descriptor">The invoice object that should be saved</param>
         /// <param name="stream">The target stream for saving the invoice</param>
@@ -336,6 +337,7 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteEndElement();
 
 
+                Writer.WriteOptionalElementString("ram", "ReasonCode", tradeAllowanceCharge.ReasonCode.GetDescriptionAttribute(), Profile.Comfort | Profile.Extended);
                 Writer.WriteOptionalElementString("ram", "Reason", tradeAllowanceCharge.Reason, Profile.Comfort | Profile.Extended);
 
                 if (tradeAllowanceCharge.Tax != null)
@@ -675,7 +677,7 @@ namespace s2industries.ZUGFeRD
             Writer.Flush();
 
             stream.Seek(streamPosition, SeekOrigin.Begin);
-        } // !Save()  
+        } // !Save()
 
 
         internal override bool Validate(InvoiceDescriptor descriptor, bool throwExceptions = true)

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -260,7 +260,8 @@ namespace s2industries.ZUGFeRD
                                                XmlUtils.NodeAsString(node, ".//ram:Reason", nsmgr),
                                                default(TaxTypes).FromString(XmlUtils.NodeAsString(node, ".//ram:CategoryTradeTax/ram:TypeCode", nsmgr)),
                                                default(TaxCategoryCodes).FromString(XmlUtils.NodeAsString(node, ".//ram:CategoryTradeTax/ram:CategoryCode", nsmgr)),
-                                               XmlUtils.NodeAsDecimal(node, ".//ram:CategoryTradeTax/ram:RateApplicablePercent", nsmgr, 0).Value);
+                                               XmlUtils.NodeAsDecimal(node, ".//ram:CategoryTradeTax/ram:RateApplicablePercent", nsmgr, 0).Value,
+                                               EnumExtensions.FromDescription<AllowanceReasonCodes>(XmlUtils.NodeAsString(node, "./ram:ReasonCode", nsmgr)));
             }
 
             foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedLogisticsServiceCharge", nsmgr))

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -443,6 +443,13 @@ namespace s2industries.ZUGFeRD
                     Writer.WriteEndElement();
                 }
 
+                if (tradeAllowanceCharge.ReasonCode != AllowanceReasonCodes.Unknown)
+                {
+                    Writer.WriteStartElement("cbc", "AllowanceChargeReasonCode"); // BT-97 / BT-104
+                    Writer.WriteValue(tradeAllowanceCharge.ReasonCode.GetDescriptionAttribute());
+                    Writer.WriteEndElement();
+                }
+
                 if (!string.IsNullOrWhiteSpace(tradeAllowanceCharge.Reason))
                 {
                     Writer.WriteStartElement("cbc", "AllowanceChargeReason"); // BT-97 / BT-104

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -60,16 +60,16 @@ namespace s2industries.ZUGFeRD
             {
                 isInvoice = false;
             }
-            
+
             if (isInvoice)
             {
-                nsmgr.AddNamespace("ubl", "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2");                
+                nsmgr.AddNamespace("ubl", "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2");
             }
             else
             {
                 nsmgr.AddNamespace("ubl", "urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2");
             }
-                     
+
             nsmgr.AddNamespace("cac", "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2");
             nsmgr.AddNamespace("cbc", "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2");
 
@@ -99,7 +99,7 @@ namespace s2industries.ZUGFeRD
             {
                 IsTest = XmlUtils.NodeAsBool(doc.DocumentElement, "//cbc:TestIndicator", nsmgr, false),
                 BusinessProcess = XmlUtils.NodeAsString(doc.DocumentElement, "//cbc:ProfileID", nsmgr),
-                Profile = Profile.XRechnung, //default(Profile).FromString(XmlUtils.NodeAsString(doc.DocumentElement, "//ram:GuidelineSpecifiedDocumentContextParameter/ram:ID", nsmgr)),                
+                Profile = Profile.XRechnung, //default(Profile).FromString(XmlUtils.NodeAsString(doc.DocumentElement, "//ram:GuidelineSpecifiedDocumentContextParameter/ram:ID", nsmgr)),
                 InvoiceNo = XmlUtils.NodeAsString(doc.DocumentElement, "//cbc:ID", nsmgr),
                 InvoiceDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//cbc:IssueDate", nsmgr),
                 Type = default(InvoiceType).FromString(XmlUtils.NodeAsString(doc.DocumentElement, typeSelector, nsmgr))
@@ -341,7 +341,8 @@ namespace s2industries.ZUGFeRD
                                                XmlUtils.NodeAsString(node, ".//cbc:AllowanceChargeReason", nsmgr),
                                                default(TaxTypes).FromString(XmlUtils.NodeAsString(node, ".//cac:TaxCategory/cac:TaxScheme/cbc:ID", nsmgr)),
                                                default(TaxCategoryCodes).FromString(XmlUtils.NodeAsString(node, ".//cac:TaxCategory/cbc:ID", nsmgr)),
-                                               XmlUtils.NodeAsDecimal(node, ".//cac:TaxCategory/cbc:Percent", nsmgr, 0).Value);
+                                               XmlUtils.NodeAsDecimal(node, ".//cac:TaxCategory/cbc:Percent", nsmgr, 0).Value,
+                                               EnumExtensions.FromDescription<AllowanceReasonCodes>(XmlUtils.NodeAsString(node, "./cbc:AllowanceChargeReasonCode", nsmgr)));
             }
 
             // TODO: Find value //foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedLogisticsServiceCharge", nsmgr))
@@ -625,7 +626,7 @@ namespace s2industries.ZUGFeRD
             //        break;
             //    }
             //  }
-            //}            
+            //}
 
             XmlNodeList noteNodes = tradeLineItem.SelectNodes(".//cbc:Note", nsmgr);
             foreach (XmlNode noteNode in noteNodes)
@@ -646,12 +647,14 @@ namespace s2industries.ZUGFeRD
                 decimal actualAmount = XmlUtils.NodeAsDecimal(appliedTradeAllowanceChargeNode, "./cbc:Amount", nsmgr, 0).Value;
                 string actualAmountCurrency = XmlUtils.NodeAsString(appliedTradeAllowanceChargeNode, "./cbc:Amount/@currencyID", nsmgr);
                 string reason = XmlUtils.NodeAsString(appliedTradeAllowanceChargeNode, "./cbc:AllowanceChargeReason", nsmgr);
+                string reasonCode = XmlUtils.NodeAsString(appliedTradeAllowanceChargeNode, "./cbc:AllowanceChargeReasonCode", nsmgr);
 
                 item.AddTradeAllowanceCharge(!chargeIndicator, // wichtig: das not (!) beachten
                                                 default(CurrencyCodes).FromString(basisAmountCurrency),
                                                 basisAmount,
                                                 actualAmount,
-                                                reason);
+                                                reason,
+                                                EnumExtensions.FromDescription<AllowanceReasonCodes>(reasonCode));
             }
 
             if (item.UnitCode == QuantityCodes.Unknown)

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using System.Xml.Linq;
 
 
 namespace s2industries.ZUGFeRD
@@ -331,7 +332,8 @@ namespace s2industries.ZUGFeRD
                                                XmlUtils.NodeAsString(node, ".//ram:Reason", nsmgr),
                                                default(TaxTypes).FromString(XmlUtils.NodeAsString(node, ".//ram:CategoryTradeTax/ram:TypeCode", nsmgr)),
                                                default(TaxCategoryCodes).FromString(XmlUtils.NodeAsString(node, ".//ram:CategoryTradeTax/ram:CategoryCode", nsmgr)),
-                                               XmlUtils.NodeAsDecimal(node, ".//ram:CategoryTradeTax/ram:RateApplicablePercent", nsmgr, 0).Value);
+                                               XmlUtils.NodeAsDecimal(node, ".//ram:CategoryTradeTax/ram:RateApplicablePercent", nsmgr, 0).Value,
+                                               EnumExtensions.FromDescription<AllowanceReasonCodes>(XmlUtils.NodeAsString(node, "./ram:ReasonCode", nsmgr)));
             }
 
             foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedLogisticsServiceCharge", nsmgr))
@@ -564,13 +566,15 @@ namespace s2industries.ZUGFeRD
                             string actualAmountCurrency = XmlUtils.NodeAsString(lineTradeSettlementNode, "./ram:ActualAmount/@currencyID", nsmgr);
                             string reason = XmlUtils.NodeAsString(lineTradeSettlementNode, "./ram:Reason", nsmgr);
                             decimal? chargePercentage = XmlUtils.NodeAsDecimal(lineTradeSettlementNode, "./ram:CalculationPercent", nsmgr, null);
+                            string reasonCode = XmlUtils.NodeAsString(lineTradeSettlementNode, "./ram:ReasonCode", nsmgr);
 
                             item.AddSpecifiedTradeAllowanceCharge(!chargeIndicator, // wichtig: das not (!) beachten
                                                         default(CurrencyCodes).FromString(basisAmountCurrency),
                                                         basisAmount,
                                                         actualAmount,
                                                         chargePercentage,
-                                                        reason);
+                                                        reason,
+                                                        EnumExtensions.FromDescription<AllowanceReasonCodes>(reasonCode));
                             break;
                         case "ram:SpecifiedTradeSettlementLineMonetarySummation":
                             //TODO
@@ -595,9 +599,9 @@ namespace s2industries.ZUGFeRD
                 foreach (XmlNode noteNode in noteNodes)
                 {
                     item.AssociatedDocument.Notes.Add(new Note(
-						content: XmlUtils.NodeAsString(noteNode, ".//ram:Content", nsmgr),
-						subjectCode: default(SubjectCodes).FromString(XmlUtils.NodeAsString(noteNode, ".//ram:SubjectCode", nsmgr)),
-						contentCode: default(ContentCodes).FromString(XmlUtils.NodeAsString(noteNode, ".//ram:ContentCode", nsmgr))
+                        content: XmlUtils.NodeAsString(noteNode, ".//ram:Content", nsmgr),
+                        subjectCode: default(SubjectCodes).FromString(XmlUtils.NodeAsString(noteNode, ".//ram:SubjectCode", nsmgr)),
+                        contentCode: default(ContentCodes).FromString(XmlUtils.NodeAsString(noteNode, ".//ram:ContentCode", nsmgr))
                     ));
                 }
             }

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -380,6 +380,7 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteEndElement();
                             #endregion
 
+                            Writer.WriteOptionalElementString("ram", "ReasonCode", tradeAllowanceCharge.ReasonCode.GetDescriptionAttribute(), Profile.Extended);
                             Writer.WriteOptionalElementString("ram", "Reason", tradeAllowanceCharge.Reason, Profile.Extended); // not in XRechnung according to CII-SR-128
 
                             Writer.WriteEndElement(); // !AppliedTradeAllowanceCharge
@@ -535,7 +536,7 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteEndElement();
                             #endregion
 
-                            // TODO: ReasonCode, BT-140, BT-145 -> missing in TradeAllowanceCharge
+                            Writer.WriteOptionalElementString("ram", "ReasonCode", specifiedTradeAllowanceCharge.ReasonCode.GetDescriptionAttribute()); // BT-140, BT-145
                             Writer.WriteOptionalElementString("ram", "Reason", specifiedTradeAllowanceCharge.Reason); // BT-139, BT-144
 
                             Writer.WriteEndElement(); // !ram:SpecifiedTradeAllowanceCharge
@@ -956,31 +957,36 @@ namespace s2industries.ZUGFeRD
             //  13. SpecifiedTradeAllowanceCharge (optional)
             foreach (TradeAllowanceCharge tradeAllowanceCharge in this.Descriptor.GetTradeAllowanceCharges())
             {
-                Writer.WriteStartElement("ram", "SpecifiedTradeAllowanceCharge");
-                Writer.WriteStartElement("ram", "ChargeIndicator");
-                Writer.WriteElementString("udt", "Indicator", tradeAllowanceCharge.ChargeIndicator ? "true" : "false");
+                Writer.WriteStartElement("ram", "SpecifiedTradeAllowanceCharge", ALL_PROFILES ^ Profile.Minimum);
+                Writer.WriteStartElement("ram", "ChargeIndicator"); // BG-21-0
+                Writer.WriteElementString("udt", "Indicator", tradeAllowanceCharge.ChargeIndicator ? "true" : "false"); // BG-21-1
                 Writer.WriteEndElement(); // !ram:ChargeIndicator
+
+                // TODO: SequenceNumeric, BT-X-268, Berechnungsreihenfolge
 
                 if (tradeAllowanceCharge.ChargePercentage.HasValue)
                 {
-                    Writer.WriteStartElement("ram", "CalculationPercent", profile: Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+                    Writer.WriteStartElement("ram", "CalculationPercent", profile: Profile.Extended | Profile.XRechnung1 | Profile.XRechnung); // BT-101
                     Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ChargePercentage.Value));
                     Writer.WriteEndElement();
                 }
 
                 if (tradeAllowanceCharge.BasisAmount.HasValue)
                 {
-                    Writer.WriteStartElement("ram", "BasisAmount", profile: Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+                    Writer.WriteStartElement("ram", "BasisAmount"); // BT-100
                     Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount.Value));
                     Writer.WriteEndElement();
                 }
 
-                Writer.WriteStartElement("ram", "ActualAmount");
+                // TODO: BasisQuantity (+unitCode), BT-X-269, Basismenge des Rabatts
+
+                Writer.WriteStartElement("ram", "ActualAmount"); // BT-99
                 Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 2));
                 Writer.WriteEndElement();
 
 
-                Writer.WriteOptionalElementString("ram", "Reason", tradeAllowanceCharge.Reason);
+                Writer.WriteOptionalElementString("ram", "ReasonCode", tradeAllowanceCharge.ReasonCode.GetDescriptionAttribute()); // BT-98
+                Writer.WriteOptionalElementString("ram", "Reason", tradeAllowanceCharge.Reason); // BT-97
 
                 if (tradeAllowanceCharge.Tax != null)
                 {

--- a/ZUGFeRD/TradeAllowanceCharge.cs
+++ b/ZUGFeRD/TradeAllowanceCharge.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,7 +26,7 @@ namespace s2industries.ZUGFeRD
 {
     /// <summary>
     /// Zu- und Abschlag
-    /// 
+    ///
     /// Beispiel:
     /// <SpecifiedTradeAllowanceCharge>
 	///   <ChargeIndicator>false</ChargeIndicator>
@@ -44,10 +44,10 @@ namespace s2industries.ZUGFeRD
     {
         /// <summary>
         /// Switch for discount and surcharge
-        /// 
+        ///
         /// false: Skonto
         /// true: Verzug
-        /// 
+        ///
         /// In case of a discount (BG-27) the value of the ChargeIndicators has to be "false". In case of a surcharge (BG-28) the value of the ChargeIndicators has to be "true".
         /// </summary>
         public bool ChargeIndicator { get; internal set; }
@@ -56,6 +56,11 @@ namespace s2industries.ZUGFeRD
         /// The reason for the surcharge or discount in written form
         /// </summary>
         public string Reason { get; internal set; }
+
+        /// <summary>
+        /// The reason code for the surcharge or discount
+        /// </summary>
+        public AllowanceReasonCodes ReasonCode { get; internal set; }
 
         /// <summary>
         /// The base amount that may be used in conjunction with the percentage of the invoice line discount to calculate the amount of the invoice line discount

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -277,7 +277,9 @@ namespace s2industries.ZUGFeRD
         /// <param name="basisAmount">Basis aount for the allowance or surcharge, typicalls the net amount of the item</param>
         /// <param name="actualAmount">The actual allowance or surcharge amount</param>
         /// <param name="reason">Reason for the allowance or surcharge</param>
-        public void AddTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount, string reason)
+        /// <param name="reasonCode">Reason code for the allowance or surcharge</param>
+        public void AddTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount,
+                                            string reason, AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Unknown)
         {
             this._TradeAllowanceCharges.Add(new TradeAllowanceCharge()
             {
@@ -285,7 +287,8 @@ namespace s2industries.ZUGFeRD
                 Currency = currency,
                 ActualAmount = actualAmount,
                 BasisAmount = basisAmount,
-                Reason = reason
+                Reason = reason,
+                ReasonCode = reasonCode
             });
         } // !AddTradeAllowanceCharge()
 
@@ -299,7 +302,9 @@ namespace s2industries.ZUGFeRD
         /// <param name="actualAmount">The actual allowance or surcharge amount</param>
         /// <param name="chargePercentage">Actual allowance or surcharge charge percentage</param>
         /// <param name="reason">Reason for the allowance or surcharge</param>
-        public void AddTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount, decimal? chargePercentage, string reason)
+        /// <param name="reasonCode">Reason code for the allowance or surcharge</param>
+        public void AddTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount,
+                                            decimal? chargePercentage, string reason, AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Unknown)
         {
             this._TradeAllowanceCharges.Add(new TradeAllowanceCharge()
             {
@@ -308,7 +313,8 @@ namespace s2industries.ZUGFeRD
                 ActualAmount = actualAmount,
                 BasisAmount = basisAmount,
                 ChargePercentage = chargePercentage,
-                Reason = reason
+                Reason = reason,
+                ReasonCode = reasonCode
             });
         } // !AddTradeAllowanceCharge()
 
@@ -331,7 +337,9 @@ namespace s2industries.ZUGFeRD
         /// <param name="basisAmount">Basis aount for the allowance or surcharge, typicalls the net amount of the item</param>
         /// <param name="actualAmount">The actual allowance or surcharge amount</param>
         /// <param name="reason">Reason for the allowance or surcharge</param>
-        public void AddSpecifiedTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount, string reason)
+        public void AddSpecifiedTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount,
+                                                     string reason,
+                                                     AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Unknown)
         {
             this.SpecifiedTradeAllowanceCharges.Add(new TradeAllowanceCharge()
             {
@@ -339,7 +347,8 @@ namespace s2industries.ZUGFeRD
                 Currency = currency,
                 ActualAmount = actualAmount,
                 BasisAmount = basisAmount,
-                Reason = reason
+                Reason = reason,
+                ReasonCode = reasonCode
             });
         } // !AddSpecifiedTradeAllowanceCharge()
 
@@ -353,7 +362,9 @@ namespace s2industries.ZUGFeRD
         /// <param name="actualAmount">The actual allowance or surcharge amount</param>
         /// <param name="chargePercentage">Actual allowance or surcharge charge percentage</param>
         /// <param name="reason">Reason for the allowance or surcharge</param>
-        public void AddSpecifiedTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount, decimal? chargePercentage, string reason)
+        public void AddSpecifiedTradeAllowanceCharge(bool isDiscount, CurrencyCodes currency, decimal? basisAmount, decimal actualAmount,
+                                                     decimal? chargePercentage, string reason,
+                                                     AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Unknown)
         {
             this.SpecifiedTradeAllowanceCharges.Add(new TradeAllowanceCharge()
             {
@@ -362,7 +373,8 @@ namespace s2industries.ZUGFeRD
                 ActualAmount = actualAmount,
                 BasisAmount = basisAmount,
                 ChargePercentage = chargePercentage,
-                Reason = reason
+                Reason = reason,
+                ReasonCode = reasonCode
             });
         } // !AddSpecifiedTradeAllowanceCharge()
 


### PR DESCRIPTION
- Added `ReasonCode` to `TradeAllowanceCharge` and all invoice readers/writers
- Updated tests in several places to write/read a ReasonCode
- Added new file `AllowanceReasonCodes.cs` (tbd if I missed any codes). Note: the actual value being used in files is in the description.
  Maybe there're nicer ways to do this with mixed numeric and literal codes?
- Added 2 new methods to the EnumExtensions.