### PR TITLE
Read CII line status fields independently

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -43,6 +43,60 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
+        [DataRow(ZUGFeRDVersion.Version20)]
+        [DataRow(ZUGFeRDVersion.Version23)]
+        public void TestLineStatusReasonCodeWithoutStatusCode(ZUGFeRDVersion version)
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            desc.TradeLineItems[0].SetLineStatus(LineStatusCodes.New, LineStatusReasonCodes.GROUP);
+
+            using MemoryStream invoiceStream = new();
+            desc.Save(invoiceStream, version, Profile.Extended);
+            string invoiceXml = Encoding.UTF8.GetString(invoiceStream.ToArray());
+
+            XmlDocument reasonOnlyDocument = new();
+            reasonOnlyDocument.LoadXml(invoiceXml);
+            XmlNamespaceManager reasonOnlyNamespaceManager = new(reasonOnlyDocument.NameTable);
+            reasonOnlyNamespaceManager.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
+            XmlNode? lineStatusCodeNode = reasonOnlyDocument.SelectSingleNode("//ram:AssociatedDocumentLineDocument/ram:LineStatusCode", reasonOnlyNamespaceManager);
+            Assert.IsNotNull(lineStatusCodeNode);
+            lineStatusCodeNode.ParentNode!.RemoveChild(lineStatusCodeNode);
+
+            using MemoryStream reasonOnlyStream = new(Encoding.UTF8.GetBytes(reasonOnlyDocument.OuterXml));
+            InvoiceDescriptor reasonOnlyInvoice = InvoiceDescriptor.Load(reasonOnlyStream);
+            Assert.IsNull(reasonOnlyInvoice.TradeLineItems[0].AssociatedDocument.LineStatusCode);
+            Assert.AreEqual(LineStatusReasonCodes.GROUP, reasonOnlyInvoice.TradeLineItems[0].AssociatedDocument.LineStatusReasonCode);
+        } // !TestLineStatusReasonCodeWithoutStatusCode()
+
+
+        [TestMethod]
+        [DataRow(ZUGFeRDVersion.Version20)]
+        [DataRow(ZUGFeRDVersion.Version23)]
+        public void TestLineStatusCodeWithoutReasonCode(ZUGFeRDVersion version)
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            desc.TradeLineItems[0].SetLineStatus(LineStatusCodes.New, LineStatusReasonCodes.GROUP);
+
+            using MemoryStream invoiceStream = new();
+            desc.Save(invoiceStream, version, Profile.Extended);
+            string invoiceXml = Encoding.UTF8.GetString(invoiceStream.ToArray());
+
+            XmlDocument statusOnlyDocument = new();
+            statusOnlyDocument.LoadXml(invoiceXml);
+            XmlNamespaceManager statusOnlyNamespaceManager = new(statusOnlyDocument.NameTable);
+            statusOnlyNamespaceManager.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
+            XmlNode? lineStatusReasonCodeNode = statusOnlyDocument.SelectSingleNode("//ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode", statusOnlyNamespaceManager);
+            Assert.IsNotNull(lineStatusReasonCodeNode);
+            lineStatusReasonCodeNode.ParentNode!.RemoveChild(lineStatusReasonCodeNode);
+
+            using MemoryStream statusOnlyStream = new(Encoding.UTF8.GetBytes(statusOnlyDocument.OuterXml));
+            InvoiceDescriptor statusOnlyInvoice = InvoiceDescriptor.Load(statusOnlyStream);
+            Assert.AreEqual(LineStatusCodes.New, statusOnlyInvoice.TradeLineItems[0].AssociatedDocument.LineStatusCode);
+            Assert.IsNull(statusOnlyInvoice.TradeLineItems[0].AssociatedDocument.LineStatusReasonCode);
+        } // !TestLineStatusCodeWithoutReasonCode()
+
+
+        [TestMethod]
         [DataRow(ZUGFeRDVersion.Version1, Profile.Extended)]
         [DataRow(ZUGFeRDVersion.Version20, Profile.Extended)]
         [DataRow(ZUGFeRDVersion.Version23, Profile.Extended)]

--- a/ZUGFeRD/AssociatedDocument.cs
+++ b/ZUGFeRD/AssociatedDocument.cs
@@ -77,5 +77,16 @@ namespace s2industries.ZUGFeRD
         /// BT-X-8
         /// </summary>
         public LineStatusReasonCodes? LineStatusReasonCode { get; internal set; } = null;
+
+
+        /// <summary>
+        /// Sets independently read optional line status values during import.
+        /// Both CII fields are optional and must be preserved independently.
+        /// </summary>
+        internal void SetLineStatus(LineStatusCodes? lineStatusCode, LineStatusReasonCodes? lineStatusReasonCode)
+        {
+            this.LineStatusCode = lineStatusCode;
+            this.LineStatusReasonCode = lineStatusReasonCode;
+        }
     }
 }

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -498,9 +498,7 @@ namespace s2industries.ZUGFeRD
                 BillingPeriodEnd = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString", nsmgr),
             };
 
-            // Both CII fields are optional; preserve each value independently during import.
-            item.AssociatedDocument.LineStatusCode = lineStatusCode;
-            item.AssociatedDocument.LineStatusReasonCode = lineStatusReasonCode;
+            item.AssociatedDocument.SetLineStatus(lineStatusCode, lineStatusReasonCode);
 
             if (tradeLineItem.SelectNodes(".//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic", nsmgr) != null)
             {

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -470,7 +470,7 @@ namespace s2industries.ZUGFeRD
 
             string lineId = XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr, String.Empty);
 
