### PR TITLE
When using Version 2.3, BT-147 and BT-148 are now written with four d…

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -302,11 +302,11 @@ namespace s2industries.ZUGFeRD
                         if (tradeAllowanceCharge.BasisAmount.HasValue)
                         {
                             Writer.WriteStartElement("ram", "BasisAmount");
-                            Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount.Value, 4));
+                            Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount.Value, 4)); // BT-148
                             Writer.WriteEndElement();
                         }
                         Writer.WriteStartElement("ram", "ActualAmount");
-                        Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 4));
+                        Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 4)); // BT-147
                         Writer.WriteEndElement();
 
                         Writer.WriteOptionalElementString("ram", "Reason", tradeAllowanceCharge.Reason, Profile.Comfort | Profile.Extended);

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1349,14 +1349,14 @@ namespace s2industries.ZUGFeRD
             if (tradeAllowanceCharge.BasisAmount.HasValue)
             {
                 Writer.WriteStartElement("ram", "BasisAmount", profile: Profile.Extended); // not in XRechnung, according to CII-SR-123
-                Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount.Value, 2));
+                Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount.Value, 4)); // BT-148
                 Writer.WriteEndElement();
             }
             #endregion
 
             #region ActualAmount
             Writer.WriteStartElement("ram", "ActualAmount");
-            Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 2));
+            Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 4)); // BT-147
             Writer.WriteEndElement();
             #endregion
 


### PR DESCRIPTION
When using Version 2.3, BT-147 and BT-148 are now written with four decimal places (same as already implemented with Version 2.0).

Fixes #713.