### PR TITLE
added line identifiers to DeliveryNoteReferencedDocument and ContractReferencedDocument

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD20Tests.cs
@@ -578,8 +578,8 @@ namespace s2industries.ZUGFeRD.Test
             lineItem.Description = "This is line item TB100A4";
             lineItem.BuyerAssignedID = "0815";
             lineItem.SetOrderReferencedDocument("12345", timestamp, "1");
-            lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp);
-            lineItem.SetContractReferencedDocument("12345", timestamp);
+            lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp, "1");
+            lineItem.SetContractReferencedDocument("12345", timestamp, "1");
 
             lineItem.AddAdditionalReferencedDocument("xyz", AdditionalReferencedDocumentTypeCode.ReferenceDocument, ReferenceTypeCodes.AAB, timestamp);
 
@@ -787,8 +787,10 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual("1", loadedLineItem.BuyerOrderReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.BuyerOrderReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.BuyerOrderReferencedDocument.IssueDateTime);
+            Assert.AreEqual("1", loadedLineItem.DeliveryNoteReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.DeliveryNoteReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.DeliveryNoteReferencedDocument.IssueDateTime);
+            Assert.AreEqual("1", loadedLineItem.ContractReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.ContractReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.ContractReferencedDocument.IssueDateTime);
 

--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -1847,8 +1847,8 @@ namespace s2industries.ZUGFeRD.Test
             lineItem.Description = "This is line item TB100A4";
             lineItem.BuyerAssignedID = "0815";
             lineItem.SetOrderReferencedDocument("12345", timestamp, "1");
-            lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp);
-            lineItem.SetContractReferencedDocument("12345", timestamp);
+            lineItem.SetDeliveryNoteReferencedDocument("12345", timestamp, "1");
+            lineItem.SetContractReferencedDocument("12345", timestamp, "1");
 
             lineItem.AddAdditionalReferencedDocument("xyz", AdditionalReferencedDocumentTypeCode.ReferenceDocument, ReferenceTypeCodes.AAB, timestamp);
             lineItem.AddAdditionalReferencedDocument("abc", AdditionalReferencedDocumentTypeCode.InvoiceDataSheet, ReferenceTypeCodes.PP, timestamp);
@@ -2059,8 +2059,10 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual("1", loadedLineItem.BuyerOrderReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.BuyerOrderReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.BuyerOrderReferencedDocument.IssueDateTime);
+            Assert.AreEqual("1", loadedLineItem.DeliveryNoteReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.DeliveryNoteReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.DeliveryNoteReferencedDocument.IssueDateTime);
+            Assert.AreEqual("1", loadedLineItem.ContractReferencedDocument.LineID);
             Assert.AreEqual("12345", loadedLineItem.ContractReferencedDocument.ID);
             Assert.AreEqual(timestamp, loadedLineItem.ContractReferencedDocument.IssueDateTime);
 

