### PR TITLE
Add total allowance and charge amount for CII line items

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -120,6 +120,69 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
+        public void TestTotalAllowanceChargeAmountWriterProfiles()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            desc.TradeLineItems[0].TotalAllowanceChargeAmount = 12.5m;
+
+            using MemoryStream extendedStream = new();
+            desc.Save(extendedStream, ZUGFeRDVersion.Version23, Profile.Extended);
+            extendedStream.Position = 0;
+
+            XmlDocument extendedDocument = new();
+            extendedDocument.Load(extendedStream);
+            XmlNamespaceManager extendedNamespaceManager = new(extendedDocument.NameTable);
+            extendedNamespaceManager.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
+            XmlNode? extendedAmountNode = extendedDocument.SelectSingleNode("//ram:SpecifiedTradeSettlementLineMonetarySummation/ram:TotalAllowanceChargeAmount", extendedNamespaceManager);
+
+            Assert.IsNotNull(extendedAmountNode);
+            Assert.AreEqual("12.50", extendedAmountNode.InnerText);
+
+            using MemoryStream comfortStream = new();
+            desc.Save(comfortStream, ZUGFeRDVersion.Version23, Profile.Comfort);
+            comfortStream.Position = 0;
+
+            XmlDocument comfortDocument = new();
+            comfortDocument.Load(comfortStream);
+            XmlNamespaceManager comfortNamespaceManager = new(comfortDocument.NameTable);
+            comfortNamespaceManager.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
+            XmlNode? comfortAmountNode = comfortDocument.SelectSingleNode("//ram:SpecifiedTradeSettlementLineMonetarySummation/ram:TotalAllowanceChargeAmount", comfortNamespaceManager);
+
+            Assert.IsNull(comfortAmountNode);
+        } // !TestTotalAllowanceChargeAmountWriterProfiles()
+
+
+        [TestMethod]
+        public void TestTotalAllowanceChargeAmountReader()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+
+            using MemoryStream invoiceStream = new();
+            desc.Save(invoiceStream, ZUGFeRDVersion.Version23, Profile.Extended);
+            invoiceStream.Position = 0;
+
+            XmlDocument invoiceDocument = new();
+            invoiceDocument.Load(invoiceStream);
+            const string ramNamespace = "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100";
+            XmlNamespaceManager namespaceManager = new(invoiceDocument.NameTable);
+            namespaceManager.AddNamespace("ram", ramNamespace);
+            XmlNode? monetarySummationNode = invoiceDocument.SelectSingleNode("//ram:SpecifiedTradeSettlementLineMonetarySummation", namespaceManager);
+            Assert.IsNotNull(monetarySummationNode);
+
+            XmlElement totalAllowanceChargeAmountElement = invoiceDocument.CreateElement("ram", "TotalAllowanceChargeAmount", ramNamespace);
+            totalAllowanceChargeAmountElement.InnerText = "12.50";
+            monetarySummationNode.AppendChild(totalAllowanceChargeAmountElement);
+
+            using MemoryStream modifiedInvoiceStream = new();
+            invoiceDocument.Save(modifiedInvoiceStream);
+            modifiedInvoiceStream.Position = 0;
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(modifiedInvoiceStream);
+            Assert.AreEqual(12.5m, loadedInvoice.TradeLineItems[0].TotalAllowanceChargeAmount);
+        } // !TestTotalAllowanceChargeAmountReader()
+
+
+        [TestMethod]
         public void TestExtendedInvoiceWithIncludedItems()
         {
             string path = @"..\..\..\..\demodata\zugferd21\zugferd_2p1_EXTENDED_Warenrechnung-factur-x.xml";

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -702,7 +702,11 @@ namespace s2industries.ZUGFeRD
                 }
 
                 XmlNode specifiedTradeSettlementLineMonetarySummationNode = tradeLineItem.SelectSingleNode(".//ram:SpecifiedLineTradeSettlement/ram:SpecifiedTradeSettlementLineMonetarySummation", nsmgr);
-                // TODO: process
+                if (specifiedTradeSettlementLineMonetarySummationNode != null)
+                {
+                    // Der Reader erhält vorhandene Daten unabhängig von der späteren Profilvalidierung.
+                    item.TotalAllowanceChargeAmount = XmlUtils.NodeAsDecimal(specifiedTradeSettlementLineMonetarySummationNode, "./ram:TotalAllowanceChargeAmount", nsmgr);
+                }
 
                 foreach (XmlNode invoiceReferencedDocumentNode in tradeLineItem.SelectNodes(".//ram:SpecifiedLineTradeSettlement/ram:InvoiceReferencedDocument", nsmgr))
                 {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -577,8 +577,8 @@ namespace s2industries.ZUGFeRD
                 _Writer.WriteValue(_formatDecimal(total));
                 _Writer.WriteEndElement(); // !ram:LineTotalAmount
 
-                // TODO: TotalAllowanceChargeAmount
-                //Gesamtbetrag der Positionszu- und Abschläge
+                // Gesamtbetrag der Positionszu- und Abschläge; nur Extended, in EN 16931 nicht verwendet.
+                _writeOptionalAmount(_Writer, "ram", "TotalAllowanceChargeAmount", tradeLineItem.TotalAllowanceChargeAmount, 2, false, Profile.Extended);
                 _Writer.WriteEndElement(); // ram:SpecifiedTradeSettlementMonetarySummation
                 #endregion                
 

--- a/ZUGFeRD/TradeLineItem.cs
+++ b/ZUGFeRD/TradeLineItem.cs
@@ -128,6 +128,13 @@ namespace s2industries.ZUGFeRD
         public decimal? LineTotalAmount { get; set; }
 
         /// <summary>
+        /// Gesamtbetrag der Zu- und Abschläge auf Positionsebene
+        ///
+        /// Nur im Profil Extended verfügbar. Profile nach EN 16931 verwenden dieses Feld nicht.
+        /// </summary>
+        public decimal? TotalAllowanceChargeAmount { get; set; }
+
+        /// <summary>
         /// Detailed information about the invoicing period
         ///
         /// Invoicing period start date


### PR DESCRIPTION
## Summary
- Add nullable `TradeLineItem.TotalAllowanceChargeAmount` to preserve the CII line-level allowance and charge total.
- Read `ram:TotalAllowanceChargeAmount` from CII 2.3 line monetary summations whenever it is present.
- Write the element only for the Extended profile because EN 16931 rule CII-SR-203 excludes it.
- Add isolated reader and writer tests, including omission in the Comfort profile.

The field follows the optional `0..1` definition in the [UNECE CII RSM 2.0](https://unece.org/DAM/cefact/rsm/RSM_CrossIndustryInvoice_v2.0.pdf). Its profile restriction follows [EN 16931 CII-SR-203](https://github.com/ConnectingEurope/eInvoicing-EN16931/blob/master/cii/schematron/abstract/EN16931-CII-syntax.sch).

## Verification
- `dotnet test ZUGFeRD.Test/ZUGFeRD.Test.csproj --filter FullyQualifiedName~TotalAllowanceChargeAmount`: 2 passed, 0 failed

## Checklist
- [x] Code follows repo **Coding Instructions**
- [x] Public APIs documented (XML)
- [x] Unit tests added/updated
- [x] No blocking async (`.Result` / `GetAwaiter().GetResult()`)
- [x] `CancellationToken` respected (no asynchronous code changes)
- [ ] Analyzers clean (`dotnet build` no warnings as errors)
- [ ] `dotnet format --verify-no-changes` passes

## Breaking changes?
- [x] No
- [ ] Yes (explain impact & migration)
