### PR TITLE
support reading discounts from xrechnung3 with diffrent values then 100%

### DIFF
--- a/ZUGFeRD.Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD.Test/XRechnungUBLTests.cs
@@ -331,6 +331,148 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
+        public void TestAllowanceChargePercentageOnDocumentLevel()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+
+            // Test Values
+            decimal? basisAmount = 123.45m;
+            CurrencyCodes currency = CurrencyCodes.EUR;
+            decimal actualAmount = 12.34m;
+            decimal chargePercentage = 10.0m;
+            string reason = "Besondere Vereinbarung";
+            AllowanceReasonCodes reasonCode = AllowanceReasonCodes.SpecialAgreement;
+            TaxTypes taxTypeCode = TaxTypes.VAT;
+            TaxCategoryCodes taxCategoryCode = TaxCategoryCodes.AA;
+            decimal taxPercent = 19.0m;
+
+            desc.AddTradeAllowance(basisAmount, currency, actualAmount, chargePercentage, reason, taxTypeCode, taxCategoryCode, taxPercent, reasonCode);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, _Version, Profile.XRechnung, ZUGFeRDFormats.UBL);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            TradeAllowance loadedAllowance = loadedInvoice.GetTradeAllowances().FirstOrDefault();
+
+            Assert.IsNotNull(loadedAllowance);
+            Assert.AreEqual(loadedAllowance.BasisAmount, basisAmount, message: "basisAmount");
+            Assert.AreEqual(loadedAllowance.Amount, actualAmount, message: "actualAmount");
+            Assert.AreEqual(loadedAllowance.ChargePercentage, chargePercentage, message: "chargePercentage"); // BT-94
+            Assert.AreEqual(loadedAllowance.Reason, reason, message: "reason");
+        } // !TestAllowanceChargePercentageOnDocumentLevel
+
+
+        /// <summary>
+        /// BG-27, the allowance of the invoice line, which is not the discount of the item price (BT-147)
+        /// </summary>
+        [TestMethod]
+        public void TestSpecifiedTradeAllowanceOnLineLevel()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            desc.TradeLineItems.Clear();
+
+            // Test Values
+            CurrencyCodes currency = CurrencyCodes.EUR;
+            decimal netUnitPrice = 1950.0m;
+            decimal? basisAmount = 1950.0m;
+            decimal actualAmount = 780.0m;
+            decimal chargePercentage = 40.0m;
+            string reason = "Nachlass";
+            AllowanceReasonCodes reasonCode = AllowanceReasonCodes.Discount;
+
+            TradeLineItem item = desc.AddTradeLineItem(
+                lineID: "1",
+                name: "Ultraschallprüfung",
+                billedQuantity: 1m,
+                unitCode: QuantityCodes.C62,
+                netUnitPrice: netUnitPrice,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 19.0m,
+                taxType: TaxTypes.VAT);
+
+            item.AddSpecifiedTradeAllowance(currency, basisAmount, actualAmount, chargePercentage, reason, reasonCode);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, _Version, Profile.XRechnung, ZUGFeRDFormats.UBL);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            TradeLineItem loadedItem = loadedInvoice.GetTradeLineItems().First();
+            TradeAllowance loadedAllowance = loadedItem.GetSpecifiedTradeAllowances().FirstOrDefault();
+
+            Assert.IsNotNull(loadedAllowance);
+            Assert.AreEqual(loadedAllowance.ChargeIndicator, false, message: "isDiscount");
+            Assert.AreEqual(loadedAllowance.BasisAmount, basisAmount, message: "basisAmount"); // BT-137
+            Assert.AreEqual(loadedAllowance.ActualAmount, actualAmount, message: "actualAmount"); // BT-136
+            Assert.AreEqual(loadedAllowance.ChargePercentage, chargePercentage, message: "chargePercentage"); // BT-138
+            Assert.AreEqual(loadedAllowance.Reason, reason, message: "reason");
+            Assert.AreEqual(loadedAllowance.ReasonCode, reasonCode, message: "reasonCode");
+
+            // an allowance of the invoice line says nothing about the price of the item
+            Assert.HasCount(0, loadedItem.GetTradeAllowanceCharges());
+            Assert.AreEqual(loadedItem.NetUnitPrice, netUnitPrice, message: "netUnitPrice");
+            Assert.IsNull(loadedItem.GrossUnitPrice, message: "grossUnitPrice");
+        } // !TestSpecifiedTradeAllowanceOnLineLevel
+
+
+        /// <summary>
+        /// BT-147 and BT-148, the discount of the item price, which is written inside cac:Price
+        /// </summary>
+        [TestMethod]
+        public void TestPriceDiscountOnLineLevel()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            desc.TradeLineItems.Clear();
+
+            // Test Values
+            CurrencyCodes currency = CurrencyCodes.EUR;
+            decimal netUnitPrice = 9.9m;
+            decimal grossUnitPrice = 11.0m;
+            decimal actualAmount = 1.1m;
+            string reason = "Rabatt";
+
+            TradeLineItem item = desc.AddTradeLineItem(
+                lineID: "1",
+                name: "Trennblätter A4",
+                billedQuantity: 20m,
+                unitCode: QuantityCodes.H87,
+                netUnitPrice: netUnitPrice,
+                grossUnitPrice: grossUnitPrice,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 19.0m,
+                taxType: TaxTypes.VAT);
+
+            item.AddTradeAllowance(currency, grossUnitPrice, actualAmount, reason, AllowanceReasonCodes.Discount);
+
+            MemoryStream ms = new MemoryStream();
+
+            desc.Save(ms, _Version, Profile.XRechnung, ZUGFeRDFormats.UBL);
+            ms.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(ms);
+
+            TradeLineItem loadedItem = loadedInvoice.GetTradeLineItems().First();
+
+            Assert.AreEqual(loadedItem.NetUnitPrice, netUnitPrice, message: "netUnitPrice"); // BT-146
+            Assert.AreEqual(loadedItem.GrossUnitPrice, grossUnitPrice, message: "grossUnitPrice"); // BT-148
+
+            TradeAllowance loadedAllowance = loadedItem.GetTradeAllowances().FirstOrDefault();
+
+            Assert.IsNotNull(loadedAllowance);
+            Assert.AreEqual(loadedAllowance.ActualAmount, actualAmount, message: "actualAmount"); // BT-147
+            Assert.AreEqual(loadedAllowance.BasisAmount, grossUnitPrice, message: "basisAmount");
+
+            // the discount of the price is not an allowance of the invoice line
+            Assert.HasCount(0, loadedItem.GetSpecifiedTradeAllowances());
+        } // !TestPriceDiscountOnLineLevel
+
+
+        [TestMethod]
         public void TestInvoiceWithAttachment()
         {
             InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();

--- a/ZUGFeRD.Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD.Test/XRechnungUBLTests.cs
@@ -358,10 +358,10 @@ namespace s2industries.ZUGFeRD.Test
             TradeAllowance loadedAllowance = loadedInvoice.GetTradeAllowances().FirstOrDefault();
 
             Assert.IsNotNull(loadedAllowance);
-            Assert.AreEqual(loadedAllowance.BasisAmount, basisAmount, message: "basisAmount");
-            Assert.AreEqual(loadedAllowance.Amount, actualAmount, message: "actualAmount");
-            Assert.AreEqual(loadedAllowance.ChargePercentage, chargePercentage, message: "chargePercentage"); // BT-94
-            Assert.AreEqual(loadedAllowance.Reason, reason, message: "reason");
+            Assert.AreEqual(basisAmount, loadedAllowance.BasisAmount, message: "basisAmount");
+            Assert.AreEqual(actualAmount, loadedAllowance.Amount, message: "actualAmount");
+            Assert.AreEqual(chargePercentage, loadedAllowance.ChargePercentage, message: "chargePercentage"); // BT-94
+            Assert.AreEqual(reason, loadedAllowance.Reason, message: "reason");
         } // !TestAllowanceChargePercentageOnDocumentLevel
 
 
