### PR TITLE
Fix/pdf xml filename check

### DIFF
--- a/ZUGFeRD.PDF.Test/LoadTests.cs
+++ b/ZUGFeRD.PDF.Test/LoadTests.cs
@@ -43,5 +43,18 @@ namespace s2industries.ZUGFeRD.PDF.Test
             path = _makeSurePathIsCrossPlatformCompatible(path);
             await Assert.ThrowsExceptionAsync<FileNotFoundException>(() => InvoicePdfProcessor.LoadFromPdfAsync(path));
         } // !BasicLoadNonExistingFile()
+
+
+        [TestMethod]
+        public async Task BasicLoadFileWithNonLowerXMLName()
+        {
+            string path = @"..\..\..\..\documentation\zugferd10\Beispiele\ZUGFeRD_1p0_BASIC_Einfach.pdf";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            InvoiceDescriptor? desc = await InvoicePdfProcessor.LoadFromPdfAsync(path);
+
+            Assert.IsNotNull(desc);
+            Assert.AreEqual("471102", desc.InvoiceNo);
+        } // !BasicLoadFileWithNonLowerXMLName()
     }
 }

--- a/ZUGFeRD.PDF/InvoiceDescriptorPdfLoader.cs
+++ b/ZUGFeRD.PDF/InvoiceDescriptorPdfLoader.cs
@@ -133,7 +133,7 @@ namespace s2industries.ZUGFeRD.PDF
                     {
                         var filename = dict.Elements["/F"] as PdfString;
 
-                        if (!potentialFilenames.Contains(filename.Value))
+                        if (string.IsNullOrWhiteSpace(filename?.Value) || !potentialFilenames.Contains(filename.Value.ToLower()))
                         {
                             continue;
                         }

--- a/ZUGFeRD.PDF/InvoiceDescriptorPdfLoader.cs
+++ b/ZUGFeRD.PDF/InvoiceDescriptorPdfLoader.cs
@@ -133,7 +133,7 @@ namespace s2industries.ZUGFeRD.PDF
                     {
                         var filename = dict.Elements["/F"] as PdfString;
 
-                        if (string.IsNullOrWhiteSpace(filename?.Value) || !potentialFilenames.Contains(filename.Value.ToLower()))
+                        if (string.IsNullOrWhiteSpace(filename?.Value) || !potentialFilenames.Any(pfn => pfn.IndexOf(filename.Value, StringComparison.OrdinalIgnoreCase) >= 0))
                         {
                             continue;
                         }


### PR DESCRIPTION
It's possible for an ZUGFeRD pdf to contain an xml with non lowercase name. 
These changes should fix the problem.