### PR TITLE
Fixes issue #798: Under CII Version 20 the generated e-invoice might …

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -624,8 +624,8 @@ namespace s2industries.ZUGFeRD
             //   4. InvoiceCurrencyCode (optional)
             _Writer.WriteElementString("ram", "InvoiceCurrencyCode", this._Descriptor.Currency.EnumToString());
 
-            //   5. InvoiceIssuerReference (optional)
-            _Writer.WriteElementString("ram", "InvoiceIssuerReference", this._Descriptor.SellerReferenceNo, profile: Profile.Extended);
+            //   5. InvoiceIssuerReference (optional), BT-X-204
+            _Writer.WriteOptionalElementString("ram", "InvoiceIssuerReference", this._Descriptor.SellerReferenceNo, Profile.Extended);
 
             //   6. InvoicerTradeParty (optional)
             _writeOptionalParty(_Writer, "ram", "InvoicerTradeParty", this._Descriptor.Invoicer);


### PR DESCRIPTION
Fixes issue #798: Under CII Version 20 the generated e-invoice might contain an empty `InvoiceIssuerReference` section.

The code change has just been copied from the code for writing version 23 files.