--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -1,4 +1,22 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace s2industries.ZUGFeRD.Test
+{
+    [TestClass]
+    public class ZUGFeRDCrossVersionTests : TestBase
+    {
+        private InvoiceProvider _InvoiceProvider = new InvoiceProvider();
+
+        [TestMethod]
+        [DataRow(ZUGFeRDVersion.Version1)]
+        [DataRow(ZUGFeRDVersion.Version20)]
+        [DataRow(ZUGFeRDVersion.Version23)]
+        public void TestDeliveryNoteReferencedDocumentLineIdInExtended(ZUGFeRDVersion version)
+        {
+            string deliveryNoteNumber = "DeliveryNote-0815";
+            DateTime deliveryNoteDate = DateTime.Today;
+            string deliveryNoteLineID = "0815.001";
+
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+
+            TradeLineItem line = desc.AddTradeLineItem("DeliveryNoteReferencedDocument-Text");
+            line.SetDeliveryNoteReferencedDocument(deliveryNoteNumber, deliveryNoteDate, deliveryNoteLineID);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, version, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            TradeLineItem? loadedLine = loadedInvoice.TradeLineItems.LastOrDefault();
+
+            Assert.IsNotNull(loadedLine);
+            Assert.IsNotNull(loadedLine?.DeliveryNoteReferencedDocument);
+            Assert.AreEqual(deliveryNoteNumber, loadedLine?.DeliveryNoteReferencedDocument?.ID);
+            Assert.AreEqual(deliveryNoteDate, loadedLine?.DeliveryNoteReferencedDocument?.IssueDateTime);
+            Assert.AreEqual(deliveryNoteLineID, loadedLine?.DeliveryNoteReferencedDocument?.LineID);
+        }
+
+        [TestMethod]
+        [DataRow(ZUGFeRDVersion.Version1)]
+        [DataRow(ZUGFeRDVersion.Version20)]
+        [DataRow(ZUGFeRDVersion.Version23)]
+        public void TestContractReferencedDocumentLineIdInExtended(ZUGFeRDVersion version)
+        {
+            string contractNumber = "Contract-0815";
+            DateTime contractDate = DateTime.Today;
+            string contractLineID = "0815.001";
+
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+
+            TradeLineItem line = desc.AddTradeLineItem("ContractReferencedDocument-Text");
+            line.SetContractReferencedDocument(contractNumber, contractDate, contractLineID);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, version, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            TradeLineItem? loadedLine = loadedInvoice.TradeLineItems.LastOrDefault();
+
+            Assert.IsNotNull(loadedLine);
+            Assert.IsNotNull(loadedLine?.ContractReferencedDocument);
+            Assert.AreEqual(contractNumber, loadedLine?.ContractReferencedDocument?.ID);
+            Assert.AreEqual(contractDate, loadedLine?.ContractReferencedDocument?.IssueDateTime);
+            Assert.AreEqual(contractLineID, loadedLine?.ContractReferencedDocument?.LineID);
+        }
+    }
+}

--- a/ZUGFeRD/ContractReferencedDocument.cs
+++ b/ZUGFeRD/ContractReferencedDocument.cs
@@ -29,5 +29,9 @@ namespace s2industries.ZUGFeRD
     /// </summary>
     public class ContractReferencedDocument : BaseReferencedDocument
     {
+        /// <summary>
+        /// Reference to the contract position BT-X-25
+        /// </summary>
+        public string LineID { get; set; }
     }
 }

--- a/ZUGFeRD/DeliveryNoteReferencedDocument.cs
+++ b/ZUGFeRD/DeliveryNoteReferencedDocument.cs
@@ -28,5 +28,9 @@ namespace s2industries.ZUGFeRD
     /// </summary>
     public class DeliveryNoteReferencedDocument : BaseReferencedDocument
     {
+        /// <summary>
+        /// Reference to the delivery note item BT-X-93
+        /// </summary>
+        public string LineID { get; set; }
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor1Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Reader.cs
@@ -372,6 +372,7 @@ namespace s2industries.ZUGFeRD
                 {
                     ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID", nsmgr),
                     IssueDateTime = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime", nsmgr),
+                    LineID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID", nsmgr)
                 };
             }
 
@@ -386,6 +387,7 @@ namespace s2industries.ZUGFeRD
                 {
                     ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:ID", nsmgr),
                     IssueDateTime = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:IssueDateTime", nsmgr),
+                    LineID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedSupplyChainTradeAgreement/ram:ContractReferencedDocument/ram:LineID", nsmgr)
                 };
             }
 

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -497,6 +497,7 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteValue(_formatDate(tradeLineItem.ContractReferencedDocument.IssueDateTime.Value, false));
                             Writer.WriteEndElement(); // !ram:IssueDateTime
                         }
+                        Writer.WriteOptionalElementString("ram", "LineID", tradeLineItem.ContractReferencedDocument.LineID);
                         Writer.WriteOptionalElementString("ram", "ID", tradeLineItem.ContractReferencedDocument.ID);
                         Writer.WriteEndElement(); // !ram:ContractReferencedDocument
                     }
@@ -581,6 +582,7 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteValue(_formatDate(tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.Value, false));
                             Writer.WriteEndElement(); // !ram:IssueDateTime
                         }
