### PR TITLE
Addition of the AAB PMD ABL CUS codes for the reform of the French electronic invoice.

### DIFF
--- a/ZUGFeRD/SubjectCodes.cs
+++ b/ZUGFeRD/SubjectCodes.cs
@@ -24,7 +24,7 @@ using System.Text;
 namespace s2industries.ZUGFeRD
 {
     /// <summary>
-    /// http://www.stylusstudio.com/edifact/D02A/4451.htm
+    /// https://service.unece.org/trade/untdid/d23a/tred/tred4451.htm
     /// </summary>
     public enum SubjectCodes
     {
@@ -73,6 +73,12 @@ namespace s2industries.ZUGFeRD
         ABN,
 
         /// <summary>
+        /// Factor assignment clause
+        /// </summary>
+        /// Assignment based on an agreement between seller and factor.
+        ACC,
+
+        /// <summary>
         /// Zusätzliche Angaben
         /// </summary>
         /// Zusaätzliche Angaben zu diesem Kauf
@@ -87,6 +93,12 @@ namespace s2industries.ZUGFeRD
         /// Instructions to the paying and/or accepting and/or negotiating bank
         /// </summary>
         AET,
+
+        /// <summary>
+        /// Waste information
+        /// </summary>
+        /// Text describing waste related information.
+        BLU,
 
         /// <summary>
         /// Order information


### PR DESCRIPTION
Hello,

Addition of the missing codes AAB PMD ABL CUS  for the reform of the French electronic invoice.

[https://www.impots.gouv.fr/factures-norme-afnor](https://www.impots.gouv.fr/factures-norme-afnor)

> 4.4.3 Gestion des Notes
> Un certain nombre de mentions obligatoires ou conditionnellement obligatoires n’ont pas d’existence propre
> dans le modéle EN16931 et sont alors codifiées au travers d’une Note (texte en BT-22), avec un code sujet
> dédié (en BT-21). Les règles BR-FR-05, BR-FR-06, BR-FR-07 indiquent la codification attendue.
> Parmi l’ensemble des codes sujets, la liste ci-dessous détaillent ceux à utiliser en fonction des sujets les plus courants :
> • AAB . Mention d’escompte.
> • AAI : Information générale : des éléments en général en fond de page des factures papier.
> • ABL : Information légale : par exemple N∞ registre des métiers, RCS.
> • ACC : Clause de subrogation factoring.
> • BLU : "Eco-participation (L. 541-10 du code de l'environnement)" ou "Eco-contribution DEEE". Peut servir aussi à d'autres taxes dont l'écotaxe 
> • CUS : Information douanière.
> • PMT . Mention de l’indemnité forfaitaire de 40 € pour frais de recouvrement.
> • PMD : Mention pénalités de retard.
> • SUR : Remarques fournisseur.
> • TXD . Mention de Membre d’Assujetti Unique.