### PR TITLE
22UBLWriter / AllowanceCharge: order of elements (reason before amount)

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -430,19 +430,6 @@ namespace s2industries.ZUGFeRD
 
                 Writer.WriteElementString("cbc", "ChargeIndicator", tradeAllowanceCharge.ChargeIndicator ? "true" : "false");
 
-                Writer.WriteStartElement("cbc", "Amount"); // BT-92 / BT-99
-                Writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
-                Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount));
-                Writer.WriteEndElement();
-
-                if (tradeAllowanceCharge.BasisAmount != null)
-                {
-                    Writer.WriteStartElement("cbc", "BaseAmount"); // BT-93 / BT-100
-                    Writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
-                    Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount));
-                    Writer.WriteEndElement();
-                }
-
                 if (tradeAllowanceCharge.ReasonCode != AllowanceReasonCodes.Unknown)
                 {
                     Writer.WriteStartElement("cbc", "AllowanceChargeReasonCode"); // BT-97 / BT-104
@@ -454,6 +441,19 @@ namespace s2industries.ZUGFeRD
                 {
                     Writer.WriteStartElement("cbc", "AllowanceChargeReason"); // BT-97 / BT-104
                     Writer.WriteValue(tradeAllowanceCharge.Reason);
+                    Writer.WriteEndElement();
+                }
+
+                Writer.WriteStartElement("cbc", "Amount"); // BT-92 / BT-99
+                Writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
+                Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount));
+                Writer.WriteEndElement();
+
+                if (tradeAllowanceCharge.BasisAmount != null)
+                {
+                    Writer.WriteStartElement("cbc", "BaseAmount"); // BT-93 / BT-100
+                    Writer.WriteAttributeString("currencyID", this.Descriptor.Currency.EnumToString());
+                    Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount));
                     Writer.WriteEndElement();
                 }
 


### PR DESCRIPTION
Correct order of elements according to xml schema "UBL-CommonAggregateComponents-2.1.xsd":

   <xsd:complexType name="AllowanceChargeType">
      <xsd:sequence>
         <xsd:element ref="cbc:ID" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:ChargeIndicator" minOccurs="1" maxOccurs="1"/>
         **<xsd:element ref="cbc:AllowanceChargeReasonCode" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:AllowanceChargeReason" minOccurs="0" maxOccurs="unbounded"/>**
         <xsd:element ref="cbc:MultiplierFactorNumeric" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:PrepaidIndicator" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:SequenceNumeric" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:Amount" minOccurs="1" maxOccurs="1"/>
         <xsd:element ref="cbc:BaseAmount" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:AccountingCostCode" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:AccountingCost" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cbc:PerUnitAmount" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cac:TaxCategory" minOccurs="0" maxOccurs="unbounded"/>
         <xsd:element ref="cac:TaxTotal" minOccurs="0" maxOccurs="1"/>
         <xsd:element ref="cac:PaymentMeans" minOccurs="0" maxOccurs="unbounded"/>
      </xsd:sequence>
   </xsd:complexType>