+                        Writer.WriteOptionalElementString("ram", "LineID", tradeLineItem.DeliveryNoteReferencedDocument.LineID);
                         Writer.WriteOptionalElementString("ram", "ID", tradeLineItem.DeliveryNoteReferencedDocument.ID);
                         Writer.WriteEndElement(); // !ram:DeliveryNoteReferencedDocument
                     }

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -479,6 +479,7 @@ namespace s2industries.ZUGFeRD
                 item.DeliveryNoteReferencedDocument = new DeliveryNoteReferencedDocument()
                 {
                     ID = XmlUtils.NodeAsString(deliveryNoteReferencedDocumentNode, "ram:IssuerAssignedID", nsmgr),
+                    LineID = XmlUtils.NodeAsString(deliveryNoteReferencedDocumentNode, "ram:LineID", nsmgr),
                     IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(deliveryNoteReferencedDocumentNode, "ram:FormattedIssueDateTime", nsmgr),
                 };
             }
@@ -494,6 +495,7 @@ namespace s2industries.ZUGFeRD
                 item.ContractReferencedDocument = new ContractReferencedDocument()
                 {
                     ID = XmlUtils.NodeAsString(contractReferencedDocument, "ram:IssuerAssignedID", nsmgr),
+                    LineID = XmlUtils.NodeAsString(contractReferencedDocument, "ram:LineID", nsmgr),
                     IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(contractReferencedDocument, "ram:FormattedIssueDateTime", nsmgr),
                 };
             }

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -220,6 +220,10 @@ namespace s2industries.ZUGFeRD
                 if (tradeLineItem.ContractReferencedDocument != null)
                 {
                     Writer.WriteStartElement("ram", "ContractReferencedDocument", Profile.Extended);
+
+                    // reference to the contract position
+                    Writer.WriteOptionalElementString("ram", "LineID", tradeLineItem.ContractReferencedDocument.LineID);
+
                     if (tradeLineItem.ContractReferencedDocument.IssueDateTime.HasValue)
                     {
                         Writer.WriteStartElement("ram", "FormattedIssueDateTime");
@@ -324,12 +328,13 @@ namespace s2industries.ZUGFeRD
                             Writer.WriteStartElement("ram", "FormattedIssueDateTime");
                             Writer.WriteStartElement("qdt", "DateTimeString");
                             Writer.WriteAttributeString("format", "102");
-                            Writer.WriteValue(_formatDate(this.Descriptor.OrderDate.Value));
+                            Writer.WriteValue(_formatDate(tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.Value));
                             Writer.WriteEndElement(); // !qdt:DateTimeString
                             Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
                         }
 
                         Writer.WriteOptionalElementString("ram", "IssuerAssignedID", tradeLineItem.DeliveryNoteReferencedDocument.ID);
+                        Writer.WriteOptionalElementString("ram", "LineID", tradeLineItem.DeliveryNoteReferencedDocument.LineID);
                         Writer.WriteEndElement(); // !ram:DeliveryNoteReferencedDocument
                     }
 

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -504,7 +504,8 @@ namespace s2industries.ZUGFeRD
                 item.ContractReferencedDocument = new ContractReferencedDocument()
                 {
                     ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(tradeLineItem, "//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime", nsmgr)
+                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(tradeLineItem, "//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:FormattedIssueDateTime", nsmgr),
+                    LineID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument/ram:LineID", nsmgr)
                 };
             }
 
@@ -599,7 +600,8 @@ namespace s2industries.ZUGFeRD
                 item.DeliveryNoteReferencedDocument = new DeliveryNoteReferencedDocument()
                 {
                     ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr),
