### PR TITLE
Remove try-catch parsing, which throws a lot of exceptions

### DIFF
--- a/ZUGFeRD/ContentCodes.cs
+++ b/ZUGFeRD/ContentCodes.cs
@@ -76,14 +76,11 @@ namespace s2industries.ZUGFeRD
     {
         public static ContentCodes FromString(this ContentCodes _, string s)
         {
-            try
+            if (Enum.TryParse(s, true, out ContentCodes result))
             {
-                return (ContentCodes)Enum.Parse(typeof(ContentCodes), s);
+                return result;
             }
-            catch
-            {
-                return ContentCodes.Unknown;
-            }
+            return ContentCodes.Unknown;
         } // !FromString()
 
 

--- a/ZUGFeRD/CountryCodes.cs
+++ b/ZUGFeRD/CountryCodes.cs
@@ -1581,16 +1581,13 @@ namespace s2industries.ZUGFeRD
                 return CountryCodes._1A;
             }
 
-            try
+            if (Enum.TryParse(s, true, out CountryCodes result))
             {
-                return (CountryCodes)Enum.Parse(typeof(CountryCodes), s);
+                return result;
             }
-            catch
-            {
-                return CountryCodes.Unknown;
-            }
-        } // !FromString()
 
+            return CountryCodes.Unknown;
+        } // !FromString()
 
         public static string EnumToString(this CountryCodes c)
         {

--- a/ZUGFeRD/EnumExtensions.cs
+++ b/ZUGFeRD/EnumExtensions.cs
@@ -44,18 +44,14 @@ namespace s2industries.ZUGFeRD
             }
         } // !IntToEnum()
 
-
-        internal static T StringToEnum<T>(this string value) where T : Enum
+        internal static T StringToEnum<T>(this string value) where T : struct, Enum
         {
-            try
+            if (Enum.TryParse(value, true, out T result))
             {
-                return (T)Enum.Parse(typeof(T), value);
+                return result;
             }
-            catch
-            {
-                return default;
-            }
-        } // !IntToEnum()
+            return default;
+        } // !StringToEnum()
 
 
         internal static int EnumToInt<T>(this T value) where T : Enum

--- a/ZUGFeRD/QuantityCodes.cs
+++ b/ZUGFeRD/QuantityCodes.cs
@@ -634,42 +634,31 @@ namespace s2industries.ZUGFeRD
     {
         public static QuantityCodes FromString(this QuantityCodes _, string s)
         {
-            try
+            if (!string.IsNullOrWhiteSpace(s) && char.IsDigit(s[0]))
             {
-                if (!string.IsNullOrWhiteSpace(s) && char.IsDigit(s[0]))
-                {
-                    return (QuantityCodes)Enum.Parse(typeof(QuantityCodes), "_" + s);
-                }
-                else
-                {
-                    return (QuantityCodes)Enum.Parse(typeof(QuantityCodes), s);
-                }
+                s = "_" + s;
             }
-            catch
-            {
-                // mapping of legacy unit codes
-                if (s == "NPR")
-                {
-                    return QuantityCodes.PR;
-                }
-                else if (s == "PCE")
-                {
-                    return QuantityCodes.C62;
-                }
-                else if (s == "KTM")
-                {
-                    return QuantityCodes.KMT;
-                }
-                else if (s == "HAR")
-                {
-                    return QuantityCodes.H18;
-                }
-                else if (s == "D64")
-                {
-                    return QuantityCodes.XOK;
-                }
 
-                return QuantityCodes.Unknown;
+            if (Enum.TryParse(s, true, out QuantityCodes result))
+            {
+                return result;
+            }
+
+            // mapping of legacy unit codes
+            switch (s)
+            {
+                case "NPR":
+                    return QuantityCodes.PR;
+                case "PCE":
+                    return QuantityCodes.C62;
+                case "KTM":
+                    return QuantityCodes.KMT;
+                case "HAR":
+                    return QuantityCodes.H18;
+                case "D64":
+                    return QuantityCodes.XOK;
+                default:
+                    return QuantityCodes.Unknown;
             }
         } // !FromString()
 

--- a/ZUGFeRD/ReferenceTypeCodes.cs
+++ b/ZUGFeRD/ReferenceTypeCodes.cs
@@ -249,14 +249,11 @@ namespace s2industries.ZUGFeRD
     {
         public static ReferenceTypeCodes FromString(this ReferenceTypeCodes _, string s)
         {
-            try
+            if (Enum.TryParse(s, true, out ReferenceTypeCodes result))
             {
-                return (ReferenceTypeCodes)Enum.Parse(typeof(ReferenceTypeCodes), s);
+                return result;
             }
-            catch
-            {
-                return ReferenceTypeCodes.Unknown;
-            }
+            return ReferenceTypeCodes.Unknown;
         } // !FromString()
 
 

--- a/ZUGFeRD/TaxExemptionReasonCodes.cs
+++ b/ZUGFeRD/TaxExemptionReasonCodes.cs
@@ -491,14 +491,11 @@ namespace s2industries.ZUGFeRD
     {
         public static TaxExemptionReasonCodes? FromString(this TaxExemptionReasonCodes _, string s)
         {
-            try
+            if (Enum.TryParse(s.Replace("-", "_"), true, out TaxExemptionReasonCodes result))
             {
-                return (TaxExemptionReasonCodes)Enum.Parse(typeof(TaxExemptionReasonCodes), s.Replace("-", "_"));
+                return result;
             }
-            catch
-            {
-                return null;
-            }
+            return null;
         } // !FromString()
 
 

--- a/ZUGFeRD/TaxRegistrationSchemeID.cs
+++ b/ZUGFeRD/TaxRegistrationSchemeID.cs
@@ -59,14 +59,11 @@ namespace s2industries.ZUGFeRD
     {
         public static TaxRegistrationSchemeID FromString(this TaxRegistrationSchemeID _, string s)
         {
-            try
+            if (Enum.TryParse(s, true, out TaxRegistrationSchemeID result))
             {
-                return (TaxRegistrationSchemeID)Enum.Parse(typeof(TaxRegistrationSchemeID), s);
+                return result;
             }
-            catch
-            {
-                return TaxRegistrationSchemeID.Unknown;
-            }
+            return TaxRegistrationSchemeID.Unknown;
         } // !FromString()
 
 


### PR DESCRIPTION
During debugging, I saw a lot of catched exceptions. I think it makes more sense to use TryParse instead of try-catch.