### PR TITLE
Fix: FC TaxRegistration only written for SellerTradeParty in Comfort/Extended profile

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -1650,6 +1650,32 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
+        public void TestBuyerFCTaxRegistrationFiltered()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+
+            // CreateInvoice already adds Seller with FC + VA
+            // Add both FC + VA for Buyer as well
+            desc.AddBuyerTaxRegistration("99/999/99999", TaxRegistrationSchemeID.FC);
+            desc.AddBuyerTaxRegistration("DE987654321", TaxRegistrationSchemeID.VA);
+
+            MemoryStream ms = new MemoryStream();
+            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            // Seller: both FC + VA written (Extended allows FC for Seller)
+            Assert.AreEqual(2, loadedInvoice.SellerTaxRegistration.Count,
+                "Seller should have 2 TaxRegistrations (FC + VA)");
+
+            // Buyer: only VA, FC was filtered out
+            Assert.AreEqual(1, loadedInvoice.BuyerTaxRegistration.Count,
+                "Buyer should have only 1 TaxRegistration (VA), FC is filtered");
+            Assert.AreEqual(TaxRegistrationSchemeID.VA, loadedInvoice.BuyerTaxRegistration.First().SchemeID);
+        }
+
+
+        [TestMethod]
         public void TestUltimateShipToTradePartyOnItemLevel()
         {
             InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1850,6 +1850,13 @@ namespace s2industries.ZUGFeRD
                 // for buyer : BT-48
                 foreach (TaxRegistration taxRegistration in taxRegistrations.Where(tr => !String.IsNullOrWhiteSpace(tr.No)))
                 {
+                    // FC allowed only in Comfort and Extended profile for SellerTradeParty (and TODO: ItemSellerTradeParty)
+                    if (taxRegistration.SchemeID == TaxRegistrationSchemeID.FC
+                        && !(partyType == PartyTypes.SellerTradeParty && this._Descriptor.Profile.In(Profile.Extended, Profile.Comfort)))
+                    {
+                        continue;
+                    }
+
                     writer.WriteStartElement("ram", "SpecifiedTaxRegistration");
                     writer.WriteStartElement("ram", "ID");
                     writer.WriteAttributeString("schemeID", taxRegistration.SchemeID.EnumToString());


### PR DESCRIPTION
## Summary
FC TaxRegistration only written for SellerTradeParty in Comfort/Extended profile

## Checklist
- [ ] Code follows repo **Coding Instructions**
- [ ] Public APIs documented (XML)
- [ ] Unit tests added/updated
- [ ] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [ ] `CancellationToken` respected
- [ ] Analyzers clean (`dotnet build` no warnings as errors)
- [ ] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [x] No
- [ ] Yes (explain impact & migration)