### PR TITLE
ActualDeliverySupplyChainEvent for position level

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -417,7 +417,7 @@ namespace s2industries.ZUGFeRD
 
                 if (tradeLineItem.ActualDeliveryDate.HasValue)
                 {
-                    _Writer.WriteStartElement("ram", "ActualDeliverySupplyChainEvent", ALL_PROFILES ^ (Profile.XRechnung1 | Profile.XRechnung | Profile.Comfort | Profile.Basic)); // this violates CII-SR-170 for XRechnung 3
+                    _Writer.WriteStartElement("ram", "ActualDeliverySupplyChainEvent", Profile.Extended); // Delivery date in line item level should only be added in the extended profile. 
                     _Writer.WriteStartElement("ram", "OccurrenceDateTime");
                     _Writer.WriteStartElement("udt", "DateTimeString");
                     _Writer.WriteAttributeString("format", "102");


### PR DESCRIPTION
**ActualDeliverySupplyChainEvent** should not be added in the Comfort profile for the tradeline items.
The tradeline item delivery note date should only be used in the Extended profile.

## Breaking changes?
- [x] No

<img width="634" height="300" alt="image" src="https://github.com/user-attachments/assets/445a44b0-53ba-47f2-b32e-fd1c2465517d" />
