### PR TITLE
Fix/open pdf with password

### DIFF
--- a/ZUGFeRD.PDF.Test/LoadTests.cs
+++ b/ZUGFeRD.PDF.Test/LoadTests.cs
@@ -43,5 +43,19 @@ namespace s2industries.ZUGFeRD.PDF.Test
             path = _makeSurePathIsCrossPlatformCompatible(path);
             await Assert.ThrowsExceptionAsync<FileNotFoundException>(() => InvoicePdfProcessor.LoadFromPdfAsync(path));
         } // !BasicLoadNonExistingFile()
+
+
+        [TestMethod]
+        public async Task BasicLoadPdfFileWithPassword()
+        {
+            string path = @"..\..\..\..\ZUGFeRD.PDF.Test\PDFWithPassword.pdf";
+            path = _makeSurePathIsCrossPlatformCompatible(path);
+
+            var ex = await Assert.ThrowsExceptionAsync<Exception>(async () => await InvoicePdfProcessor.LoadFromPdfAsync(path));
+
+            Assert.IsFalse(string.IsNullOrWhiteSpace(ex.Source));
+            Assert.IsTrue(ex.Source.Equals("s2industries.ZUGFeRD.PDF"));
+            Assert.IsTrue(ex.Message.Trim().Equals("Could not find PDF Element AF containing"));
+        }
     }
 }

--- a/ZUGFeRD.PDF/InvoiceDescriptorPdfLoader.cs
+++ b/ZUGFeRD.PDF/InvoiceDescriptorPdfLoader.cs
@@ -33,7 +33,7 @@ namespace s2industries.ZUGFeRD.PDF
     {
         internal static async Task<InvoiceDescriptor> LoadAsync(Stream pdfStream)
         {
-            PdfDocument pdfDocument = PdfReader.Open(pdfStream);
+            PdfDocument pdfDocument = PdfReader.Open(pdfStream, PdfDocumentOpenMode.Import);
             return await _LoadXmlAsync(pdfDocument);
         } // !LoadAsync()
 
@@ -47,7 +47,7 @@ namespace s2industries.ZUGFeRD.PDF
 
             using (var pdfFile = File.OpenRead(pdfPath))
             {
-                PdfDocument pdfDocument = PdfReader.Open(pdfFile);
+                PdfDocument pdfDocument = PdfReader.Open(pdfFile, PdfDocumentOpenMode.Import);
                 return await _LoadXmlAsync(pdfDocument);
             }
         } // !LoadAsync()


### PR DESCRIPTION
If an ZUGFeRD pdf had an password only for writing, it wasn't possible to to open the file and read the content or attachments.
These changes should fix the problem.