### PR TITLE
Allow FC TaxRegistration for SellerTradeParty in XRechnung profile

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1849,9 +1849,9 @@ namespace s2industries.ZUGFeRD
                 // for buyer : BT-48
                 foreach (TaxRegistration taxRegistration in taxRegistrations.Where(tr => !String.IsNullOrWhiteSpace(tr.No)))
                 {
-                    // FC allowed only in Comfort and Extended profile for SellerTradeParty (and TODO: ItemSellerTradeParty)
+                    // FC allowed only in Comfort, Extended and XRechnung profile for SellerTradeParty (and TODO: ItemSellerTradeParty)
                     if (taxRegistration.SchemeID == TaxRegistrationSchemeID.FC
-                        && !(partyType == PartyTypes.SellerTradeParty && this._Descriptor.Profile.In(Profile.Extended, Profile.Comfort)))
+                        && !(partyType == PartyTypes.SellerTradeParty && this._Descriptor.Profile.In(Profile.Extended, Profile.Comfort, Profile.XRechnung1, Profile.XRechnung)))
                     {
                         continue;
                     }


### PR DESCRIPTION
## Summary
- FC (Steuernummer) TaxRegistration for SellerTradeParty was previously only allowed in Comfort and Extended profiles
- XRechnung profile also supports BT-32 (Seller Tax Registration with scheme FC), so it should be included

## Changes
- `InvoiceDescriptor23CIIWriter.cs`: Added `Profile.XRechnung1` and `Profile.XRechnung` to the allowed profiles for FC TaxRegistration on SellerTradeParty

## Context
Discovered during Delphi port review. The corresponding fix has already been applied to [ZUGFeRD-for-Delphi](https://github.com/LandrixSoftware/ZUGFeRD-for-Delphi/pull/91).