### PR TITLE
Added SellerOrderReferencedDocument on Tradeline level

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -3312,6 +3312,25 @@ namespace s2industries.ZUGFeRD.Test
             Assert.AreEqual(desc.GetTradeLineItems().First().BuyerOrderReferencedDocument.LineID, "1");
             Assert.AreEqual(desc.GetTradeLineItems().First().BuyerOrderReferencedDocument.ID, "ORDER84359");
         }
+        
+        [TestMethod]
+        public void TestSellerOrderReferenceLineId()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+
+            desc.TradeLineItems[0].SellerOrderReferencedDocument = new SellerOrderReferencedDocument { ID = "ORDER84359" , IssueDateTime = new DateTime(2024, 6, 1)};
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, ZUGFeRDVersion.Version23, Profile.Extended);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+            List<TradeLineItem> items = loadedInvoice.GetTradeLineItems();
+
+            Assert.AreEqual(items[0].SellerOrderReferencedDocument.IssueDateTime, new DateTime(2024, 6, 1));
+            Assert.AreEqual(items[0].SellerOrderReferencedDocument.ID, "ORDER84359");
+        }
 
         [TestMethod]
         public void TestRequiredDirectDebitFieldsShouldExist()

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -646,6 +646,15 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
+            if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument", nsmgr) != null)
+            {
+                item.SellerOrderReferencedDocument = new SellerOrderReferencedDocument()
+                {
+                    ID = XmlUtils.NodeAsString(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(tradeLineItem, ".//ram:SpecifiedLineTradeAgreement/ram:SellerOrderReferencedDocument/ram:FormattedIssueDateTime", nsmgr)
+                };
+            }
+
             if (tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeAgreement/ram:ContractReferencedDocument", nsmgr) != null)
             {
                 item.ContractReferencedDocument = new ContractReferencedDocument()

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1678,7 +1678,7 @@ namespace s2industries.ZUGFeRD
                 writer.WriteStartElement("ram", "IncludedNote", profile);
                 if (note.ContentCode.HasValue)
                 {
-                    writer.WriteElementString("ram", "ContentCode", note.ContentCode.EnumToString());
+                    writer.WriteElementString("ram", "ContentCode", note.ContentCode.EnumToString(), Profile.Extended);
                 }
                 writer.WriteOptionalElementString("ram", "Content", note.Content);
                 if (note.SubjectCode.HasValue)

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -290,6 +290,27 @@ namespace s2industries.ZUGFeRD
                 {
                     _Writer.WriteStartElement("ram", "SpecifiedLineTradeAgreement", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
+                    #region SellerOrderReferencedDocument (Comfort, Extended, XRechnung)
+                    if (tradeLineItem.SellerOrderReferencedDocument != null &&
+                        !string.IsNullOrWhiteSpace(tradeLineItem.SellerOrderReferencedDocument.ID))
+                    {
+                        _Writer.WriteStartElement("ram", "SellerOrderReferencedDocument", PROFILE_COMFORT_EXTENDED_XRECHNUNG);
+                        _Writer.WriteOptionalElementString("ram", "IssuerAssignedID", tradeLineItem.SellerOrderReferencedDocument.ID);
+
+                        if (tradeLineItem.SellerOrderReferencedDocument.IssueDateTime.HasValue)
+                        {
+                            _Writer.WriteStartElement("ram", "FormattedIssueDateTime", Profile.Extended);
+                            _Writer.WriteStartElement("qdt", "DateTimeString");
+                            _Writer.WriteAttributeString("format", "102");
+                            _Writer.WriteValue(_formatDate(tradeLineItem.SellerOrderReferencedDocument.IssueDateTime.Value));
+                            _Writer.WriteEndElement(); // !qdt:DateTimeString
+                            _Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+                        }
+
+                        _Writer.WriteEndElement(); // !ram:SellerOrderReferencedDocument
+                    }
+                    #endregion
+
                     #region BuyerOrderReferencedDocument (Comfort, Extended, XRechnung)
                     // Detailangaben zur zugehörigen Bestellung
                     bool hasLineID = !string.IsNullOrWhiteSpace(tradeLineItem.BuyerOrderReferencedDocument?.LineID);
@@ -319,27 +340,6 @@ namespace s2industries.ZUGFeRD
                         }
 
                         _Writer.WriteEndElement(); // !ram:BuyerOrderReferencedDocument
-                    }
-                    #endregion
-
-                    #region SellerOrderReferencedDocument (Comfort, Extended, XRechnung)
-                    if (tradeLineItem.SellerOrderReferencedDocument != null &&
-                        !string.IsNullOrWhiteSpace(tradeLineItem.SellerOrderReferencedDocument.ID))
-                    {
-                        _Writer.WriteStartElement("ram", "SellerOrderReferencedDocument", PROFILE_COMFORT_EXTENDED_XRECHNUNG);
-                        _Writer.WriteOptionalElementString("ram", "IssuerAssignedID", tradeLineItem.SellerOrderReferencedDocument.ID);
-
-                        if (tradeLineItem.SellerOrderReferencedDocument.IssueDateTime.HasValue)
-                        {
-                            _Writer.WriteStartElement("ram", "FormattedIssueDateTime", Profile.Extended);
-                            _Writer.WriteStartElement("qdt", "DateTimeString");
-                            _Writer.WriteAttributeString("format", "102");
-                            _Writer.WriteValue(_formatDate(tradeLineItem.SellerOrderReferencedDocument.IssueDateTime.Value));
-                            _Writer.WriteEndElement(); // !qdt:DateTimeString
-                            _Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
-                        }
-
-                        _Writer.WriteEndElement(); // !ram:SellerOrderReferencedDocument
                     }
                     #endregion
 

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -322,6 +322,27 @@ namespace s2industries.ZUGFeRD
                     }
                     #endregion
 
+                    #region SellerOrderReferencedDocument (Comfort, Extended, XRechnung)
+                    if (tradeLineItem.SellerOrderReferencedDocument != null &&
+                        !string.IsNullOrWhiteSpace(tradeLineItem.SellerOrderReferencedDocument.ID))
+                    {
+                        _Writer.WriteStartElement("ram", "SellerOrderReferencedDocument", PROFILE_COMFORT_EXTENDED_XRECHNUNG);
+                        _Writer.WriteOptionalElementString("ram", "IssuerAssignedID", tradeLineItem.SellerOrderReferencedDocument.ID);
+
+                        if (tradeLineItem.SellerOrderReferencedDocument.IssueDateTime.HasValue)
+                        {
+                            _Writer.WriteStartElement("ram", "FormattedIssueDateTime", Profile.Extended);
+                            _Writer.WriteStartElement("qdt", "DateTimeString");
+                            _Writer.WriteAttributeString("format", "102");
+                            _Writer.WriteValue(_formatDate(tradeLineItem.SellerOrderReferencedDocument.IssueDateTime.Value));
+                            _Writer.WriteEndElement(); // !qdt:DateTimeString
+                            _Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+                        }
+
+                        _Writer.WriteEndElement(); // !ram:SellerOrderReferencedDocument
+                    }
+                    #endregion
+
                     #region ContractReferencedDocument
                     //Detailangaben zum zugehörigen Vertrag
                     if (tradeLineItem.ContractReferencedDocument != null)

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -251,6 +251,13 @@ namespace s2industries.ZUGFeRD
         public BuyerOrderReferencedDocument BuyerOrderReferencedDocument { get; set; }
 
         /// <summary>
+        /// Details of the associated order confirmation (seller's order)
+        ///
+        /// BT-X (item level)
+        /// </summary>
+        public SellerOrderReferencedDocument SellerOrderReferencedDocument { get; set; }
+
+        /// <summary>
         /// Detailed information about the corresponding delivery note
         ///
         /// BG-X-83

--- a/docs/zugferd-details.md
+++ b/docs/zugferd-details.md
@@ -75,21 +75,13 @@ The library supports setting a status code and a reason for each line item. This
 // Example: Adding a trade line item with a specific status and reason
 
 TradeLineItem tradeLineItem3 = desc.AddTradeLineItem(
-
-&#x20;   name: "Abschlagsrechnung vom 01.01.2024",
-
-&#x20;   netUnitPrice: 500,
-
-&#x20;   unitCode: QuantityCodes.H87,
-
-&#x20;   billedQuantity: -1m,
-
-&#x20;   categoryCode: TaxCategoryCodes.S,
-
-&#x20;   taxPercent: 19.0m,
-
-&#x20;   taxType: TaxTypes.VAT
-
+    name: "Abschlagsrechnung vom 01.01.2024",
+    netUnitPrice: 500,
+    unitCode: QuantityCodes.H87,
+    billedQuantity: -1m,
+    categoryCode: TaxCategoryCodes.S,
+    taxPercent: 19.0m,
+    taxType: TaxTypes.VAT
 );
 
 

--- a/docs/zugferd-details.md
+++ b/docs/zugferd-details.md
@@ -10,26 +10,16 @@ One trade product can have one or more product characteristics, which can contai
 
 // you can optionally add product characteristics:
 
-&#x20;desc.TradeLineItems.Add(new TradeLineItem("0003")
-
+desc.TradeLineItems.Add(new TradeLineItem("0003")
 {
-
-&#x20;   ApplicableProductCharacteristics = new List<ApplicableProductCharacteristic>
-
-&#x20;   {
-
-&#x20;       new ApplicableProductCharacteristic()
-
-&#x20;       {
-
-&#x20;           Description = "Description",
-
-&#x20;           Value = "Value"
-
-&#x20;       }
-
-&#x20;   }
-
+    ApplicableProductCharacteristics = new List<ApplicableProductCharacteristic>
+    {
+        new ApplicableProductCharacteristic()
+        { 
+            Description = "Description",
+            Value = "Value"
+        }
+    }
 });
 
 ```

--- a/docs/zugferd-details.md
+++ b/docs/zugferd-details.md
@@ -54,6 +54,24 @@ desc.SpecifiedProcuringProject = new SpecifiedProcuringProject {Name = "Projekt 
 
 desc.ContractReferencedDocument = new ContractReferencedDocument {ID = "AB-312-1", IssueDateTime = new DateTime(2013,1,1)};
 
+
+
+// you can optionally reference an order confirmation (seller's order) at invoice level
+
+desc.SellerOrderReferencedDocument = new SellerOrderReferencedDocument {ID = "SO-2013-471331", IssueDateTime = new DateTime(2013, 3, 1)};
+
+```
+
+
+
+Order confirmations can also be referenced at the trade line item level:
+
+
+
+```csharp
+// reference an order confirmation at line item level:
+TradeLineItem item = desc.AddTradeLineItem(...);
+item.SellerOrderReferencedDocument = new SellerOrderReferencedDocument {ID = "SO-2013-471331-001", IssueDateTime = new DateTime(2013, 3, 1)};
 ```
 
 

--- a/docs/zugferd-details.md
+++ b/docs/zugferd-details.md
@@ -6,7 +6,7 @@ One trade product can have one or more product characteristics, which can contai
 
 
 
-&#x20;```csharp
+```csharp
 
 // you can optionally add product characteristics:
 


### PR DESCRIPTION
Added Docs 

ContentCode on Notes are only Supported in Extended Format

Extended
<img width="683" height="81" alt="image" src="https://github.com/user-attachments/assets/ac3b4b67-19b5-4625-8de4-34d2e8166b90" />

Comfort
<img width="697" height="58" alt="image" src="https://github.com/user-attachments/assets/db7a6c5c-abad-4840-910c-1f563b3aadca" />

