### PR TITLE
Support more than 2 decimal places in LineTotalAmount

### DIFF
--- a/ZUGFeRD/IInvoiceDescriptorWriter.cs
+++ b/ZUGFeRD/IInvoiceDescriptorWriter.cs
@@ -94,6 +94,32 @@ namespace s2industries.ZUGFeRD
         } // !_formatDecimal()
 
 
+        private int _getDecimalPlaces(decimal n)
+        {
+            n = Math.Abs(n);
+            n -= (int)n;
+            var bits = decimal.GetBits(n);
+            var scale = (bits[3] >> 16) & 0xFF;
+            return scale;
+        }
+
+
+        protected string _formatDecimalFlexible(decimal? value, int minDecimals, int maxDecimals)
+        {
+            if (!value.HasValue)
+            {
+                return String.Empty;
+            }
+
+            decimal roundedValue = Math.Round(value.Value, maxDecimals, MidpointRounding.AwayFromZero);
+            int actualPlaces = _getDecimalPlaces(roundedValue);
+            int formatPlaces = Math.Max(minDecimals, actualPlaces);
+            formatPlaces = Math.Min(maxDecimals, formatPlaces);
+
+            return roundedValue.ToString($"F{formatPlaces}", CultureInfo.InvariantCulture);
+        }
+
+
         protected string _formatDate(DateTime date, bool formatAs102 = true, bool toUBLDate = false)
         {
             if (formatAs102)

--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -673,7 +673,7 @@ namespace s2industries.ZUGFeRD
                     }
                 }
 
-                _writeElementWithAttribute(_Writer, "ram", "LineTotalAmount", "currencyID", this._Descriptor.Currency.EnumToString(), _formatDecimal(total));
+                _writeElementWithAttribute(_Writer, "ram", "LineTotalAmount", "currencyID", this._Descriptor.Currency.EnumToString(), _formatDecimalFlexible(total, options?.LineTotalAmountMinDecimalPlaces ?? 2, options?.LineTotalAmountMaxDecimalPlaces ?? 2));
                 _Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementMonetarySummation
                 _Writer.WriteEndElement(); // !ram:SpecifiedSupplyChainTradeSettlement
 

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -387,7 +387,7 @@ namespace s2industries.ZUGFeRD
                 {
                     _Writer.WriteElementString("ram", "CategoryCode", tradeLineItem.TaxCategoryCode.EnumToString());
                 }
-                
+
                 _Writer.WriteElementString("ram", "RateApplicablePercent", _formatDecimal(tradeLineItem.TaxPercent));
                 _Writer.WriteEndElement(); // !ram:ApplicableTradeTax
 
@@ -428,7 +428,7 @@ namespace s2industries.ZUGFeRD
                     }
                 }
 
-                _Writer.WriteElementString("ram", "LineTotalAmount", _formatDecimal(total));
+                _Writer.WriteElementString("ram", "LineTotalAmount", _formatDecimalFlexible(total, options?.LineTotalAmountMinDecimalPlaces ?? 2, options?.LineTotalAmountMaxDecimalPlaces ?? 2));
 
                 _Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementLineMonetarySummation
                 _Writer.WriteEndElement(); // !ram:SpecifiedLineTradeSettlement
@@ -1027,7 +1027,7 @@ namespace s2industries.ZUGFeRD
                 {
                     _Writer.WriteElementString("ram", "CategoryCode", tradeAllowanceCharge.Tax.CategoryCode.EnumToString());
                 }
-                
+
                 _Writer.WriteElementString("ram", "RateApplicablePercent", _formatDecimal(tradeAllowanceCharge.Tax.Percent));
                 _Writer.WriteEndElement();
             }

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -62,7 +62,7 @@ namespace s2industries.ZUGFeRD
                 { "ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" },
                 { "xs", "http://www.w3.org/2001/XMLSchema" },
                 { "udt", "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" }
-            });            
+            });
 
             _Writer.WriteStartDocument();
             _WriteHeaderComments(_Writer, options);
@@ -536,7 +536,7 @@ namespace s2industries.ZUGFeRD
                 }
 
                 _Writer.WriteStartElement("ram", "LineTotalAmount", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
-                _Writer.WriteValue(_formatDecimal(total));
+                _Writer.WriteValue(_formatDecimalFlexible(total, options?.LineTotalAmountMinDecimalPlaces ?? 2, options?.LineTotalAmountMaxDecimalPlaces ?? 2));
                 _Writer.WriteEndElement(); // !ram:LineTotalAmount
 
                 // TODO: TotalAllowanceChargeAmount
@@ -1021,7 +1021,7 @@ namespace s2industries.ZUGFeRD
                         var sbPaymentNotes = new StringBuilder();
                         DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this._Descriptor.GetTradePaymentTerms())
-                        {                                                        
+                        {
 
                             // every line break must be a valid xml line break.
                             // if a note already exists, append a valid line break.
@@ -1055,7 +1055,7 @@ namespace s2industries.ZUGFeRD
                                     sbPaymentNotes.Append(paymentTerms.Description.Trim());
                                 }
                             }
-                            dueDate = dueDate ?? paymentTerms.DueDate;                            
+                            dueDate = dueDate ?? paymentTerms.DueDate;
                         }
 
                         _Writer.WriteStartElement("ram", "Description");