-            LineStatusCodes? lineStatusCode = EnumExtensions.StringToEnum<LineStatusCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineStatusCode", nsmgr, null));
+            LineStatusCodes? lineStatusCode = EnumExtensions.StringToNullableEnum<LineStatusCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineStatusCode", nsmgr, null));
             LineStatusReasonCodes? lineStatusReasonCode = EnumExtensions.StringToNullableEnum<LineStatusReasonCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode", nsmgr, null));
 
             TradeLineItem item = new TradeLineItem(lineId)
@@ -498,10 +498,9 @@ namespace s2industries.ZUGFeRD
                 BillingPeriodEnd = XmlUtils.NodeAsDateTime(tradeLineItem, ".//ram:BillingSpecifiedPeriod/ram:EndDateTime/udt:DateTimeString", nsmgr),
             };
 
-            if (lineStatusCode.HasValue && lineStatusReasonCode.HasValue)
-            {
-                item.SetLineStatus(lineStatusCode.Value, lineStatusReasonCode.Value);
-            }
+            // Both CII fields are optional; preserve each value independently during import.
+            item.AssociatedDocument.LineStatusCode = lineStatusCode;
+            item.AssociatedDocument.LineStatusReasonCode = lineStatusReasonCode;
 
             if (tradeLineItem.SelectNodes(".//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic", nsmgr) != null)
             {

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -557,7 +557,7 @@ namespace s2industries.ZUGFeRD
 
             string lineId = XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineID", nsmgr, String.Empty);
             string parentLineId = XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:ParentLineID", nsmgr, null);
-            LineStatusCodes? lineStatusCode = EnumExtensions.StringToEnum<LineStatusCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineStatusCode", nsmgr, null));
+            LineStatusCodes? lineStatusCode = EnumExtensions.StringToNullableEnum<LineStatusCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineStatusCode", nsmgr, null));
             LineStatusReasonCodes? lineStatusReasonCode = EnumExtensions.StringToNullableEnum<LineStatusReasonCodes>(XmlUtils.NodeAsString(tradeLineItem, ".//ram:AssociatedDocumentLineDocument/ram:LineStatusReasonCode", nsmgr, null));
 
             TradeLineItem item = new TradeLineItem(lineId)
@@ -601,10 +601,9 @@ namespace s2industries.ZUGFeRD
                 item.SetParentLineId(parentLineId);
             }
 
-            if (lineStatusCode.HasValue && lineStatusReasonCode.HasValue)
-            {
-                item.SetLineStatus(lineStatusCode.Value, lineStatusReasonCode.Value);
-            }
+            // Both CII fields are optional; preserve each value independently during import.
+            item.AssociatedDocument.LineStatusCode = lineStatusCode;
+            item.AssociatedDocument.LineStatusReasonCode = lineStatusReasonCode;
 
             if (tradeLineItem.SelectNodes(".//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic", nsmgr) != null)
             {

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -601,9 +601,7 @@ namespace s2industries.ZUGFeRD
                 item.SetParentLineId(parentLineId);
             }
 
-            // Both CII fields are optional; preserve each value independently during import.
-            item.AssociatedDocument.LineStatusCode = lineStatusCode;
-            item.AssociatedDocument.LineStatusReasonCode = lineStatusReasonCode;
+            item.AssociatedDocument.SetLineStatus(lineStatusCode, lineStatusReasonCode);
 
             if (tradeLineItem.SelectNodes(".//ram:SpecifiedTradeProduct/ram:ApplicableProductCharacteristic", nsmgr) != null)
             {

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -619,8 +619,7 @@ namespace s2industries.ZUGFeRD
         /// <param name="lineStatusReasonCode">The reason code explaining the status</param>
         public TradeLineItem SetLineStatus(LineStatusCodes lineStatusCode, LineStatusReasonCodes lineStatusReasonCode)
         {
-            this.AssociatedDocument.LineStatusCode = lineStatusCode;
-            this.AssociatedDocument.LineStatusReasonCode = lineStatusReasonCode;
+            this.AssociatedDocument.SetLineStatus(lineStatusCode, lineStatusReasonCode);
             return this;
         }
 


### PR DESCRIPTION
## Summary
- Preserve `LineStatusCode` and `LineStatusReasonCode` independently when reading CII invoices in ZUGFeRD 2.0 and 2.3.
- Keep an omitted status code as `null` instead of mapping it to `Unknown`.
- Add cross-version tests for reason-only and status-only input.

The [CII D16B schema](https://github.com/ConnectingEurope/eInvoicing-EN16931/blob/master/cii/schema/D16B%20SCRDM%20%28Subset%29/uncoupled%20clm/CII/uncefact/data/standard/CrossIndustryInvoice_ReusableAggregateBusinessInformationEntity_100pD16B.xsd) declares both fields optional. The ZUGFeRD Extended rule that a status code requires a reason is a validation constraint and does not require the reader to discard a status-only input or invent a status for a reason-only input.

## Verification
- `dotnet test ZUGFeRD.Test/ZUGFeRD.Test.csproj --filter FullyQualifiedName~LineStatus`: 6 passed, 0 failed

## Checklist
- [x] Code follows repo **Coding Instructions**
- [x] Public APIs documented (XML) (no public API changes)
- [x] Unit tests added/updated
- [x] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [x] `CancellationToken` respected (no asynchronous code changes)
- [ ] Analyzers clean (`dotnet build` no warnings as errors)
- [ ] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [x] No
- [ ] Yes (explain impact & migration)
