### PR TITLE
Add missing QuantityCodes from UN/ECE Rec 20 and Rec 21

### DIFF
--- a/ZUGFeRD/QuantityCodes.cs
+++ b/ZUGFeRD/QuantityCodes.cs
@@ -917,6 +917,86 @@ namespace s2industries.ZUGFeRD
         XUN,
 
         /// <summary>
+        /// inch
+        /// </summary>
+        INH,
+
+        /// <summary>
+        /// square inch
+        /// </summary>
+        INK,
+
+        /// <summary>
+        /// cubic inch
+        /// </summary>
+        INQ,
+
+        /// <summary>
+        /// bar [unit of pressure]
+        /// </summary>
+        BAR,
+
+        /// <summary>
+        /// gigawatt hour
+        /// </summary>
+        GWH,
+
+        /// <summary>
+        /// Container, not otherwise specified as transport equipment
+        /// </summary>
+        XCN,
+
+        /// <summary>
+        /// Cylinder
+        /// </summary>
+        XCY,
+
+        /// <summary>
+        /// Coil
+        /// </summary>
+        XCL,
+
+        /// <summary>
+        /// Envelope
+        /// </summary>
+        XEN,
+
+        /// <summary>
+        /// Jar
+        /// </summary>
+        XJR,
+
+        /// <summary>
+        /// Keg
+        /// </summary>
+        XKG,
+
+        /// <summary>
+        /// Pail
+        /// </summary>
+        XPL,
+
+        /// <summary>
+        /// Reel
+        /// </summary>
+        XRL,
+
+        /// <summary>
+        /// Sachet
+        /// </summary>
+        XSH,
+
+        /// <summary>
+        /// Vat
+        /// </summary>
+        XVA,
+
+        /// <summary>
+        /// Vial
+        /// </summary>
+        XVI,
+
+        /// <summary>
         /// ton-force (US short)
         /// </summary>
         L94


### PR DESCRIPTION
## Summary
- Added 16 missing `QuantityCodes` enum values identified by comparing the existing 
  enum against UN/ECE Recommendation No. 20 (units of measure) and No. 21 (packaging codes)

**Rec 20 additions (5):**
| Code | Description |
|------|-------------|
| `INH` | inch |
| `INK` | square inch |
| `INQ` | cubic inch |
| `BAR` | bar (unit of pressure) |
| `GWH` | gigawatt hour |

**Rec 21 additions (11):**
| Code | Original Rec 21 code | Description |
|------|----------------------|-------------|
| `XCN` | CN | Container, not otherwise specified |
| `XCY` | CY | Cylinder |
| `XCL` | CL | Coil |
| `XEN` | EN | Envelope |
| `XJR` | JR | Jar |
| `XKG` | KG | Keg |
| `XPL` | PL | Pail |
| `XRL` | RL | Reel |
| `XSH` | SH | Sachet |
| `XVA` | VA | Vat |
| `XVI` | VI | Vial |

## Checklist
- [x] Code follows repo **Coding Instructions**
- [x] Public APIs documented (XML)
- [ ] Unit tests added/updated
- [x] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [x] `CancellationToken` respected
- [x] Analyzers clean (`dotnet build` no warnings as errors)

## Breaking changes?
- [x] No