### PR TITLE
Issue with the Transportmode enum numbering

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -469,6 +469,7 @@ namespace s2industries.ZUGFeRD.Test
 
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
             Assert.AreEqual(loadedInvoice.TransportMode, TransportModeCodes.Road);
+            Assert.AreEqual(3, (int)TransportModeCodes.Road);
         } // !TestTransportModeWithExtended()
 
 

--- a/ZUGFeRD/TransportModeCodes.cs
+++ b/ZUGFeRD/TransportModeCodes.cs
@@ -29,7 +29,7 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Transport mode not specified
         /// </summary>
-        Unknown = 1,
+        Unknown = 0,
 
         /// <summary>
         /// Maritime transport


### PR DESCRIPTION
The enum index must start with 0 but was 1 in the code.

![image](https://github.com/user-attachments/assets/79bcb4b9-4aea-4be7-b912-eb1ab6fce74a)
