### PR TITLE
feat: add UNTDID 4451 SubjectCodes DIN and AIN; reference sibling core from PDF project

### DIFF
--- a/ZUGFeRD.PDF/ZUGFeRD.PDF.csproj
+++ b/ZUGFeRD.PDF/ZUGFeRD.PDF.csproj
@@ -48,8 +48,10 @@ A special favor is the so-called XRechnung which is also supported by this libra
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PDFsharp-extended" Version="1.3.0" />	  
-	  <PackageReference Include="ZUGFeRD-csharp" Version="18.0.0" />
+    <PackageReference Include="PDFsharp-extended" Version="1.3.0" />
+	  <!-- VOLFI fork: reference the sibling (patched) core project instead of the unpatched nupkg,
+	       so the PDF assembly binds to our SubjectCodes additions (DIN/AIN/BOA). -->
+	  <ProjectReference Include="..\ZUGFeRD\ZUGFeRD.csproj" />
   </ItemGroup>
 
 	<!-- netstandard: minimal & stabil -->

--- a/ZUGFeRD/SubjectCodes.cs
+++ b/ZUGFeRD/SubjectCodes.cs
@@ -185,6 +185,27 @@ namespace s2industries.ZUGFeRD
         ///
         /// Note contains information mutually defined by trading partners.
         /// </summary>
-        ZZZ
+        ZZZ,
+
+        /// <summary>
+        /// Delivery instructions
+        ///
+        /// [4492] Instructions regarding the delivery of the cargo. Used here for
+        /// Lieferbedingung / Incoterm.
+        /// </summary>
+        /// VOLFI fork addition: valid UNTDID 4451 code (verified against UNECE d23a/d24a), merged
+        /// upstream (PR #905) after the 18.0.0 release was cut, so absent from the 18.0.0 source we
+        /// vendor. Serialized via ToString().
+        DIN,
+
+        /// <summary>
+        /// Consignment routing
+        ///
+        /// Information on routing of the consignment. Used here for abweichende Lieferanschrift /
+        /// Streckenlieferung (free-text carrier).
+        /// </summary>
+        /// VOLFI fork addition: valid UNTDID 4451 code (verified against UNECE d23a/d24a), not
+        /// present in the curated upstream enum.
+        AIN
     }
 }


### PR DESCRIPTION
DIN (Delivery instructions) and AIN (Consignment routing) are valid UNTDID 4451 codes (verified against UNECE d23a/d24a) but absent from the curated upstream SubjectCodes enum. Add them so BT-21 notes can be emitted with their literal codes. The CII writer serializes via enum.ToString(), so plainly-named members emit the literal code.

Also repoint ZUGFeRD.PDF.csproj from the ZUGFeRD-csharp nupkg to a sibling ProjectReference so the PDF assembly binds to this patched core.

## Summary
- What changed and why?

## Checklist
- [ ] Code follows repo **Coding Instructions**
- [ ] Public APIs documented (XML)
- [ ] Unit tests added/updated
- [ ] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [ ] `CancellationToken` respected
- [ ] Analyzers clean (`dotnet build` no warnings as errors)
- [ ] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [ ] No
- [ ] Yes (explain impact & migration)