@@ -406,16 +406,16 @@ namespace s2industries.ZUGFeRD.Test
             TradeAllowance loadedAllowance = loadedItem.GetSpecifiedTradeAllowances().FirstOrDefault();
 
             Assert.IsNotNull(loadedAllowance);
-            Assert.AreEqual(loadedAllowance.ChargeIndicator, false, message: "isDiscount");
-            Assert.AreEqual(loadedAllowance.BasisAmount, basisAmount, message: "basisAmount"); // BT-137
-            Assert.AreEqual(loadedAllowance.ActualAmount, actualAmount, message: "actualAmount"); // BT-136
-            Assert.AreEqual(loadedAllowance.ChargePercentage, chargePercentage, message: "chargePercentage"); // BT-138
-            Assert.AreEqual(loadedAllowance.Reason, reason, message: "reason");
-            Assert.AreEqual(loadedAllowance.ReasonCode, reasonCode, message: "reasonCode");
+            Assert.AreEqual(false, loadedAllowance.ChargeIndicator, message: "isDiscount");
+            Assert.AreEqual(basisAmount, loadedAllowance.BasisAmount, message: "basisAmount"); // BT-137
+            Assert.AreEqual(actualAmount, loadedAllowance.ActualAmount, message: "actualAmount"); // BT-136
+            Assert.AreEqual(chargePercentage, loadedAllowance.ChargePercentage, message: "chargePercentage"); // BT-138
+            Assert.AreEqual(reason, loadedAllowance.Reason, message: "reason");
+            Assert.AreEqual(reasonCode, loadedAllowance.ReasonCode, message: "reasonCode");
 
             // an allowance of the invoice line says nothing about the price of the item
             Assert.HasCount(0, loadedItem.GetTradeAllowanceCharges());
