### PR TITLE
Add TypeCode support for InvoiceReferencedDocument (ZUGFeRD 2.3.2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,7 @@ insert_final_newline = true
 # C# specific rules
 dotnet_style_require_accessibility_modifiers = always:error
 dotnet_sort_system_directives_first = true:error
+dotnet_remove_unnecessary_imports_on_save = false
 
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
@@ -37,3 +38,6 @@ dotnet_naming_style.camel_case_style.capitalization = camel_case
 dotnet_naming_rule.local_variables_must_be_camel_case.severity = error
 dotnet_naming_rule.local_variables_must_be_camel_case.symbols = local_variables
 dotnet_naming_rule.local_variables_must_be_camel_case.style = camel_case_style
+
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_new_line_before_open_brace = all

--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -66,7 +66,7 @@ namespace s2industries.ZUGFeRD.Test
             desc.TaxBasisAmount = 9.9m;
             desc.TaxTotalAmount = 9.9m * 0.19m;
             desc.GrandTotalAmount = 9.9m * 1.19m;
-            desc.DuePayableAmount = 9.9m * 1.19m;            
+            desc.DuePayableAmount = 9.9m * 1.19m;
         }
 
 
@@ -1028,7 +1028,7 @@ namespace s2industries.ZUGFeRD.Test
 
             Assert.AreEqual("DE98ZZZ09999999999", invoiceDescriptor.PaymentMeans.SEPACreditorIdentifier);
             Assert.AreEqual("REF A-123", invoiceDescriptor.PaymentMeans.SEPAMandateReference);
-            Assert.AreEqual(PaymentMeansTypeCodes.SEPADirectDebit, invoiceDescriptor.PaymentMeans.TypeCode);                      
+            Assert.AreEqual(PaymentMeansTypeCodes.SEPADirectDebit, invoiceDescriptor.PaymentMeans.TypeCode);
             Assert.AreEqual(1, invoiceDescriptor.DebitorBankAccounts.Count);
             Assert.AreEqual("DE21860000000086001055", invoiceDescriptor.DebitorBankAccounts[0].IBAN);
 
@@ -1304,7 +1304,7 @@ namespace s2industries.ZUGFeRD.Test
                 name: "Invoice Data Sheet",
                 uriID: uriID);
             desc.AddAdditionalReferencedDocument(
-                id: id+"2",
+                id: id + "2",
                 typeCode: AdditionalReferencedDocumentTypeCode.ReferenceDocument,
                 referenceTypeCode: ReferenceTypeCodes.PP,
                 issueDateTime: issueDateTime);
@@ -1330,7 +1330,7 @@ namespace s2industries.ZUGFeRD.Test
             // checks for 2nd document
             Assert.AreEqual("", loadedInvoice.AdditionalReferencedDocuments[1].Name);
             Assert.AreEqual(issueDateTime, loadedInvoice.AdditionalReferencedDocuments[1].IssueDateTime);
-            Assert.AreEqual(id+"2", loadedInvoice.AdditionalReferencedDocuments[1].ID);
+            Assert.AreEqual(id + "2", loadedInvoice.AdditionalReferencedDocuments[1].ID);
             Assert.IsNull(loadedInvoice.AdditionalReferencedDocuments[1].URIID);
             Assert.IsNull(loadedInvoice.AdditionalReferencedDocuments[1].LineID);
             Assert.IsNull(loadedInvoice.AdditionalReferencedDocuments[1].ReferenceTypeCode);
@@ -1424,7 +1424,8 @@ namespace s2industries.ZUGFeRD.Test
             // Check the output in the XML for Comfort.
             // REM: In Comfort only ID, GlobalID, Name, and SpecifiedLegalOrganization are allowed.
 
