### PR TITLE
add MaturityDate (BT-X-276-0 and BT-X-282-0) a.k.a. SpecifiedTradePay…

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -2311,7 +2311,7 @@ namespace s2industries.ZUGFeRD.Test
             MemoryStream ms = new MemoryStream();
 
             desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung);
-            desc.Save("e:\\output.xml", ZUGFeRDVersion.Version23, Profile.XRechnung);
+            desc.Save("output.xml", ZUGFeRDVersion.Version23, Profile.XRechnung);
             ms.Seek(0, SeekOrigin.Begin);
 
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -1144,7 +1144,7 @@ namespace s2industries.ZUGFeRD
         /// <param name="actualAmount">Optional actual amount</param>
         public void AddTradePaymentTerms(string description, DateTime? dueDate = null,
             PaymentTermsType? paymentTermsType = null, int? dueDays = null,
-            decimal? percentage = null, decimal? baseAmount = null, decimal? actualAmount = null)
+            decimal? percentage = null, decimal? baseAmount = null, decimal? actualAmount = null, DateTime? maturityDate = null)
         {
             _PaymentTerms.Add(new PaymentTerms()
             {
@@ -1154,7 +1154,8 @@ namespace s2industries.ZUGFeRD
                 DueDays = dueDays,
                 Percentage = percentage,
                 BaseAmount = baseAmount,
-                ActualAmount = actualAmount
+                ActualAmount = actualAmount,
+                MaturityDate = maturityDate
             });
         }
 

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -386,6 +386,7 @@ namespace s2industries.ZUGFeRD
                             _writeElementWithAttribute(Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
                             Writer.WriteEndElement(); // !ram:DueDateDateTime
                         }
+                        Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         if (paymentTerms.PaymentTermsType.HasValue)
                         {
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
@@ -405,7 +406,6 @@ namespace s2industries.ZUGFeRD
                                 Writer.WriteEndElement(); // !ram:ApplicableTradePaymentPenaltyTerms
                             }
                         }
-                        Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }
                     if (this.Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -816,6 +816,7 @@ namespace s2industries.ZUGFeRD
                             _writeElementWithAttribute(Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
                             Writer.WriteEndElement(); // !ram:DueDateDateTime
                         }
+                        Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         if (paymentTerms.PaymentTermsType.HasValue)
                         {
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
@@ -835,7 +836,6 @@ namespace s2industries.ZUGFeRD
                                 Writer.WriteEndElement(); // !ram:ApplicableTradePaymentPenaltyTerms
                             }
                         }
