### PR TITLE
Corrected comment for `LineTotalAmount` in "InvoiceDescriptor.cs".

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -326,9 +326,9 @@ namespace s2industries.ZUGFeRD
         public List<TradeLineItem> TradeLineItems { get; internal set; } = new List<TradeLineItem>();
 
         /// <summary>
-        /// Sum of all invoice line net amounts in the invoice
+        /// Sum of all invoice line net amounts (BT-131) in the invoice
         ///
-        /// BT-131
+        /// BT-106
         /// </summary>
         public decimal? LineTotalAmount { get; set; } = null;
 


### PR DESCRIPTION
Corrected comment for `LineTotalAmount` in "InvoiceDescriptor.cs".
BT-131 is the net amout of an invoice line and BT-106 is the sum of all invoice line net amounts.