### PR TITLE
Fixes #791 .gitattributes:

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # set the handling of line endings for this repository, for people who don't have core.autocrlf set.
-text=auto
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.cs text
+*.xml text


### PR DESCRIPTION
* Forgot the star (*) at the beginning of the line.
* Explicitly declared .cs and .xml files as text files.