### PR TITLE
fix: SellerOrderReferencedDocument on Item Level only in Extended

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -290,11 +290,11 @@ namespace s2industries.ZUGFeRD
                 {
                     _Writer.WriteStartElement("ram", "SpecifiedLineTradeAgreement", Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
 
-                    #region SellerOrderReferencedDocument (Comfort, Extended, XRechnung)
+                    #region SellerOrderReferencedDocument (Extended)
                     if (tradeLineItem.SellerOrderReferencedDocument != null &&
                         !string.IsNullOrWhiteSpace(tradeLineItem.SellerOrderReferencedDocument.ID))
                     {
-                        _Writer.WriteStartElement("ram", "SellerOrderReferencedDocument", PROFILE_COMFORT_EXTENDED_XRECHNUNG);
+                        _Writer.WriteStartElement("ram", "SellerOrderReferencedDocument", Profile.Extended);
                         _Writer.WriteOptionalElementString("ram", "IssuerAssignedID", tradeLineItem.SellerOrderReferencedDocument.ID);
 
                         if (tradeLineItem.SellerOrderReferencedDocument.IssueDateTime.HasValue)


### PR DESCRIPTION
SellerOrderReferencedDocument on Item Level only in Extended


https://www.factoorsharp.de/de/Service/Documentation?businessId=BG-X-81