-                        Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }
                     if (this.Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -349,11 +349,17 @@ namespace s2industries.ZUGFeRD
             foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedTradePaymentTerms", nsmgr))
             {
                 decimal? discountPercent = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:CalculationPercent", nsmgr, null);
-                int? discountDueDays = null; // XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure", nsmgr);
+                int? discountDueDays = null;
+                if (QuantityCodes.DAY == default(QuantityCodes).FromString(XmlUtils.NodeAsString(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure/@unitCode", nsmgr)))
+                  discountDueDays = XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure", nsmgr);
+                DateTime? discountMaturityDate = XmlUtils.NodeAsDateTime(node, ".////ram:ApplicableTradePaymentDiscountTerms/ram:BasisDateTime/udt:DateTimeString", nsmgr); //BT-X-282-0
                 decimal? discountBaseAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount", nsmgr, null);
                 decimal? discountActualAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:ActualDiscountAmount", nsmgr, null);
                 decimal? penaltyPercent = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent", nsmgr, null);
-                int? penaltyDueDays = null; // XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure", nsmgr);
+                int? penaltyDueDays = null; 
+                if (QuantityCodes.DAY == default(QuantityCodes).FromString(XmlUtils.NodeAsString(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure/@unitCode", nsmgr)))
+                  discountDueDays = XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure", nsmgr);
+                DateTime? penaltyMaturityDate = XmlUtils.NodeAsDateTime(node, ".////ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString", nsmgr); // BT-X-276-0
                 decimal? penaltyBaseAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount", nsmgr, null);
                 decimal? penaltyActualAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:ActualPenaltyAmount", nsmgr, null);
                 PaymentTermsType? paymentTermsType = discountPercent.HasValue ? PaymentTermsType.Skonto :
@@ -366,7 +372,8 @@ namespace s2industries.ZUGFeRD
                                             discountDueDays ?? penaltyDueDays,
                                             discountPercent ?? penaltyPercent,
                                             discountBaseAmount ?? penaltyBaseAmount,
-                                            discountActualAmount ?? penaltyActualAmount);
+                                            discountActualAmount ?? penaltyActualAmount,
+                                            discountMaturityDate ?? penaltyMaturityDate);
             }
 
             retval.LineTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:LineTotalAmount", nsmgr);

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -352,14 +352,14 @@ namespace s2industries.ZUGFeRD
                 int? discountDueDays = null;
                 if (QuantityCodes.DAY == default(QuantityCodes).FromString(XmlUtils.NodeAsString(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure/@unitCode", nsmgr)))
                   discountDueDays = XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisPeriodMeasure", nsmgr);
-                DateTime? discountMaturityDate = XmlUtils.NodeAsDateTime(node, ".////ram:ApplicableTradePaymentDiscountTerms/ram:BasisDateTime/udt:DateTimeString", nsmgr); //BT-X-282-0
+                DateTime? discountMaturityDate = XmlUtils.NodeAsDateTime(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisDateTime/udt:DateTimeString", nsmgr); //BT-X-282-0
                 decimal? discountBaseAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount", nsmgr, null);
                 decimal? discountActualAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:ActualDiscountAmount", nsmgr, null);
                 decimal? penaltyPercent = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent", nsmgr, null);
                 int? penaltyDueDays = null; 
                 if (QuantityCodes.DAY == default(QuantityCodes).FromString(XmlUtils.NodeAsString(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure/@unitCode", nsmgr)))
                   discountDueDays = XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure", nsmgr);
-                DateTime? penaltyMaturityDate = XmlUtils.NodeAsDateTime(node, ".////ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString", nsmgr); // BT-X-276-0
+                DateTime? penaltyMaturityDate = XmlUtils.NodeAsDateTime(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString", nsmgr); // BT-X-276-0
                 decimal? penaltyBaseAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount", nsmgr, null);
                 decimal? penaltyActualAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:ActualPenaltyAmount", nsmgr, null);
                 PaymentTermsType? paymentTermsType = discountPercent.HasValue ? PaymentTermsType.Skonto :

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1138,6 +1138,16 @@ namespace s2industries.ZUGFeRD
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
                             {
                                 Writer.WriteStartElement("ram", "ApplicableTradePaymentDiscountTerms");
+                                if (paymentTerms.MaturityDate.HasValue)
+                                {
+                                    Writer.WriteStartElement("ram", "BasisDateTime");
+                                    _writeElementWithAttributeWithPrefix(Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.MaturityDate.Value));
+                                    Writer.WriteEndElement(); // !ram:BasisDateTime
+                                }
+                                if (paymentTerms.DueDays.HasValue)
+                                {
+                                    _writeElementWithAttribute(Writer, "ram", "BasisPeriodMeasure", "unitCode", "DAY", paymentTerms.DueDays.Value.ToString());
+                                }
                                 _writeOptionalAmount(Writer, "ram", "BasisAmount", paymentTerms.BaseAmount, forceCurrency: false);
                                 Writer.WriteOptionalElementString("ram", "CalculationPercent", _formatDecimal(paymentTerms.Percentage));
                                 _writeOptionalAmount(Writer, "ram", "ActualDiscountAmount", paymentTerms.ActualAmount, forceCurrency: false);
@@ -1146,6 +1156,16 @@ namespace s2industries.ZUGFeRD
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Verzug)
                             {
                                 Writer.WriteStartElement("ram", "ApplicableTradePaymentPenaltyTerms");
+                                if (paymentTerms.MaturityDate.HasValue)
+                                {
+                                    Writer.WriteStartElement("ram", "BasisDateTime");
+                                    _writeElementWithAttributeWithPrefix(Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.MaturityDate.Value));
+                                    Writer.WriteEndElement(); // !ram:BasisDateTime
+                                }
+                                if (paymentTerms.DueDays.HasValue)
+                                {
+                                    _writeElementWithAttribute(Writer, "ram", "BasisPeriodMeasure", "unitCode", "DAY", paymentTerms.DueDays.Value.ToString());
+                                }
                                 _writeOptionalAmount(Writer, "ram", "BasisAmount", paymentTerms.BaseAmount, forceCurrency: false);
                                 Writer.WriteOptionalElementString("ram", "CalculationPercent", _formatDecimal(paymentTerms.Percentage));
                                 _writeOptionalAmount(Writer, "ram", "ActualPenaltyAmount", paymentTerms.ActualAmount, forceCurrency: false);

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1133,6 +1133,7 @@ namespace s2industries.ZUGFeRD
                             _writeElementWithAttributeWithPrefix(Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
                             Writer.WriteEndElement(); // !ram:DueDateDateTime
                         }
+                        Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         if (paymentTerms.PaymentTermsType.HasValue)
                         {
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
@@ -1172,7 +1173,6 @@ namespace s2industries.ZUGFeRD
                                 Writer.WriteEndElement(); // !ram:ApplicableTradePaymentPenaltyTerms
                             }
                         }
-                        Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", Descriptor.PaymentMeans?.SEPAMandateReference);
                         Writer.WriteEndElement();
                     }
                     if (this.Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(Descriptor.PaymentMeans?.SEPAMandateReference))

--- a/ZUGFeRD/PaymentTerms.cs
+++ b/ZUGFeRD/PaymentTerms.cs
@@ -48,6 +48,12 @@ namespace s2industries.ZUGFeRD
         public int? DueDays { get; set; }
 
         /// <summary>
+        /// Fälligkeitsdatum im Kontext der spezifischen Zahlungsbedingung
+        /// </summary>
+        /// BT-X-276-0/BT-X-282-0
+        public DateTime? MaturityDate { get; set; } = null; 
+
+        /// <summary>
         /// Percentage of discount or surcharge
         /// </summary>
         public decimal? Percentage { get; set; }


### PR DESCRIPTION
add MaturityDate (BT-X-276-0 and BT-X-282-0) a.k.a. SpecifiedTradePaymentTerms/../BasisDateTime (Fälligkeitsdatum im Kontext der spezifischen Zahlungsbedingung) to PaymentTerms. 
Implement MaturityDate and DueDays in 23CIIReader and 23IIWriter