### PR TITLE
Description decoration for FOB should be EnumStringValue decoration

### DIFF
--- a/ZUGFeRD/TradeDeliveryTermCodes.cs
+++ b/ZUGFeRD/TradeDeliveryTermCodes.cs
@@ -121,7 +121,7 @@ namespace s2industries.ZUGFeRD
         /// FOB
         /// Frei an Bord (benannten Verschiffungshafen einfügen)
         /// </summary>
-        [Description("FOB")]
+        [EnumStringValue("FOB")]
         FOB
 	}
 }


### PR DESCRIPTION
## Summary
Description decoration for FOB should be EnumStringValue decoration

## Checklist
- [ ] Code follows repo **Coding Instructions**
- [ ] Public APIs documented (XML)
- [ ] Unit tests added/updated
- [ ] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [ ] `CancellationToken` respected
- [ ] Analyzers clean (`dotnet build` no warnings as errors)
- [ ] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [X] No
- [ ] Yes (explain impact & migration)