### PR TITLE
define old QuantityCodes used in documentation\zugferd20\Beispiele\EX…

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -3122,7 +3122,7 @@ namespace s2industries.ZUGFeRD.Test
 
             MemoryStream ms = new MemoryStream();
             desc.Save(ms, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.CII);
-            desc.Save("e:\\output.xml", ZUGFeRDVersion.Version23, Profile.XRechnung);
+            // desc.Save("e:\\output.xml", ZUGFeRDVersion.Version23, Profile.XRechnung);
 
             var lines = new StreamReader(ms).ReadToEnd().Split(new[] { System.Environment.NewLine }, StringSplitOptions.None).ToList();
 

--- a/ZUGFeRD/QuantityCodes.cs
+++ b/ZUGFeRD/QuantityCodes.cs
@@ -467,26 +467,32 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Flasche
         /// Abkürzung: Fl
+        /// Previously, BO was also used. This has been removed.
         /// </summary>
         /// <remarks>
         /// Bottle, non-protected, cylindrical
         /// A narrow-necked cylindrical shaped vessel without external protective packing material
         /// </remarks>
+        [EnumStringValue("XBO", "BO")]
         XBO,
 
         /// <summary>
         /// Karton
         /// Abkürzung: Kt
+        /// Previously, CT was also used. This has been removed.
         /// </summary>
+        [EnumStringValue("XCT", "CT")]
         XCT,
 
         /// <summary>
         /// Palette
         /// Abkürzung: Pal
+        /// Previously, PX was also used. This has been removed.
         /// </summary>
         /// <remarks>
         /// Platform or open-ended box, usually made of wood, on which goods are retained for ease of mechanical handling during transport and storage.
         /// </remarks>
+        [EnumStringValue("XPX", "PX")]
         XPX,
 
         /// <summary>
@@ -498,7 +504,9 @@ namespace s2industries.ZUGFeRD
         /// <summary>
         /// Kiste oder ein Gestell, das mehrere Flaschen sicher hält
         /// Bottlecrate / bottlerack
+        /// Previously, BC was also used. This has been removed.
         /// </summary>
+        [EnumStringValue("XBC", "BC")]
         XBC,
 
         /// <summary>


### PR DESCRIPTION


## Summary
- define old QuantityCodes BC, BO, CT, PX used in documentation\zugferd20\Beispiele\EXTENDED\zugferd_2p0_EXTENDED_Warenrechnung.pdf
- fix hardwired path in zugferd22 test
- 
## Checklist
- [ ] Code follows repo **Coding Instructions**
- [ ] Public APIs documented (XML)
- [ ] Unit tests added/updated
- [ ] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [ ] `CancellationToken` respected
- [ ] Analyzers clean (`dotnet build` no warnings as errors)
- [ ] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [x] No
- [ ] Yes (explain impact & migration)