@@ -1162,8 +1162,8 @@ namespace s2industries.ZUGFeRD
             _writeAmount(_Writer, "ram", "LineTotalAmount", this._Descriptor.LineTotalAmount, profile: ALL_PROFILES ^ Profile.Minimum);   // Summe der Nettobeträge aller Rechnungspositionen
             _writeOptionalAmount(_Writer, "ram", "ChargeTotalAmount", this._Descriptor.ChargeTotalAmount, profile: ALL_PROFILES ^ Profile.Minimum);       // Summe der Zuschläge auf Dokumentenebene, BT-108
             _writeOptionalAmount(_Writer, "ram", "AllowanceTotalAmount", this._Descriptor.AllowanceTotalAmount, profile: ALL_PROFILES ^ Profile.Minimum); // Summe der Abschläge auf Dokumentenebene, BT-107
-                                                                                                                                                // both fields are mandatory according to BR-FXEXT-CO-11
-                                                                                                                                                // and BR-FXEXT-CO-12
+                                                                                                                                                          // both fields are mandatory according to BR-FXEXT-CO-11
+                                                                                                                                                          // and BR-FXEXT-CO-12
 
             if (this._Descriptor.Profile == Profile.Extended)
             {
@@ -1623,7 +1623,7 @@ namespace s2industries.ZUGFeRD
                 if (tax.TaxPointDate.HasValue)
                 {
                     _Writer.WriteStartElement("ram", "TaxPointDate");
-                    _Writer.WriteStartElement("udt", "DateString");  
+                    _Writer.WriteStartElement("udt", "DateString");
                     _Writer.WriteAttributeString("format", "102");
                     _Writer.WriteValue(_formatDate(tax.TaxPointDate.Value));
                     _Writer.WriteEndElement(); // !udt:DateString
@@ -1918,7 +1918,7 @@ namespace s2industries.ZUGFeRD
                 case TaxCategoryCodes.S:
                     return "Normalsatz";
                 case TaxCategoryCodes.Z:
-                    return "nach dem Nullsatz zu versteuernde Waren";                
+                    return "nach dem Nullsatz zu versteuernde Waren";
                 case TaxCategoryCodes.D:
                     break;
                 case TaxCategoryCodes.F:

--- a/ZUGFeRD/InvoiceFormatOptions.cs
+++ b/ZUGFeRD/InvoiceFormatOptions.cs
@@ -30,13 +30,13 @@ namespace s2industries.ZUGFeRD
 
         /// <summary>
         /// Gets or sets the minimum number of decimal places for line total amounts.
-        /// If not set (null), the library's default (usually 2) will be used.
+        /// If not set (null), the library's default (2) will be used.
         /// </summary>
         public int? LineTotalAmountMinDecimalPlaces { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of decimal places for line total amounts.
-        /// If not set (null), the library's default (e.g., 4) will be used.
+        /// If not set (null), the library's default (2) will be used.
         /// The value will be rounded to this number of places if it has more.
         /// </summary>
         public int? LineTotalAmountMaxDecimalPlaces { get; set; }

--- a/ZUGFeRD/InvoiceFormatOptions.cs
+++ b/ZUGFeRD/InvoiceFormatOptions.cs
@@ -28,6 +28,19 @@ namespace s2industries.ZUGFeRD
         public bool IncludeXmlComments { get; internal set; } = false;
         public bool AutomaticallyCleanInvalidCharacters { get; internal set; } = false;
 
+        /// <summary>
+        /// Gets or sets the minimum number of decimal places for line total amounts.
+        /// If not set (null), the library's default (usually 2) will be used.
+        /// </summary>
+        public int? LineTotalAmountMinDecimalPlaces { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of decimal places for line total amounts.
+        /// If not set (null), the library's default (e.g., 4) will be used.
+        /// The value will be rounded to this number of places if it has more.
+        /// </summary>
+        public int? LineTotalAmountMaxDecimalPlaces { get; set; }
+
 
         internal InvoiceFormatOptions Clone()
         {


### PR DESCRIPTION
I need support for more than two decimal places in LineTotalAmount (line items).
Some of my customers use higher precision, and rounding LineTotalAmount to two decimal places causes issues in those cases.

I know this technically goes against the spec:
<img width="856" height="333" alt="grafik" src="https://github.com/user-attachments/assets/5f16ca61-1919-40d2-b84a-08a32d8414a1" />
Source: https://github.com/stephanstapel/ZUGFeRD-csharp/blob/master/documentation/zugferd233de/Dokumentation/1.%20FACTUR-X%201.07.3%20DE.pdf (page 41)

But it works - no errors or warnings from validators.

This change is completely optional - LineTotalAmountMinDecimalPlaces and LineTotalAmountMaxDecimalPlaces must be set in InvoiceFormatOptions for it to take effect.

I left LineTotalAmount in SpecifiedTradeSettlement**Header**MonetarySummation untouched, since changing it causes errors.
Same with UBL - more than two decimals there also leads to issues.

I've been using this change in production since January with no issues reported.
I have heard other complaints - so I know people are importing the invoices.

I would really appreciate it if this could be merged, so I don't have to maintain a fork.