### PR TITLE
Fix namespace resolution by always registering predefined namespaces

### DIFF
--- a/ZUGFeRD/IInvoiceDescriptorReader.cs
+++ b/ZUGFeRD/IInvoiceDescriptorReader.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -81,36 +81,60 @@ namespace s2industries.ZUGFeRD
         } // !_GenerateNamespaceManagerFromNode()
         */
 
+        //protected XmlNamespaceManager _CreateFixedNamespaceManager(XmlDocument doc)
+        //{
+        //    var nsmgr = new XmlNamespaceManager(doc.NameTable);
+
+        //    var declared = new Dictionary<string, string>();
+
+        //    // Alle deklarierten Namespaces aus dem Dokument einlesen
+        //    if (doc.DocumentElement != null)
+        //    {
+        //        foreach (XmlAttribute attr in doc.DocumentElement.Attributes)
+        //        {
+        //            if (attr.Prefix == "xmlns")
+        //            {
+        //                declared[attr.LocalName] = attr.Value;
+        //            }
+        //            else if (attr.Name == "xmlns")
+        //            {
+        //                declared[string.Empty] = attr.Value;
+        //            }
+        //        }
+        //    }
+
+        //    // Factur-X / ZUGFeRD relevante Namespaces
+        //    foreach(KeyValuePair<string,string> ns in _Namespaces)
+        //    {
+        //        _AddNamespaceIfExists(nsmgr, declared, ns.Key, ns.Value);
+        //    }
+
+        //    return nsmgr;
+        //} // !_CreateFixedNamespaceManager()
         protected XmlNamespaceManager _CreateFixedNamespaceManager(XmlDocument doc)
         {
             var nsmgr = new XmlNamespaceManager(doc.NameTable);
 
-            var declared = new Dictionary<string, string>();
-
-            // Alle deklarierten Namespaces aus dem Dokument einlesen
-            if (doc.DocumentElement != null)
-            {
-                foreach (XmlAttribute attr in doc.DocumentElement.Attributes)
-                {
-                    if (attr.Prefix == "xmlns")
-                    {
-                        declared[attr.LocalName] = attr.Value;
-                    }
-                    else if (attr.Name == "xmlns")
-                    {
-                        declared[string.Empty] = attr.Value;
-                    }
-                }
-            }
-
-            // Factur-X / ZUGFeRD relevante Namespaces
-            foreach(KeyValuePair<string,string> ns in _Namespaces)
+            foreach (var ns in _Namespaces)
             {
                 nsmgr.AddNamespace(ns.Key, ns.Value);
             }
 
             return nsmgr;
-        } // !_CreateFixedNamespaceManager()
+        }
+
+
+
+        private void _AddNamespaceIfExists(XmlNamespaceManager mgr, Dictionary<string, string> declared, string prefix, string expectedUri)
+        {
+            // Prüfen, ob dieser Namespace im Dokument vorkommt
+            bool exists = declared.Values.Contains(expectedUri);
+
+            if (exists)
+            {
+                mgr.AddNamespace(prefix, expectedUri);
+            }
+        } //!_AddNamespaceIfExists()
 
 
         protected bool _IsReadableByThisReaderVersion(Stream stream, IList<string> validURIs)


### PR DESCRIPTION
## Summary
This change simplifies namespace handling in `IInvoiceDescriptorReader`.

Instead of dynamically detecting namespaces from the XML document,
the reader now always registers the predefined namespaces.

## Motivation
In some real-world XML files (e.g. ZUGFeRD / Factur-X),
namespaces are missing, inconsistent, or not declared as expected.
This caused XPath queries to fail.

By always registering the known namespaces, parsing becomes more robust.

## Changes
- Removed document-based namespace detection
- Always register namespaces from `_Namespaces`

## Impact
- Improves compatibility with non-standard or slightly malformed XML files
- May introduce unused namespaces in the namespace manager (harmless in most cases)

## Testing
Tested with XML files where namespace declarations were incomplete or missing.

[RETAIL_ERECHNUNGEN_2025-11-26 125506.xml](https://github.com/user-attachments/files/26216873/RETAIL_ERECHNUNGEN_2025-11-26.125506.xml)
