### PR TITLE
No empty `<ram:BICID/>` section with Version 20.

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -674,10 +674,13 @@ namespace s2industries.ZUGFeRD
                     Writer.WriteOptionalElementString("ram", "ProprietaryID", creditorAccount.ID);
                     Writer.WriteEndElement(); // !PayeePartyCreditorFinancialAccount
 
-                    Writer.WriteStartElement("ram", "PayeeSpecifiedCreditorFinancialInstitution");
-                    Writer.WriteElementString("ram", "BICID", creditorAccount.BIC);
-                    Writer.WriteOptionalElementString("ram", "GermanBankleitzahlID", creditorAccount.Bankleitzahl);
-                    Writer.WriteEndElement(); // !PayeeSpecifiedCreditorFinancialInstitution
+                    if (!String.IsNullOrWhiteSpace(creditorAccount.BIC))
+                    {
+                        Writer.WriteStartElement("ram", "PayeeSpecifiedCreditorFinancialInstitution");
+                        Writer.WriteElementString("ram", "BICID", creditorAccount.BIC);
+                        Writer.WriteOptionalElementString("ram", "GermanBankleitzahlID", creditorAccount.Bankleitzahl);
+                        Writer.WriteEndElement(); // !PayeeSpecifiedCreditorFinancialInstitution
+                    }
                     Writer.WriteEndElement(); // !SpecifiedTradeSettlementPaymentMeans
                 }
 


### PR DESCRIPTION
When using `ZUGFeRDVersion.Version20`, there's no empty `<ram:BICID/>` section written anymore. The section will only be written, when a BIC has been set.
Because with an empty `<ram:BICID/>` section https://www.portinvoice.com/ reports a warning:

> [VD-Valitool-126]-Hinweis: Es wurde ein leeres Element übergeben z.B. . Dies kann bei einigen Zielsystemen zu Problemen führen. Sie sind leere Elemente z.B. bei der Übermittlung der Rechnung über das Peppol-Netzwerk nicht zulässig.
> /rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeSettlement/ram:SpecifiedTradeSettlementPaymentMeans/ram:PayeeSpecifiedCreditorFinancialInstitution/ram:BICID

The code changes have been copied from "InvoiceDescriptor23CIIWriter.cs".