### PR TITLE
When using Version 2.3, BT-147 is now written with four decimal places

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -285,7 +285,7 @@ namespace s2industries.ZUGFeRD
                 if (needToWriteGrossUnitPrice)
                 {
                     Writer.WriteStartElement("ram", "GrossPriceProductTradePrice");
-                    _writeOptionalAdaptiveAmount(Writer, "ram", "ChargeAmount", tradeLineItem.GrossUnitPrice, 2, 4);
+                    _writeOptionalAdaptiveAmount(Writer, "ram", "ChargeAmount", tradeLineItem.GrossUnitPrice, 2, 4); // BT-148
                     if (tradeLineItem.UnitQuantity.HasValue)
                     {
                         _writeElementWithAttribute(Writer, "ram", "BasisQuantity", "unitCode", tradeLineItem.UnitCode.EnumToString(), _formatDecimal(tradeLineItem.UnitQuantity.Value, 4));
@@ -302,11 +302,11 @@ namespace s2industries.ZUGFeRD
                         if (tradeAllowanceCharge.BasisAmount.HasValue)
                         {
                             Writer.WriteStartElement("ram", "BasisAmount");
-                            Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount.Value, 4));
+                            Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.BasisAmount.Value, 4)); // BT-X-35
                             Writer.WriteEndElement();
                         }
                         Writer.WriteStartElement("ram", "ActualAmount");
-                        Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 4));
+                        Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 4)); // BT-147
                         Writer.WriteEndElement();
 
                         Writer.WriteOptionalElementString("ram", "Reason", tradeAllowanceCharge.Reason, Profile.Comfort | Profile.Extended);

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1340,7 +1340,7 @@ namespace s2industries.ZUGFeRD
             if (tradeAllowanceCharge.ChargePercentage.HasValue)
             {
                 Writer.WriteStartElement("ram", "CalculationPercent", profile: Profile.Extended); // not in XRechnung, according to CII-SR-122
-                _writeOptionalAdaptiveValue(writer, tradeAllowanceCharge.ChargePercentage.Value, 2, 4);
+                _writeOptionalAdaptiveValue(writer, tradeAllowanceCharge.ChargePercentage.Value, 2, 4); // BT-X-34
                 Writer.WriteEndElement();
             }
             #endregion
@@ -1349,14 +1349,14 @@ namespace s2industries.ZUGFeRD
             if (tradeAllowanceCharge.BasisAmount.HasValue)
             {
                 Writer.WriteStartElement("ram", "BasisAmount", profile: Profile.Extended); // not in XRechnung, according to CII-SR-123
-                _writeOptionalAdaptiveValue(writer, tradeAllowanceCharge.BasisAmount.Value, 2, 4);
+                _writeOptionalAdaptiveValue(writer, tradeAllowanceCharge.BasisAmount.Value, 2, 4); // BT-X-35
                 Writer.WriteEndElement();
             }
             #endregion
 
             #region ActualAmount
             Writer.WriteStartElement("ram", "ActualAmount");
-            Writer.WriteValue(_formatDecimal(tradeAllowanceCharge.ActualAmount, 2));
+            _writeOptionalAdaptiveValue(writer, tradeAllowanceCharge.ActualAmount, 2, 4); // BT-147
             Writer.WriteEndElement();
             #endregion
 


### PR DESCRIPTION
When using Version 2.3, BT-147 is now written with four decimal places (same as already implemented with Version 2.0).

Fixes #713.