### PR TITLE
Update TradeLineItem.cs

### DIFF
--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -208,7 +208,7 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Detailed information about the actual Delivery
         ///
-        /// BT-72
+        /// BT-X-85
         /// </summary>
         public DateTime? ActualDeliveryDate { get; set; }
 


### PR DESCRIPTION
Hallo Stephan

hier kommt nur eine ganz kleine Korrektur eines Kommentars zum Feld Tradeline.ActualDeliveryDate. Das hat die EN16931-ID "BT-X-85" statt  "BT-72". 

BT-X-85 ist das aus der Rechnungsposition und BT-72 ist das Lieferdatums-Feld aus dem Rechnungskopf.

So ist es dann weniger verwirrend, wenn man das Datum in der TradeLine setzt. Ich hatte mir notiert, dass ich BT-X-85 setzen muss und dann stand BT-72 in der Beschreibung und ich war ganz verwundert und dachte schon, dass da etwas falsch zugeordnet wird. Der Code stimmt aber!

Viele Grüße, Stefan