### PR TITLE
Fixes issue #800.

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -648,7 +648,23 @@ namespace s2industries.ZUGFeRD
             _Writer.WriteEndElement(); // !InvoicedQuantity || CreditedQuantity
 
             _WriteComment(_Writer, options, InvoiceCommentConstants.SpecifiedTradeSettlementLineMonetarySummationComment);
-            _writeOptionalAmount(_Writer, "cbc", "LineExtensionAmount", tradeLineItem.LineTotalAmount, forceCurrency: true);
+            decimal lineTotalAmount = 0m;
+            if (tradeLineItem.LineTotalAmount.HasValue)
+            {
+                lineTotalAmount = tradeLineItem.LineTotalAmount.Value;
+            }
+            else
+            {
+                lineTotalAmount = tradeLineItem.NetUnitPrice * tradeLineItem.BilledQuantity;
+                if (tradeLineItem.NetQuantity.HasValue && (tradeLineItem.NetQuantity.Value != 0))
+                {
+                    lineTotalAmount /= tradeLineItem.NetQuantity.Value;
+                }
+            }
+            _Writer.WriteStartElement("cbc", "LineExtensionAmount");
+            _Writer.WriteAttributeString("currencyID", this._Descriptor.Currency.EnumToString());
+            _Writer.WriteValue(_formatDecimal(lineTotalAmount));
+            _Writer.WriteEndElement(); // cbc:LineExtensionAmount
 
             if (tradeLineItem.AdditionalReferencedDocuments.Count > 0)
             {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -522,22 +522,22 @@ namespace s2industries.ZUGFeRD
                 //Detailinformationen zu Positionssummen
                 _WriteComment(_Writer, options, InvoiceCommentConstants.SpecifiedTradeSettlementLineMonetarySummationComment);
                 _Writer.WriteStartElement("ram", "SpecifiedTradeSettlementLineMonetarySummation");
-                decimal total = 0m;
+                decimal lineTotalAmount = 0m;
                 if (tradeLineItem.LineTotalAmount.HasValue)
                 {
-                    total = tradeLineItem.LineTotalAmount.Value;
+                    lineTotalAmount = tradeLineItem.LineTotalAmount.Value;
                 }
                 else
                 {
-                    total = tradeLineItem.NetUnitPrice * tradeLineItem.BilledQuantity;
+                    lineTotalAmount = tradeLineItem.NetUnitPrice * tradeLineItem.BilledQuantity;
                     if (tradeLineItem.NetQuantity.HasValue && (tradeLineItem.NetQuantity.Value != 0))
                     {
-                        total /= tradeLineItem.NetQuantity.Value;
+                        lineTotalAmount /= tradeLineItem.NetQuantity.Value;
                     }
                 }
 
                 _Writer.WriteStartElement("ram", "LineTotalAmount", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
-                _Writer.WriteValue(_formatDecimal(total));
+                _Writer.WriteValue(_formatDecimal(lineTotalAmount));
                 _Writer.WriteEndElement(); // !ram:LineTotalAmount
 
                 // TODO: TotalAllowanceChargeAmount


### PR DESCRIPTION
When writing in UBL format and `lineTotalAmount` was omitted in `AddTradeLineItem `, it caused a validation error, because `LineExtensionAmount` was missing. We now calculate it in the same way as for the CII format.
