### PR TITLE
Improved Exception Message when used UBL and not XRechnung in v2.3

### DIFF
--- a/ZUGFeRD/InvoiceDescriptor23Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor23Writer.cs
@@ -53,7 +53,10 @@ namespace s2industries.ZUGFeRD
             {
                 writer = new InvoiceDescriptor22UBLWriter();
             }
-
+            if ((format == ZUGFeRDFormats.UBL) && (descriptor.Profile != Profile.XRechnung) && writer == null)
+            {
+                throw new UnsupportedException($"Format {ZUGFeRDFormats.UBL.ToString()} is only allowed with Profile {Profile.XRechnung.ToString()}");
+            }
             if (writer == null)
             {                
                 throw new UnsupportedException($"Profile {descriptor.Profile.ToString()} and format {format.EnumToString()} is not supported.");


### PR DESCRIPTION
`InvoiceDescriptor23Writer` small change to make it obvious what combination to use with UBL as the current exception message gives no clue that UBL needs to be with XRechnung!

## Summary
- What changed and why?

## Checklist
- [ ] Code follows repo **Coding Instructions** - `I couldnt find them please poitn them out`
- [x] Public APIs documented (XML)
- [ ] Unit tests added/updated - `could not run Excel.Test as there is a issue with `GetTradeAllowanceCharges``
- [x] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [x] `CancellationToken` respected 
- [x] Analyzers clean (`dotnet build` no warnings as errors) - `my code didnt broad up any`
- [x] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [x] No
- [ ] Yes (explain impact & migration)