### PR TITLE
Fix charge tax basis calculation in InvoiceValidator

### DIFF
--- a/ZUGFeRD/InvoiceValidator.cs
+++ b/ZUGFeRD/InvoiceValidator.cs
@@ -106,7 +106,7 @@ namespace s2industries.ZUGFeRD
                 {
                     lineTotalPerTax.Add(charge.Tax.Percent, new decimal());
                 }
-                lineTotalPerTax[charge.Tax.Percent] -= charge.Amount;
+                lineTotalPerTax[charge.Tax.Percent] += charge.Amount;
                 chargeTotal += charge.Amount;
             }
 


### PR DESCRIPTION
Trade charges were incorrectly subtracted from the per-tax-rate basis (lineTotalPerTax), when they should be added. This aligns the per-rate calculation with the overall tax basis formula (lineTotal - allowanceTotal + chargeTotal).