-                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime", nsmgr)
+                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime", nsmgr),
+                    LineID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:LineID", nsmgr)
                 };
             }
 

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -300,6 +300,10 @@ namespace s2industries.ZUGFeRD
                     if (tradeLineItem.ContractReferencedDocument != null)
                     {
                         Writer.WriteStartElement("ram", "ContractReferencedDocument", Profile.Extended);
+
+                        // reference to the contract position
+                        Writer.WriteOptionalElementString("ram", "LineID", tradeLineItem.ContractReferencedDocument.LineID);
+
                         if (tradeLineItem.ContractReferencedDocument.IssueDateTime.HasValue)
                         {
                             Writer.WriteStartElement("ram", "FormattedIssueDateTime");
@@ -440,6 +444,9 @@ namespace s2industries.ZUGFeRD
                 {
                     Writer.WriteStartElement("ram", "DeliveryNoteReferencedDocument", Profile.Extended); // this violates CII-SR-175 for XRechnung 3
                     Writer.WriteOptionalElementString("ram", "IssuerAssignedID", tradeLineItem.DeliveryNoteReferencedDocument.ID);
+
+                    // reference to the delivery note item
+                    Writer.WriteOptionalElementString("ram", "LineID", tradeLineItem.DeliveryNoteReferencedDocument.LineID);
 
                     if (tradeLineItem.DeliveryNoteReferencedDocument.IssueDateTime.HasValue)
                     {

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -409,10 +409,12 @@ namespace s2industries.ZUGFeRD
         }
 
         /// <summary>
-        /// Sets the delivery note reference information for this trade line item
+        /// Sets the delivery note reference information for this trade line item. BG-X-83
+        /// Only available in Extended profile.
         /// </summary>
-        /// <param name="deliveryNoteId">The identifier of the delivery note</param>
-        /// <param name="deliveryNoteDate">The date of the delivery note</param>
+        /// <param name="deliveryNoteId">The identifier of the delivery note. BT-X-92</param>
+        /// <param name="deliveryNoteDate">The date of the delivery note. BT-X-94</param>
+        /// <param name="deliveryNoteReferencedLineId">The identifier of the delivery note item. BT-X-93</param>
         public void SetDeliveryNoteReferencedDocument(string deliveryNoteId, DateTime? deliveryNoteDate, string deliveryNoteReferencedLineId = null)
         {
             this.DeliveryNoteReferencedDocument = new DeliveryNoteReferencedDocument()
@@ -516,10 +518,12 @@ namespace s2industries.ZUGFeRD
 
 
         /// <summary>
-        /// Sets the contract reference information for this trade line item
+        /// Sets the contract reference information for this trade line item. BG-X-2
+        /// Only available in Extended profile.
         /// </summary>
-        /// <param name="contractReferencedId">The identifier of the contract</param>
-        /// <param name="contractReferencedDate">The date of the contract</param>
+        /// <param name="contractReferencedId">The identifier of the contract. BT-X-24</param>
+        /// <param name="contractReferencedDate">The date of the contract. BT-X-26</param>
+        /// <param name="contractReferencedLineId">The identifier of the contract position. BT-X-25</param>
         public void SetContractReferencedDocument(string contractReferencedId, DateTime? contractReferencedDate, string contractReferencedLineId = null)
         {
             this.ContractReferencedDocument = new ContractReferencedDocument()

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -413,12 +413,13 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         /// <param name="deliveryNoteId">The identifier of the delivery note</param>
         /// <param name="deliveryNoteDate">The date of the delivery note</param>
-        public void SetDeliveryNoteReferencedDocument(string deliveryNoteId, DateTime? deliveryNoteDate)
+        public void SetDeliveryNoteReferencedDocument(string deliveryNoteId, DateTime? deliveryNoteDate, string deliveryNoteReferencedLineId = null)
         {
             this.DeliveryNoteReferencedDocument = new DeliveryNoteReferencedDocument()
             {
                 ID = deliveryNoteId,
-                IssueDateTime = deliveryNoteDate
+                IssueDateTime = deliveryNoteDate,
+                LineID = deliveryNoteReferencedLineId
             };
         } // !SetDeliveryNoteReferencedDocument()
 
@@ -519,12 +520,13 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         /// <param name="contractReferencedId">The identifier of the contract</param>
         /// <param name="contractReferencedDate">The date of the contract</param>
-        public void SetContractReferencedDocument(string contractReferencedId, DateTime? contractReferencedDate)
+        public void SetContractReferencedDocument(string contractReferencedId, DateTime? contractReferencedDate, string contractReferencedLineId = null)
         {
             this.ContractReferencedDocument = new ContractReferencedDocument()
             {
                 ID = contractReferencedId,
-                IssueDateTime = contractReferencedDate
+                IssueDateTime = contractReferencedDate,
+                LineID = contractReferencedLineId
             };
         } // !SetContractReferencedDocument()
 


### PR DESCRIPTION
LineID for DeliveryNoteReferencedDocument and ContractReferencedDocument are available since ZUGFeRD v1. I have reviewed all three documentations regarding this.

Viele Grüße :)