### PR TITLE
Fix null handling in EnumExtensions (followup to #575)

### DIFF
--- a/ZUGFeRD/EnumExtensions.cs
+++ b/ZUGFeRD/EnumExtensions.cs
@@ -40,7 +40,7 @@ namespace s2industries.ZUGFeRD
             }
             else
             {
-                return default(T);
+                return default;
             }
         } // !IntToEnum()
 
@@ -53,7 +53,7 @@ namespace s2industries.ZUGFeRD
             }
             catch
             {
-                return default(T);
+                return default;
             }
         } // !IntToEnum()
 
@@ -67,8 +67,12 @@ namespace s2industries.ZUGFeRD
         internal static string GetDescriptionAttribute<T>(this T value) where T : Enum
         {
             FieldInfo field = value.GetType().GetField(value.ToString());
+            if (field == null)
+            {
+                return null;
+            }
             DescriptionAttribute attribute = field.GetCustomAttribute<DescriptionAttribute>();
-            return attribute?.Description ?? value.ToString();
+            return attribute?.Description;
         } // !GetDescriptionAttribute()
 
 
@@ -76,16 +80,17 @@ namespace s2industries.ZUGFeRD
         {
             if (string.IsNullOrEmpty(code))
             {
-                return default(T);
+                return default;
             }
             foreach (T value in Enum.GetValues(typeof(T)))
             {
-                if (value.GetDescriptionAttribute().Equals(code, StringComparison.OrdinalIgnoreCase))
+                var description = value.GetDescriptionAttribute();
+                if (description != null && description.Equals(code, StringComparison.OrdinalIgnoreCase))
                 {
                     return value;
                 }
             }
-            return default(T);
+            return default;
         } // !FromDescription()
     }
 }


### PR DESCRIPTION
In #575 I had introduced 2 new methods to `EnumExtensions.cs`.
This PR fixes their handling of `null` values to correctly avoid exceptions.
Also, simplified `default(T)` expressions to just `default`.