### PR TITLE
Output the "DirectDebitMandateID" section only once

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor1Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor1Writer.cs
@@ -387,6 +387,12 @@ namespace s2industries.ZUGFeRD
                 case Profile.Minimum:
                     break;
                 case Profile.Extended:
+                {
+                    // The SEPA mandate reference (BT-89) is stored in the PaymentMeans and not in the individual PaymentTerms, but it schould be
+                    // written only once and not multiple time. Therefore, we write it only in the first "SpecifiedTradePaymentTerms" section.
+                    // See https://github.com/stephanstapel/ZUGFeRD-csharp/issues/907
+                    bool bSEPAMandateReferenceWritten = false;
+
                     foreach (PaymentTerms paymentTerms in this._Descriptor.GetTradePaymentTerms())
                     {
                         _Writer.WriteStartElement("ram", "SpecifiedTradePaymentTerms");
@@ -397,7 +403,11 @@ namespace s2industries.ZUGFeRD
                             _writeElementWithAttribute(_Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
                             _Writer.WriteEndElement(); // !ram:DueDateDateTime
                         }
-                        _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
+                        if ( ! bSEPAMandateReferenceWritten)
+                        {
+                            _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
+                            bSEPAMandateReferenceWritten = true;
+                        }
                         if (paymentTerms.PaymentTermsType.HasValue)
                         {
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
@@ -419,13 +429,15 @@ namespace s2industries.ZUGFeRD
                         }
                         _Writer.WriteEndElement();
                     }
-                    if (this._Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(_Descriptor.PaymentMeans?.SEPAMandateReference))
+                    // If BT-89 has not been written and a SEPA mandate reference exists, write it in an own "SpecifiedTradePaymentTerms" section without a description and due date.
+                    if (!bSEPAMandateReferenceWritten && !string.IsNullOrWhiteSpace(_Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         _Writer.WriteStartElement("ram", "SpecifiedTradePaymentTerms");
                         _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
                         _Writer.WriteEndElement();
                     }
                     break;
+                }
                 default:
                     if (_Descriptor.GetTradePaymentTerms().Count > 0)
                     {

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -883,6 +883,12 @@ namespace s2industries.ZUGFeRD
                     }
                     break;
                 case Profile.Extended:
+                {
+                    // The SEPA mandate reference (BT-89) is stored in the PaymentMeans and not in the individual PaymentTerms, but it schould be
+                    // written only once and not multiple time. Therefore, we write it only in the first "SpecifiedTradePaymentTerms" section.
+                    // See https://github.com/stephanstapel/ZUGFeRD-csharp/issues/907
+                    bool bSEPAMandateReferenceWritten = false;
+
                     foreach (PaymentTerms paymentTerms in this._Descriptor.GetTradePaymentTerms())
                     {
                         _Writer.WriteStartElement("ram", "SpecifiedTradePaymentTerms");
@@ -893,7 +899,11 @@ namespace s2industries.ZUGFeRD
                             _writeElementWithAttribute(_Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
                             _Writer.WriteEndElement(); // !ram:DueDateDateTime
                         }
-                        _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
+                        if ( ! bSEPAMandateReferenceWritten)
+                        {
+                            _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
+                            bSEPAMandateReferenceWritten = true;
+                        }
                         if (paymentTerms.PaymentTermsType.HasValue)
                         {
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
@@ -915,13 +925,15 @@ namespace s2industries.ZUGFeRD
                         }
                         _Writer.WriteEndElement();
                     }
-                    if (this._Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(_Descriptor.PaymentMeans?.SEPAMandateReference))
+                    // If BT-89 has not been written and a SEPA mandate reference exists, write it in an own "SpecifiedTradePaymentTerms" section without a description and due date.
+                    if (!bSEPAMandateReferenceWritten && !string.IsNullOrWhiteSpace(_Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         _Writer.WriteStartElement("ram", "SpecifiedTradePaymentTerms");
                         _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
                         _Writer.WriteEndElement();
                     }
                     break;
+                }
                 default:
                     if (_Descriptor.GetTradePaymentTerms().Count > 0 || !string.IsNullOrWhiteSpace(_Descriptor.PaymentMeans?.SEPAMandateReference))
                     {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1096,6 +1096,12 @@ namespace s2industries.ZUGFeRD
                     }
                     break;
                 case Profile.Extended:
+                {
+                    // The SEPA mandate reference (BT-89) is stored in the PaymentMeans and not in the individual PaymentTerms, but it schould be
+                    // written only once and not multiple time. Therefore, we write it only in the first "SpecifiedTradePaymentTerms" section.
+                    // See https://github.com/stephanstapel/ZUGFeRD-csharp/issues/907
+                    bool bSEPAMandateReferenceWritten = false;
+
                     foreach (PaymentTerms paymentTerms in this._Descriptor.GetTradePaymentTerms())
                     {
                         _Writer.WriteStartElement("ram", "SpecifiedTradePaymentTerms");
@@ -1106,7 +1112,11 @@ namespace s2industries.ZUGFeRD
                             _writeElementWithAttributeWithPrefix(_Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
                             _Writer.WriteEndElement(); // !ram:DueDateDateTime
                         }
-                        _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
+                        if ( ! bSEPAMandateReferenceWritten)
+                        {
+                            _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
+                            bSEPAMandateReferenceWritten = true;
+                        }
                         if (paymentTerms.PaymentTermsType.HasValue)
                         {
                             if (paymentTerms.PaymentTermsType == PaymentTermsType.Skonto)
@@ -1148,14 +1158,21 @@ namespace s2industries.ZUGFeRD
                         }
                         _Writer.WriteEndElement(); // !ram:SpecifiedTradePaymentTerms
                     }
-                    if (this._Descriptor.GetTradePaymentTerms().Count == 0 && !string.IsNullOrWhiteSpace(_Descriptor.PaymentMeans?.SEPAMandateReference))
+                    // If BT-89 has not been written and a SEPA mandate reference exists, write it in an own "SpecifiedTradePaymentTerms" section without a description and due date.
+                    if (!bSEPAMandateReferenceWritten && !string.IsNullOrWhiteSpace(_Descriptor.PaymentMeans?.SEPAMandateReference))
                     {
                         _Writer.WriteStartElement("ram", "SpecifiedTradePaymentTerms");
                         _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference);
                         _Writer.WriteEndElement();
                     }
                     break;
+                }
                 default:
+                {
+                    // The SEPA mandate reference (BT-89) is stored in the PaymentMeans and not in the individual PaymentTerms, but it schould be
+                    // written only once and not multiple time. Therefore, we write it only in the first "SpecifiedTradePaymentTerms" section.
+                    // See https://github.com/stephanstapel/ZUGFeRD-csharp/issues/907
+                    bool bSEPAMandateReferenceWritten = false;
                     foreach (PaymentTerms paymentTerms in this._Descriptor.GetTradePaymentTerms())
                     {
                         _Writer.WriteStartElement("ram", "SpecifiedTradePaymentTerms");
@@ -1166,10 +1183,15 @@ namespace s2industries.ZUGFeRD
                             _writeElementWithAttributeWithPrefix(_Writer, "udt", "DateTimeString", "format", "102", _formatDate(paymentTerms.DueDate.Value));
                             _Writer.WriteEndElement(); // !ram:DueDateDateTime
                         }
-                        _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference, ALL_PROFILES ^ Profile.Minimum);
+                        if ( ! bSEPAMandateReferenceWritten)
+                        {
+                            _Writer.WriteOptionalElementString("ram", "DirectDebitMandateID", _Descriptor.PaymentMeans?.SEPAMandateReference, ALL_PROFILES ^ Profile.Minimum);
+                            bSEPAMandateReferenceWritten = true;
+                        }
                         _Writer.WriteEndElement(); // !ram:SpecifiedTradePaymentTerms
                     }
                     break;
+                }
             }
 
             #region SpecifiedTradeSettlementHeaderMonetarySummation


### PR DESCRIPTION
When there are multiple "PaymentTerms", then multiple "DirectDebitMandateID" sections (BT-89) have been written.

This has been corrected. The "DirectDebitMandateID" sections (BT-89) is now only written once, in the very first "SpecifiedTradePaymentTerms" section.

Fixes #907