-            desc.Payee = new Party() {
+            desc.Payee = new Party()
+            {
                 ID = new GlobalID(null, "SL1001"),
                 Name = "Max Mustermann"
                 // Country is not set and should not be written into the XML
@@ -1458,11 +1459,13 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
-        public void TestShipTo() {
+        public void TestShipTo()
+        {
 
             InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
 
-            desc.ShipTo = new Party() {
+            desc.ShipTo = new Party()
+            {
                 ID = new GlobalID(null, "SL1001"),
                 GlobalID = new GlobalID(GlobalIDSchemeIdentifiers.GLN, "MusterGLN"),
                 Name = "AbKunden AG Mitte",
@@ -1627,10 +1630,10 @@ namespace s2industries.ZUGFeRD.Test
                 Country = CountryCodes.DE,
                 CountrySubdivisionName = "Hessen"
             };
-            
+
             desc.AddShipToTaxRegistration("DE123456789", TaxRegistrationSchemeID.VA);
 
-            desc.Invoicee = new Party() 
+            desc.Invoicee = new Party()
             {
                 Name = "Invoicee",
                 ContactName = "Max Mustermann",
@@ -1781,7 +1784,7 @@ namespace s2industries.ZUGFeRD.Test
             s.Close();
 
             MemoryStream ms = new MemoryStream();
-            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);            
+            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);
 
             ms.Seek(0, SeekOrigin.Begin);
             StreamReader reader = new StreamReader(ms);
@@ -1937,7 +1940,7 @@ namespace s2industries.ZUGFeRD.Test
             desc.AddLogisticsServiceCharge(10m, "Logistics service charge", TaxTypes.AAC, TaxCategoryCodes.AC, 7m);
 
             desc.GetTradePaymentTerms().FirstOrDefault().DueDate = timestamp.AddDays(14);
-            desc.AddInvoiceReferencedDocument("RE-12345", timestamp);
+            desc.AddInvoiceReferencedDocument("RE-12344", timestamp, InvoiceType.PartialInvoice);
 
 
             //set additional LineItem data
@@ -2089,7 +2092,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(timestamp.AddDays(14), loadedInvoice.BillingPeriodEnd);
 
             //TradeAllowanceCharges
-            Assert.AreEqual(loadedInvoice.GetTradeAllowances().Count, 0);   
+            Assert.AreEqual(loadedInvoice.GetTradeAllowances().Count, 0);
             var tradeAllowanceCharge = loadedInvoice.GetTradeCharges().FirstOrDefault(i => i.Reason == "Reason for charge");
             Assert.IsNotNull(tradeAllowanceCharge);
             Assert.IsTrue(tradeAllowanceCharge.ChargeIndicator);
@@ -2126,8 +2129,9 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(529.87m, loadedInvoice.DuePayableAmount);
 
             //InvoiceReferencedDocument
-            Assert.AreEqual("RE-12345", loadedInvoice.GetInvoiceReferencedDocuments().First().ID);
+            Assert.AreEqual("RE-12344", loadedInvoice.GetInvoiceReferencedDocuments().First().ID);
             Assert.AreEqual(timestamp, loadedInvoice.GetInvoiceReferencedDocuments().First().IssueDateTime);
+            Assert.AreEqual(InvoiceType.PartialInvoice, loadedInvoice.GetInvoiceReferencedDocuments().First().TypeCode);
 
 
             //Line items
@@ -2246,7 +2250,7 @@ namespace s2industries.ZUGFeRD.Test
         {
             DateTime issueDateTime = DateTime.Today;
 
-            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();            
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
             //PayerSpecifiedDebtorFinancialInstitution
             desc.AddDebitorFinancialAccount("DE02120300000000202051", "MYBIC");
 
@@ -2912,7 +2916,7 @@ namespace s2industries.ZUGFeRD.Test
 
             ms.Seek(0, SeekOrigin.Begin);
             Assert.AreEqual(InvoiceDescriptor.GetVersion(ms), ZUGFeRDVersion.Version23);
-            
+
 
             // Act
             ms.Seek(0, SeekOrigin.Begin);
@@ -2947,7 +2951,7 @@ namespace s2industries.ZUGFeRD.Test
             desc.AddTradePaymentTerms(description, null, PaymentTermsType.Skonto, 14, 2.25m);
 
             MemoryStream ms = new MemoryStream();
-            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung);            
+            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung);
 
             ms.Seek(0, SeekOrigin.Begin);
             StreamReader reader = new StreamReader(ms);
@@ -2983,7 +2987,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.IsTrue(match.Success);
             Assert.AreEqual(match.Groups[1].Value, "SKONTO");
             Assert.AreEqual(match.Groups[2].Value, "14");
-            Assert.AreEqual(match.Groups[3].Value, "2.25");                      
+            Assert.AreEqual(match.Groups[3].Value, "2.25");
         }
 
 
@@ -3037,7 +3041,7 @@ namespace s2industries.ZUGFeRD.Test
         public void TestPaymentTermsMultiCardinalityXRechnungStructured()
         {
             DateTime timestamp = DateTime.Now.Date;
-            
+
             var desc = _InvoiceProvider.CreateInvoice();
             desc.GetTradePaymentTerms().Clear();
             desc.AddTradePaymentTerms(String.Empty, null, PaymentTermsType.Skonto, 14, 2.25m);
@@ -3068,7 +3072,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.IsNotNull(structuredPaymentTerms);
 
             var separators = new[] { "\n", XmlConstants.XmlNewLine };
-            var structuredPaymentTermsList = structuredPaymentTerms.Description.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Replace("\r",""));
+            var structuredPaymentTermsList = structuredPaymentTerms.Description.Split(separators, StringSplitOptions.RemoveEmptyEntries).Select(s => s.Replace("\r", ""));
             Assert.AreEqual(3, structuredPaymentTermsList.Count()); //Spliting the description by line break should give us the two payment terms + one description line
 
             var firstPaymentTerm = structuredPaymentTermsList.ElementAt(0);
@@ -3148,7 +3152,7 @@ namespace s2industries.ZUGFeRD.Test
         public void TestOfficialXRechnungFileForPaymentTerms()
         {
             string path = @"..\..\..\..\documentation\xRechnung\XRechnung 3.0.1\xrechnung-3.0.1-schematron-2.0.1\generated\cii-br-de-18-freespace-test-869-identity.xml";
-            path = _makeSurePathIsCrossPlatformCompatible(path);            
+            path = _makeSurePathIsCrossPlatformCompatible(path);
 
             Stream s = File.Open(path, FileMode.Open);
             InvoiceDescriptor desc = InvoiceDescriptor.Load(s);
@@ -3448,7 +3452,7 @@ namespace s2industries.ZUGFeRD.Test
             Assert.IsNull(loadedInvoice.ApplicableTradeDeliveryTermsCode);
         } // !TestSellerOrderReferencedDocument()
 
-       
+
         [TestMethod]
         public void TestInvoiceExemptions()
         {
@@ -3579,14 +3583,14 @@ namespace s2industries.ZUGFeRD.Test
         {
             // load standrd invoice
             string path = @"..\..\..\..\demodata\zugferd21\zugferd_2p1_EXTENDED_Warenrechnung-factur-x.xml";
-            path = _makeSurePathIsCrossPlatformCompatible(path);            
+            path = _makeSurePathIsCrossPlatformCompatible(path);
             InvoiceDescriptor desc = InvoiceDescriptor.Load(path);
 
             Assert.AreEqual(desc.Type, InvoiceType.Invoice);
 
             // load correction
             path = @"..\..\..\..\documentation\zugferd23en\Examples\4. EXTENDED\EXTENDED_Rechnungskorrektur\factur-x.xml";
-            path = _makeSurePathIsCrossPlatformCompatible(path);            
+            path = _makeSurePathIsCrossPlatformCompatible(path);
             desc = InvoiceDescriptor.Load(path);
 
             Assert.AreEqual(desc.Type, InvoiceType.Correction);

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -405,7 +405,7 @@ namespace s2industries.ZUGFeRD
         ///
         /// BG-23
         /// </summary>        
-        public  List<Tax> Taxes { get; internal set; } = new List<Tax>();
+        public List<Tax> Taxes { get; internal set; } = new List<Tax>();
 
 
         /// <summary>
@@ -1036,7 +1036,7 @@ namespace s2industries.ZUGFeRD
             };
         } // !SetContractReferencedDocument()
 
-        
+
         internal void _AddLogisticsServiceCharge(decimal amount, string description, TaxTypes? taxTypeCode, TaxCategoryCodes? taxCategoryCode, decimal taxPercent)
         {
             this.ServiceCharges.Add(new ServiceCharge()
@@ -1095,7 +1095,7 @@ namespace s2industries.ZUGFeRD
         internal void _AddTradeAllowance(decimal? basisAmount, CurrencyCodes currency, decimal actualAmount,
                                          string reason, TaxTypes? taxTypeCode, TaxCategoryCodes? taxCategoryCode, decimal taxPercent,
                                          AllowanceReasonCodes? reasonCode = null)
-        { 
+        {
             this.TradeAllowanceCharges.Add(new TradeAllowance()
             {
                 Reason = reason,
@@ -1142,7 +1142,7 @@ namespace s2industries.ZUGFeRD
                                       decimal? chargePercentage,
                                       string reason, TaxTypes? taxTypeCode, TaxCategoryCodes? taxCategoryCode, decimal taxPercent,
                                       ChargeReasonCodes? reasonCode = null)
-        { 
+        {
             this.TradeAllowanceCharges.Add(new TradeCharge()
             {
                 Reason = reason,
@@ -1227,7 +1227,7 @@ namespace s2industries.ZUGFeRD
 
 
         internal void _AddTradeAllowance(decimal? basisAmount, CurrencyCodes currency, decimal actualAmount, decimal? chargePercentage, string reason, TaxTypes? taxTypeCode, TaxCategoryCodes? taxCategoryCode, decimal taxPercent, AllowanceReasonCodes? reasonCode = null)
-        { 
+        {
             this.TradeAllowanceCharges.Add(new TradeAllowance()
             {
                 Reason = reason,
@@ -1266,7 +1266,7 @@ namespace s2industries.ZUGFeRD
         {
             _AddTradeCharge(basisAmount, currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, reasonCode);
         } // !AddTradeCharge()
-          
+
 
         /// <summary>
         /// Returns all existing trade allowances
@@ -1350,12 +1350,14 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         /// <param name="id">Preceding invoice number</param>
         /// <param name="IssueDateTime">Preceding invoice date</param>
-        public void AddInvoiceReferencedDocument(string id, DateTime? IssueDateTime = null)
+        /// <param name="TypeCode">Preceding invoice Type</param>
+        public void AddInvoiceReferencedDocument(string id, DateTime? IssueDateTime = null, InvoiceType? TypeCode = null)
         {
             this._InvoiceReferencedDocuments.Add(new InvoiceReferencedDocument()
             {
                 ID = id,
-                IssueDateTime = IssueDateTime
+                IssueDateTime = IssueDateTime,
+                TypeCode = TypeCode
             });
         }
 
@@ -1597,8 +1599,8 @@ namespace s2industries.ZUGFeRD
 
             item.AssociatedDocument.Notes.Add(new Note(
                 content: comment
-                // no subjectcode
-                // no contentcode
+            // no subjectcode
+            // no contentcode
             ));
 
             this.TradeLineItems.Add(item);
@@ -1638,7 +1640,7 @@ namespace s2industries.ZUGFeRD
         public TradeLineItem AddTradeLineItem(string name,
                                     decimal netUnitPrice,
                                     QuantityCodes unitCode,
-                                    string description = null,                                    
+                                    string description = null,
                                     decimal? unitQuantity = null,
                                     decimal? grossUnitPrice = null,
                                     decimal billedQuantity = 0,
@@ -1713,7 +1715,7 @@ namespace s2industries.ZUGFeRD
                                     string name,
                                     decimal netUnitPrice,
                                     QuantityCodes unitCode,
-                                    string description = null,                                    
+                                    string description = null,
                                     decimal? unitQuantity = null,
                                     decimal? grossUnitPrice = null,
                                     decimal billedQuantity = 0,
@@ -1775,7 +1777,7 @@ namespace s2industries.ZUGFeRD
                                     string buyerOrderLineID = "", string buyerOrderID = "", DateTime? buyerOrderDate = null,
                                     DateTime? billingPeriodStart = null, DateTime? billingPeriodEnd = null
                                     )
-        { 
+        {
             if (String.IsNullOrWhiteSpace(lineID))
             {
                 throw new ArgumentException("LineID cannot be Null or Empty");
@@ -2045,7 +2047,7 @@ namespace s2industries.ZUGFeRD
             return this.DebitorBankAccounts?.Any() == true;
         } // !AnyDebitorFinancialAccount()
 
-        
+
         /// <summary>
         /// Adds a receivable specified trade accounting account with ID and type code
         ///
@@ -2169,10 +2171,12 @@ namespace s2industries.ZUGFeRD
 
         private string _getNextLineId()
         {
-            int? highestLineId = this.GetTradeLineItems()?.Select(i => {
+            int? highestLineId = this.GetTradeLineItems()?.Select(i =>
+            {
                 if (Int32.TryParse(i.AssociatedDocument?.LineID, out int id) == true)
                     return id;
-                else return 0; }
+                else return 0;
+            }
                 ).DefaultIfEmpty(0).Max() ?? 0;
             return highestLineId == null ? "1" : (highestLineId + 1).ToString();
         } // !_getNextLineId()

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -365,7 +365,7 @@ namespace s2industries.ZUGFeRD
                                               EnumExtensions.StringToNullableEnum<TaxCategoryCodes>(XmlUtils.NodeAsString(node, ".//ram:CategoryTradeTax/ram:CategoryCode", nsmgr)),
                                               XmlUtils.NodeAsDecimal(node, ".//ram:CategoryTradeTax/ram:RateApplicablePercent", nsmgr, 0).Value,
                                               EnumExtensions.StringToEnum<AllowanceReasonCodes>(XmlUtils.NodeAsString(node, "./ram:ReasonCode", nsmgr)));
-                }                    
+                }
             }
 
             foreach (XmlNode node in doc.SelectNodes("//ram:SpecifiedLogisticsServiceCharge", nsmgr))
@@ -380,8 +380,9 @@ namespace s2industries.ZUGFeRD
             foreach (XmlNode invoiceReferencedDocumentNodes in doc.DocumentElement.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:InvoiceReferencedDocument", nsmgr))
             {
                 retval.AddInvoiceReferencedDocument(
-                    XmlUtils.NodeAsString(invoiceReferencedDocumentNodes, "./ram:IssuerAssignedID", nsmgr),
-                     XmlUtils.NodeAsDateTime(invoiceReferencedDocumentNodes, "./ram:FormattedIssueDateTime", nsmgr)
+                     XmlUtils.NodeAsString(invoiceReferencedDocumentNodes, "./ram:IssuerAssignedID", nsmgr),
+                     XmlUtils.NodeAsDateTime(invoiceReferencedDocumentNodes, "./ram:FormattedIssueDateTime", nsmgr),
+                     EnumExtensions.StringToNullableEnum<InvoiceType>(XmlUtils.NodeAsString(invoiceReferencedDocumentNodes, "./ram:TypeCode", nsmgr))
                 );
             }
 
@@ -398,9 +399,9 @@ namespace s2industries.ZUGFeRD
                 decimal? discountBaseAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:BasisAmount", nsmgr, null);
                 decimal? discountActualAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:ActualDiscountAmount", nsmgr, null);
                 decimal? penaltyPercent = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:CalculationPercent", nsmgr, null);
-                int? penaltyDueDays = null; 
+                int? penaltyDueDays = null;
                 if (QuantityCodes.DAY == EnumExtensions.StringToNullableEnum<QuantityCodes>(XmlUtils.NodeAsString(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure/@unitCode", nsmgr)))
-                  discountDueDays = XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure", nsmgr);
+                    discountDueDays = XmlUtils.NodeAsInt(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisPeriodMeasure", nsmgr);
                 DateTime? penaltyMaturityDate = XmlUtils.NodeAsDateTime(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisDateTime/udt:DateTimeString", nsmgr); // BT-X-276-0
                 decimal? penaltyBaseAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentPenaltyTerms/ram:BasisAmount", nsmgr, null);
                 decimal? penaltyActualAmount = XmlUtils.NodeAsDecimal(node, ".//ram:ApplicableTradePaymentDiscountTerms/ram:ActualPenaltyAmount", nsmgr, null);
@@ -520,7 +521,7 @@ namespace s2industries.ZUGFeRD
                 SellerAssignedID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedTradeProduct/ram:SellerAssignedID", nsmgr),
                 BuyerAssignedID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedTradeProduct/ram:BuyerAssignedID", nsmgr),
                 Name = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedTradeProduct/ram:Name", nsmgr),
-                Description = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedTradeProduct/ram:Description", nsmgr),                
+                Description = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedTradeProduct/ram:Description", nsmgr),
                 BilledQuantity = XmlUtils.NodeAsDecimal(tradeLineItem, ".//ram:BilledQuantity", nsmgr, 0).Value,
                 ShipTo = _nodeAsParty(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:ShipToTradeParty", nsmgr),
                 UltimateShipTo = _nodeAsParty(tradeLineItem, ".//ram:SpecifiedLineTradeDelivery/ram:UltimateShipToTradeParty", nsmgr),
@@ -666,7 +667,7 @@ namespace s2industries.ZUGFeRD
                     item.AssociatedDocument.Notes.Add(new Note(
                         content: XmlUtils.NodeAsString(noteNode, ".//ram:Content", nsmgr),
                         subjectCode: EnumExtensions.StringToNullableEnum<SubjectCodes>(XmlUtils.NodeAsString(noteNode, ".//ram:SubjectCode", nsmgr)),
-                        contentCode: EnumExtensions.StringToNullableEnum<ContentCodes > (XmlUtils.NodeAsString(noteNode, ".//ram:ContentCode", nsmgr))
+                        contentCode: EnumExtensions.StringToNullableEnum<ContentCodes>(XmlUtils.NodeAsString(noteNode, ".//ram:ContentCode", nsmgr))
                     ));
                 }
             }
@@ -696,7 +697,7 @@ namespace s2industries.ZUGFeRD
                                            actualAmount,
                                            chargePercentage,
                                            reason);
-                }                    
+                }
             }
 
             if (!item.UnitCode.HasValue)
@@ -779,13 +780,13 @@ namespace s2industries.ZUGFeRD
             }
 
             Contact retval = new Contact()
-                {
-                    Name = XmlUtils.NodeAsString(node, "./ram:PersonName", nsmgr),
-                    OrgUnit = XmlUtils.NodeAsString(node, "./ram:DepartmentName", nsmgr),
-                    PhoneNo = XmlUtils.NodeAsString(node, "./ram:TelephoneUniversalCommunication/ram:CompleteNumber", nsmgr),
-                    FaxNo = XmlUtils.NodeAsString(node, "./ram:FaxUniversalCommunication/ram:CompleteNumber", nsmgr),
-                    EmailAddress = XmlUtils.NodeAsString(node, "./ram:EmailURIUniversalCommunication/ram:URIID", nsmgr)
-                };
+            {
+                Name = XmlUtils.NodeAsString(node, "./ram:PersonName", nsmgr),
+                OrgUnit = XmlUtils.NodeAsString(node, "./ram:DepartmentName", nsmgr),
+                PhoneNo = XmlUtils.NodeAsString(node, "./ram:TelephoneUniversalCommunication/ram:CompleteNumber", nsmgr),
+                FaxNo = XmlUtils.NodeAsString(node, "./ram:FaxUniversalCommunication/ram:CompleteNumber", nsmgr),
+                EmailAddress = XmlUtils.NodeAsString(node, "./ram:EmailURIUniversalCommunication/ram:URIID", nsmgr)
+            };
             return retval;
         }
 

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -62,7 +62,7 @@ namespace s2industries.ZUGFeRD
                 { "ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" },
                 { "xs", "http://www.w3.org/2001/XMLSchema" },
                 { "udt", "urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" }
-            });            
+            });
 
             _Writer.WriteStartDocument();
             _WriteHeaderComments(_Writer, options);
@@ -734,7 +734,7 @@ namespace s2industries.ZUGFeRD
             _Writer.WriteStartElement("ram", "ApplicableHeaderTradeDelivery"); // Pflichteintrag
 
             //RelatedSupplyChainConsignment --> SpecifiedLogisticsTransportMovement --> ModeCode // Only in extended profile
-            if(this._Descriptor.TransportMode != null)
+            if (this._Descriptor.TransportMode != null)
             {
                 _Writer.WriteStartElement("ram", "RelatedSupplyChainConsignment", Profile.Extended); // BG-X-24
                 _Writer.WriteStartElement("ram", "SpecifiedLogisticsTransportMovement", Profile.Extended); // BT-X-152-00
@@ -944,7 +944,7 @@ namespace s2industries.ZUGFeRD
 
             #region ApplicableTradeTax
             //  11. ApplicableTradeTax (optional)            
-            _writeOptionalTaxes(_Writer ,options);
+            _writeOptionalTaxes(_Writer, options);
             #endregion
 
             #region BillingSpecifiedPeriod
@@ -1021,7 +1021,7 @@ namespace s2industries.ZUGFeRD
                         var sbPaymentNotes = new StringBuilder();
                         DateTime? dueDate = null;
                         foreach (PaymentTerms paymentTerms in this._Descriptor.GetTradePaymentTerms())
-                        {                                                        
+                        {
 
                             // every line break must be a valid xml line break.
                             // if a note already exists, append a valid line break.
@@ -1055,7 +1055,7 @@ namespace s2industries.ZUGFeRD
                                     sbPaymentNotes.Append(paymentTerms.Description.Trim());
                                 }
                             }
-                            dueDate = dueDate ?? paymentTerms.DueDate;                            
+                            dueDate = dueDate ?? paymentTerms.DueDate;
                         }
 
                         _Writer.WriteStartElement("ram", "Description");
@@ -1188,6 +1188,7 @@ namespace s2industries.ZUGFeRD
             {
                 _Writer.WriteStartElement("ram", "InvoiceReferencedDocument", ALL_PROFILES ^ Profile.Minimum);
                 _Writer.WriteOptionalElementString("ram", "IssuerAssignedID", invoiceReferencedDocument.ID);
+                _Writer.WriteOptionalElementString("ram", "TypeCode", EnumExtensions.EnumToString(invoiceReferencedDocument.TypeCode), profile: Profile.Extended); // BT-X-332 
                 if (invoiceReferencedDocument.IssueDateTime.HasValue)
                 {
                     _Writer.WriteStartElement("ram", "FormattedIssueDateTime");
@@ -1623,7 +1624,7 @@ namespace s2industries.ZUGFeRD
                 if (tax.TaxPointDate.HasValue)
                 {
                     _Writer.WriteStartElement("ram", "TaxPointDate");
-                    _Writer.WriteStartElement("udt", "DateString");  
+                    _Writer.WriteStartElement("udt", "DateString");
                     _Writer.WriteAttributeString("format", "102");
                     _Writer.WriteValue(_formatDate(tax.TaxPointDate.Value));
                     _Writer.WriteEndElement(); // !udt:DateString
@@ -1918,7 +1919,7 @@ namespace s2industries.ZUGFeRD
                 case TaxCategoryCodes.S:
                     return "Normalsatz";
                 case TaxCategoryCodes.Z:
-                    return "nach dem Nullsatz zu versteuernde Waren";                
+                    return "nach dem Nullsatz zu versteuernde Waren";
                 case TaxCategoryCodes.D:
                     break;
                 case TaxCategoryCodes.F:

--- a/ZUGFeRD/InvoiceReferencedDocument.cs
+++ b/ZUGFeRD/InvoiceReferencedDocument.cs
@@ -27,5 +27,10 @@ namespace s2industries.ZUGFeRD
     /// </summary>
     public class InvoiceReferencedDocument : BaseReferencedDocument
     {
+        /// <summary>
+        /// BT-X-332 - Can be used in the case of a final invoice following a prepaid invoice to refer to the previous prepaid invoices.
+        /// Code list UNCL 1001 restricted as BT-3.
+        /// </summary>
+        public InvoiceType? TypeCode { get; set; }
     }
 }


### PR DESCRIPTION
Beschreibung:
Diese Änderung implementiert die Unterstützung für das optionale TypeCode-Feld auf InvoiceReferencedDocument, wie es in der ZUGFeRD 2.3.2 Spezifikation für das Extended Profile definiert ist.
Motivation:
Der TypeCode wird benötigt, um verschiedene Rechnungstypen korrekt zu referenzieren:

Abschlagsrechnungen (Partial invoices)
Stornorechnungen (Cancellation invoices)
Schlussrechnungen (Final invoices)

Ohne diese Information ist eine eindeutige Zuordnung der Rechnungsbeziehungen nicht möglich.
Änderungen:

Erweiterung von InvoiceReferencedDocument um die TypeCode-Eigenschaft
Anpassung der Serialisierung/Deserialisierung für ZUGFeRD 2.3.2 Kompatibilität

Hinweis:
Die PR enthält auch Whitespace-Korrekturen aufgrund der aktiven .editorconfig mit automatischer Formatierung. Diese können bei Bedarf in einem separaten Commit isoliert werden.