-            Assert.AreEqual(loadedItem.NetUnitPrice, netUnitPrice, message: "netUnitPrice");
+            Assert.AreEqual(netUnitPrice, loadedItem.NetUnitPrice, message: "netUnitPrice");
             Assert.IsNull(loadedItem.GrossUnitPrice, message: "grossUnitPrice");
         } // !TestSpecifiedTradeAllowanceOnLineLevel
 
@@ -458,14 +458,14 @@ namespace s2industries.ZUGFeRD.Test
 
             TradeLineItem loadedItem = loadedInvoice.GetTradeLineItems().First();
 
-            Assert.AreEqual(loadedItem.NetUnitPrice, netUnitPrice, message: "netUnitPrice"); // BT-146
-            Assert.AreEqual(loadedItem.GrossUnitPrice, grossUnitPrice, message: "grossUnitPrice"); // BT-148
+            Assert.AreEqual(netUnitPrice, loadedItem.NetUnitPrice, message: "netUnitPrice"); // BT-146
+            Assert.AreEqual(grossUnitPrice, loadedItem.GrossUnitPrice, message: "grossUnitPrice"); // BT-148
 
             TradeAllowance loadedAllowance = loadedItem.GetTradeAllowances().FirstOrDefault();
 
             Assert.IsNotNull(loadedAllowance);
