### PR TITLE
Format invoiced quantity (billed quantity) of a line item in UBL with four decimal places

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -622,7 +622,7 @@ namespace s2industries.ZUGFeRD
                 Writer.WriteStartElement("cbc", "CreditedQuantity");
             }
             Writer.WriteAttributeString("unitCode", tradeLineItem.UnitCode.EnumToString());
-            Writer.WriteValue(_formatDecimal(tradeLineItem.BilledQuantity));
+            Writer.WriteValue(_formatDecimal(tradeLineItem.BilledQuantity, 4));
             Writer.WriteEndElement(); // !InvoicedQuantity || CreditedQuantity
 
             Writer.WriteStartElement("cbc", "LineExtensionAmount");


### PR DESCRIPTION
To ensure consistency between CII and UBL, the invoiced quantity (billed quantity) of a line item in UBL will now be formatted with four decimal places. See the related issue for more details: #737 