-            Assert.AreEqual(loadedAllowance.ActualAmount, actualAmount, message: "actualAmount"); // BT-147
-            Assert.AreEqual(loadedAllowance.BasisAmount, grossUnitPrice, message: "basisAmount");
+            Assert.AreEqual(actualAmount, loadedAllowance.ActualAmount, message: "actualAmount"); // BT-147
+            Assert.AreEqual(grossUnitPrice, loadedAllowance.BasisAmount, message: "basisAmount");
 
             // the discount of the price is not an allowance of the invoice line
             Assert.HasCount(0, loadedItem.GetSpecifiedTradeAllowances());

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -348,6 +348,7 @@ namespace s2industries.ZUGFeRD
                     retval._AddTradeCharge(XmlUtils.NodeAsDecimal(node, ".//cbc:BaseAmount", nsmgr, 0).Value,
                                            retval.Currency,
                                            XmlUtils.NodeAsDecimal(node, ".//cbc:Amount", nsmgr, 0).Value,
+                                           XmlUtils.NodeAsDecimal(node, ".//cbc:MultiplierFactorNumeric", nsmgr), // BT-101
                                            XmlUtils.NodeAsString(node, ".//cbc:AllowanceChargeReason", nsmgr),
                                            EnumExtensions.StringToNullableEnum<TaxTypes>(XmlUtils.NodeAsString(node, ".//cac:TaxCategory/cac:TaxScheme/cbc:ID", nsmgr)),
                                            EnumExtensions.StringToNullableEnum<TaxCategoryCodes>(XmlUtils.NodeAsString(node, ".//cac:TaxCategory/cbc:ID", nsmgr)),
@@ -359,6 +360,7 @@ namespace s2industries.ZUGFeRD
                     retval._AddTradeAllowance(XmlUtils.NodeAsDecimal(node, ".//cbc:BaseAmount", nsmgr, 0).Value,
                                               retval.Currency,
                                               XmlUtils.NodeAsDecimal(node, ".//cbc:Amount", nsmgr, 0).Value,
+                                              XmlUtils.NodeAsDecimal(node, ".//cbc:MultiplierFactorNumeric", nsmgr), // BT-94
                                               XmlUtils.NodeAsString(node, ".//cbc:AllowanceChargeReason", nsmgr),
                                               EnumExtensions.StringToNullableEnum<TaxTypes>(XmlUtils.NodeAsString(node, ".//cac:TaxCategory/cac:TaxScheme/cbc:ID", nsmgr)),
                                               EnumExtensions.StringToNullableEnum<TaxCategoryCodes>(XmlUtils.NodeAsString(node, ".//cac:TaxCategory/cbc:ID", nsmgr)),
@@ -525,6 +527,16 @@ namespace s2industries.ZUGFeRD
                 ? EnumExtensions.StringToNullableEnum<QuantityCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//cbc:InvoicedQuantity/@unitCode", nsmgr))
                 : EnumExtensions.StringToNullableEnum<QuantityCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//cbc:CreditedQuantity/@unitCode", nsmgr));
 
+            decimal netUnitPrice = XmlUtils.NodeAsDecimal(tradeLineItem, ".//cac:Price/cbc:PriceAmount", nsmgr, 0).Value; // BT-146
+            XmlNode priceAllowanceChargeNode = tradeLineItem.SelectSingleNode("./cac:Price/cac:AllowanceCharge", nsmgr);
+            decimal? priceBasisAmount = XmlUtils.NodeAsDecimal(priceAllowanceChargeNode, "./cbc:BaseAmount", nsmgr); // BT-148
+            decimal? grossUnitPrice = priceBasisAmount;
+            if ((grossUnitPrice == null) && (priceAllowanceChargeNode != null))
+            {
+                // BT-148 is optional, but the gross price is the net price plus the price discount (BT-147)
+                grossUnitPrice = netUnitPrice + XmlUtils.NodeAsDecimal(priceAllowanceChargeNode, "./cbc:Amount", nsmgr, 0).Value;
+            }
+
             TradeLineItem item = new TradeLineItem(lineId)
             {
                 GlobalID = new GlobalID(EnumExtensions.StringToNullableEnum<GlobalIDSchemeIdentifiers>(XmlUtils.NodeAsString(tradeLineItem, "./cac:Item/cac:StandardItemIdentification/cbc:ID/@schemeID", nsmgr)),
@@ -539,8 +551,8 @@ namespace s2industries.ZUGFeRD
                 TaxCategoryCode = EnumExtensions.StringToEnum<TaxCategoryCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//cac:Item/cac:ClassifiedTaxCategory/cbc:ID", nsmgr)),
                 TaxType = EnumExtensions.StringToEnum<TaxTypes>(XmlUtils.NodeAsString(tradeLineItem, ".//cac:Item/cac:ClassifiedTaxCategory/cac:TaxScheme/cbc:ID", nsmgr)),
                 TaxPercent = XmlUtils.NodeAsDecimal(tradeLineItem, ".//cac:Item/cac:ClassifiedTaxCategory/cbc:Percent", nsmgr, 0).Value,
-                NetUnitPrice = XmlUtils.NodeAsDecimal(tradeLineItem, ".//cac:Price/cbc:PriceAmount", nsmgr, 0).Value,
-                GrossUnitPrice = 0, // TODO: Find value //GrossUnitPrice = XmlUtils.NodeAsDecimal(tradeLineItem, ".//ram:GrossPriceProductTradePrice/ram:ChargeAmount", nsmgr, 0).Value,
+                NetUnitPrice = netUnitPrice,
+                GrossUnitPrice = grossUnitPrice,
                 UnitCode = unitCode,
                 BillingPeriodStart = XmlUtils.NodeAsDateTime(tradeLineItem, ".//cac:InvoicePeriod/cbc:StartDate", nsmgr),
                 BillingPeriodEnd = XmlUtils.NodeAsDateTime(tradeLineItem, ".//cac:InvoicePeriod/cbc:EndDate", nsmgr),
@@ -664,29 +676,60 @@ namespace s2industries.ZUGFeRD
                 ));
             }
 
-            XmlNodeList appliedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes(".//cac:AllowanceCharge", nsmgr);
-            foreach (XmlNode appliedTradeAllowanceChargeNode in appliedTradeAllowanceChargeNodes)
+            // BG-27 / BG-28, allowances and charges of the invoice line itself.
+            // Only direct children, the allowance of the price (BT-147) is a different concept.
+            XmlNodeList specifiedTradeAllowanceChargeNodes = tradeLineItem.SelectNodes("./cac:AllowanceCharge", nsmgr);
+            foreach (XmlNode specifiedTradeAllowanceChargeNode in specifiedTradeAllowanceChargeNodes)
             {
-                bool chargeIndicator = XmlUtils.NodeAsBool(appliedTradeAllowanceChargeNode, "./cbc:ChargeIndicator", nsmgr);
-                decimal basisAmount = XmlUtils.NodeAsDecimal(appliedTradeAllowanceChargeNode, "./cbc:BaseAmount", nsmgr, 0).Value;
-                string basisAmountCurrency = XmlUtils.NodeAsString(appliedTradeAllowanceChargeNode, "./cbc:BaseAmount/@currencyID", nsmgr);
-                decimal actualAmount = XmlUtils.NodeAsDecimal(appliedTradeAllowanceChargeNode, "./cbc:Amount", nsmgr, 0).Value;
-                string actualAmountCurrency = XmlUtils.NodeAsString(appliedTradeAllowanceChargeNode, "./cbc:Amount/@currencyID", nsmgr);
-                string reason = XmlUtils.NodeAsString(appliedTradeAllowanceChargeNode, "./cbc:AllowanceChargeReason", nsmgr);
-                string reasonCode = XmlUtils.NodeAsString(appliedTradeAllowanceChargeNode, "./cbc:AllowanceChargeReasonCode", nsmgr);
+                bool chargeIndicator = XmlUtils.NodeAsBool(specifiedTradeAllowanceChargeNode, "./cbc:ChargeIndicator", nsmgr);
+                decimal basisAmount = XmlUtils.NodeAsDecimal(specifiedTradeAllowanceChargeNode, "./cbc:BaseAmount", nsmgr, 0).Value; // BT-137 / BT-142
+                string basisAmountCurrency = XmlUtils.NodeAsString(specifiedTradeAllowanceChargeNode, "./cbc:BaseAmount/@currencyID", nsmgr);
+                decimal actualAmount = XmlUtils.NodeAsDecimal(specifiedTradeAllowanceChargeNode, "./cbc:Amount", nsmgr, 0).Value; // BT-136 / BT-141
+                decimal? chargePercentage = XmlUtils.NodeAsDecimal(specifiedTradeAllowanceChargeNode, "./cbc:MultiplierFactorNumeric", nsmgr); // BT-138 / BT-143
+                string reason = XmlUtils.NodeAsString(specifiedTradeAllowanceChargeNode, "./cbc:AllowanceChargeReason", nsmgr);
+                string reasonCode = XmlUtils.NodeAsString(specifiedTradeAllowanceChargeNode, "./cbc:AllowanceChargeReasonCode", nsmgr);
 
                 if (chargeIndicator) // charge
                 {
-                    item.AddTradeCharge(EnumExtensions.StringToEnum<CurrencyCodes>(basisAmountCurrency),
-                                        basisAmount,
+                    item.AddSpecifiedTradeCharge(EnumExtensions.StringToEnum<CurrencyCodes>(basisAmountCurrency),
+                                                 basisAmount,
+                                                 actualAmount,
+                                                 chargePercentage,
+                                                 reason,
+                                                 EnumExtensions.StringToEnum<ChargeReasonCodes>(reasonCode));
+                }
+                else // allowance
+                {
+                    item.AddSpecifiedTradeAllowance(EnumExtensions.StringToEnum<CurrencyCodes>(basisAmountCurrency),
+                                                    basisAmount,
+                                                    actualAmount,
+                                                    chargePercentage,
+                                                    reason,
+                                                    EnumExtensions.StringToEnum<AllowanceReasonCodes>(reasonCode));
+                }
+            }
+
+            // BT-147 / BT-148, the discount of the item price. UBL allows one of them per line.
+            if (priceAllowanceChargeNode != null)
+            {
+                bool chargeIndicator = XmlUtils.NodeAsBool(priceAllowanceChargeNode, "./cbc:ChargeIndicator", nsmgr);
+                decimal actualAmount = XmlUtils.NodeAsDecimal(priceAllowanceChargeNode, "./cbc:Amount", nsmgr, 0).Value; // BT-147
+                string actualAmountCurrency = XmlUtils.NodeAsString(priceAllowanceChargeNode, "./cbc:Amount/@currencyID", nsmgr);
+                string reason = XmlUtils.NodeAsString(priceAllowanceChargeNode, "./cbc:AllowanceChargeReason", nsmgr);
+                string reasonCode = XmlUtils.NodeAsString(priceAllowanceChargeNode, "./cbc:AllowanceChargeReasonCode", nsmgr);
+
+                if (chargeIndicator) // charge
+                {
+                    item.AddTradeCharge(EnumExtensions.StringToEnum<CurrencyCodes>(actualAmountCurrency),
+                                        priceBasisAmount,
                                         actualAmount,
                                         reason,
                                         EnumExtensions.StringToEnum<ChargeReasonCodes>(reasonCode));
                 }
                 else // allowance
                 {
-                    item.AddTradeAllowance(EnumExtensions.StringToEnum<CurrencyCodes>(basisAmountCurrency),
-                                           basisAmount,
+                    item.AddTradeAllowance(EnumExtensions.StringToEnum<CurrencyCodes>(actualAmountCurrency),
+                                           priceBasisAmount,
                                            actualAmount,
                                            reason,
                                            EnumExtensions.StringToEnum<AllowanceReasonCodes>(reasonCode));


### PR DESCRIPTION
## Summary

The UBL reader (`InvoiceDescriptor22UblReader`) dropped or mis-mapped three things:

  1. **Allowance/charge percentage was never read** (BT-94, BT-101, BT-138, BT-143) —
     `cbc:MultiplierFactorNumeric` wasn't queried at all, so percentage-based discounts came
     back without their percentage.
  2. **Line allowances and the price discount were conflated.** The descendant query
     `.//cac:AllowanceCharge` also matched `cac:Price/cac:AllowanceCharge` and dumped both
     into `AddTradeAllowance`/`AddTradeCharge`. Now split: BG-27/BG-28 →
     `AddSpecifiedTradeAllowance`/`Charge`, BT-147/BT-148 → `AddTradeAllowance`/`Charge`,
     with `./cac:AllowanceCharge` for direct children only.
  3. **`GrossUnitPrice` was hardcoded to `0`** (next to a `// TODO: Find value`). Now read
     from `cbc:BaseAmount` (BT-148), or derived as BT-146 + BT-147 when that optional
     element is absent.

  This matches `InvoiceDescriptor23CIIReader`, which has always mapped these onto the same
  two collections — UBL was the outlier. Side effect: UBL → CII conversion used to write
  `ram:ChargeAmount` of `0` as the gross price; it now writes the real one.

  Reader-side only. No public API added or changed.

  ## Checklist
  - [x] Code follows repo **Coding Instructions**
  - [x] Public APIs documented (XML) — n/a, no API change
  - [x] Unit tests added/updated — 3 round-trip tests (save as UBL, reload, assert the other
        collection stays empty)
  - [x] No blocking async — n/a, no async here
  - [x] `CancellationToken` respected — n/a
  - [x] Analyzers clean — builds clean, no new warnings

  ## Breaking changes?
  - [x] Yes

  Source- and binary-compatible, but the reader returns different values:

  - `GrossUnitPrice` was always `0`; now the real price, or `null` without a price discount.
  - Line allowances move from `TradeAllowanceCharges` to `SpecifiedTradeAllowanceCharges`;
    the former now holds only the price discount.
  - The price discount's `BasisAmount` may be `null` (was `0`), and its `Currency` comes from
    `cbc:Amount/@currencyID` instead of `cbc:BaseAmount/@currencyID`.
  - `ChargePercentage` is now populated where it was always `null`.

  Migration: read line allowances from `SpecifiedTradeAllowanceCharges`, treat
  `GrossUnitPrice` as nullable.