### PR TITLE
Add support for SpecifiedAdvancePayment

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -20,6 +20,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
+using System.Xml.Schema;
 
 namespace s2industries.ZUGFeRD.Test
 {
@@ -180,6 +181,159 @@ namespace s2industries.ZUGFeRD.Test
             InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(modifiedInvoiceStream);
             Assert.AreEqual(12.5m, loadedInvoice.TradeLineItems[0].TotalAllowanceChargeAmount);
         } // !TestTotalAllowanceChargeAmountReader()
+
+
+        [TestMethod]
+        public void TestAdvancePayment()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            AdvancePayment advancePayment = desc.AddAdvancePayment(2975m, new DateTime(2025, 6, 7));
+            advancePayment.AddIncludedTradeTax(new Tax
+            {
+                TaxAmount = 1900m,
+                TypeCode = TaxTypes.VAT,
+                CategoryCode = TaxCategoryCodes.S,
+                Percent = 19m
+            });
+            advancePayment.SetInvoiceReferencedDocument("R202506-01", new DateTime(2025, 6, 1), InvoiceType.PartialInvoice);
+
+            using MemoryStream stream = new MemoryStream();
+            desc.Save(stream, ZUGFeRDVersion.Version23, Profile.Extended);
+            stream.Seek(0, SeekOrigin.Begin);
+
+            XmlDocument document = new XmlDocument();
+            document.Load(stream);
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(document.NameTable);
+            namespaceManager.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
+            namespaceManager.AddNamespace("qdt", "urn:un:unece:uncefact:data:standard:QualifiedDataType:100");
+
+            XmlNode? advancePaymentNode = document.SelectSingleNode("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment", namespaceManager);
+            Assert.IsNotNull(advancePaymentNode);
+            Assert.AreEqual("2975.00", advancePaymentNode.SelectSingleNode("./ram:PaidAmount", namespaceManager)?.InnerText);
+            Assert.AreEqual("20250607", advancePaymentNode.SelectSingleNode("./ram:FormattedReceivedDateTime/qdt:DateTimeString", namespaceManager)?.InnerText);
+            Assert.AreEqual("102", advancePaymentNode.SelectSingleNode("./ram:FormattedReceivedDateTime/qdt:DateTimeString", namespaceManager)?.Attributes?["format"]?.Value);
+            Assert.AreEqual("1900.00", advancePaymentNode.SelectSingleNode("./ram:IncludedTradeTax/ram:CalculatedAmount", namespaceManager)?.InnerText);
+            Assert.AreEqual("VAT", advancePaymentNode.SelectSingleNode("./ram:IncludedTradeTax/ram:TypeCode", namespaceManager)?.InnerText);
+            Assert.AreEqual("S", advancePaymentNode.SelectSingleNode("./ram:IncludedTradeTax/ram:CategoryCode", namespaceManager)?.InnerText);
+            Assert.AreEqual("19.00", advancePaymentNode.SelectSingleNode("./ram:IncludedTradeTax/ram:RateApplicablePercent", namespaceManager)?.InnerText);
+            Assert.AreEqual("R202506-01", advancePaymentNode.SelectSingleNode("./ram:InvoiceSpecifiedReferencedDocument/ram:IssuerAssignedID", namespaceManager)?.InnerText);
+            Assert.AreEqual("326", advancePaymentNode.SelectSingleNode("./ram:InvoiceSpecifiedReferencedDocument/ram:TypeCode", namespaceManager)?.InnerText);
+            Assert.AreEqual("20250601", advancePaymentNode.SelectSingleNode("./ram:InvoiceSpecifiedReferencedDocument/ram:FormattedIssueDateTime/qdt:DateTimeString", namespaceManager)?.InnerText);
+
+            string schemaPath = _makeSurePathIsCrossPlatformCompatible(@"..\..\..\..\documentation\zugferd23de\Schema\4. Factur-X_1.07.2_EXTENDED\Factur-X_1.07.2_EXTENDED.xsd");
+            XmlSchemaSet schemas = new XmlSchemaSet
+            {
+                XmlResolver = new XmlUrlResolver()
+            };
+            schemas.Add(null, schemaPath);
+            document.Schemas.Add(schemas);
+            List<string> validationErrors = new List<string>();
+            document.Validate((sender, args) => validationErrors.Add(args.Message));
+            Assert.IsEmpty(validationErrors, String.Join(Environment.NewLine, validationErrors));
+
+            stream.Seek(0, SeekOrigin.Begin);
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(stream);
+            Assert.HasCount(1, loadedInvoice.AdvancePayments);
+            AdvancePayment loadedAdvancePayment = loadedInvoice.AdvancePayments[0];
+            Assert.AreEqual(2975m, loadedAdvancePayment.PaidAmount);
+            Assert.AreEqual(new DateTime(2025, 6, 7), loadedAdvancePayment.FormattedReceivedDateTime);
+            Assert.HasCount(1, loadedAdvancePayment.IncludedTradeTaxes);
+            Assert.AreEqual(1900m, loadedAdvancePayment.IncludedTradeTaxes[0].TaxAmount);
+            Assert.AreEqual(TaxTypes.VAT, loadedAdvancePayment.IncludedTradeTaxes[0].TypeCode);
+            Assert.AreEqual(TaxCategoryCodes.S, loadedAdvancePayment.IncludedTradeTaxes[0].CategoryCode);
+            Assert.AreEqual(19m, loadedAdvancePayment.IncludedTradeTaxes[0].Percent);
+            Assert.IsNotNull(loadedAdvancePayment.InvoiceSpecifiedReferencedDocument);
+            Assert.AreEqual("R202506-01", loadedAdvancePayment.InvoiceSpecifiedReferencedDocument.ID);
+            Assert.AreEqual(InvoiceType.PartialInvoice, loadedAdvancePayment.InvoiceSpecifiedReferencedDocument.TypeCode);
+            Assert.AreEqual(new DateTime(2025, 6, 1), loadedAdvancePayment.InvoiceSpecifiedReferencedDocument.IssueDateTime);
+        } // !TestAdvancePayment()
+
+
+        [TestMethod]
+        public void TestAdvancePaymentRequiresIncludedTradeTax()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            desc.AddAdvancePayment(2975m, new DateTime(2025, 6, 7));
+
+            using MemoryStream stream = new MemoryStream();
+            MissingDataException exception = Assert.ThrowsExactly<MissingDataException>(
+                () => desc.Save(stream, ZUGFeRDVersion.Version23, Profile.Extended));
+
+            StringAssert.Contains(exception.Message, "included trade tax");
+        } // !TestAdvancePaymentRequiresIncludedTradeTax()
+
+
+        [TestMethod]
+        public void TestAdvancePaymentReaderRejectsMissingMandatoryData()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            AdvancePayment advancePayment = desc.AddAdvancePayment(2975m, new DateTime(2025, 6, 7));
+            advancePayment.AddIncludedTradeTax(new Tax
+            {
+                TaxAmount = 1900m,
+                TypeCode = TaxTypes.VAT,
+                CategoryCode = TaxCategoryCodes.S,
+                Percent = 19m
+            });
+            advancePayment.SetInvoiceReferencedDocument("R202506-01", new DateTime(2025, 6, 1));
+
+            using MemoryStream stream = new MemoryStream();
+            desc.Save(stream, ZUGFeRDVersion.Version23, Profile.Extended);
+            stream.Seek(0, SeekOrigin.Begin);
+
+            XmlDocument document = new XmlDocument();
+            document.Load(stream);
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(document.NameTable);
+            namespaceManager.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
+
+            XmlDocument missingTaxAmountDocument = (XmlDocument)document.CloneNode(true);
+            XmlNode? taxAmountNode = missingTaxAmountDocument.SelectSingleNode("//ram:SpecifiedAdvancePayment/ram:IncludedTradeTax/ram:CalculatedAmount", namespaceManager);
+            Assert.IsNotNull(taxAmountNode?.ParentNode);
+            taxAmountNode!.ParentNode!.RemoveChild(taxAmountNode);
+            MissingDataException taxException = Assert.ThrowsExactly<MissingDataException>(() => LoadInvoice(missingTaxAmountDocument));
+            StringAssert.Contains(taxException.Message, "tax amount");
+
+            XmlDocument missingReferenceIdDocument = (XmlDocument)document.CloneNode(true);
+            XmlNode? referenceIdNode = missingReferenceIdDocument.SelectSingleNode("//ram:SpecifiedAdvancePayment/ram:InvoiceSpecifiedReferencedDocument/ram:IssuerAssignedID", namespaceManager);
+            Assert.IsNotNull(referenceIdNode?.ParentNode);
+            referenceIdNode!.ParentNode!.RemoveChild(referenceIdNode);
+            MissingDataException referenceException = Assert.ThrowsExactly<MissingDataException>(() => LoadInvoice(missingReferenceIdDocument));
+            StringAssert.Contains(referenceException.Message, "reference ID");
+
+            static void LoadInvoice(XmlDocument invoiceDocument)
+            {
+                using MemoryStream invalidStream = new MemoryStream();
+                invoiceDocument.Save(invalidStream);
+                invalidStream.Seek(0, SeekOrigin.Begin);
+                InvoiceDescriptor.Load(invalidStream);
+            }
+        } // !TestAdvancePaymentReaderRejectsMissingMandatoryData()
+
+
+        [TestMethod]
+        public void TestAdvancePaymentIsNotWrittenOutsideExtendedProfile()
+        {
+            InvoiceDescriptor desc = this._InvoiceProvider.CreateInvoice();
+            AdvancePayment advancePayment = desc.AddAdvancePayment(2975m, new DateTime(2025, 6, 7));
+            advancePayment.AddIncludedTradeTax(new Tax
+            {
+                TaxAmount = 1900m,
+                TypeCode = TaxTypes.VAT,
+                CategoryCode = TaxCategoryCodes.S,
+                Percent = 19m
+            });
+
+            using MemoryStream stream = new MemoryStream();
+            desc.Save(stream, ZUGFeRDVersion.Version23, Profile.Comfort);
+            stream.Seek(0, SeekOrigin.Begin);
+
+            XmlDocument document = new XmlDocument();
+            document.Load(stream);
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(document.NameTable);
+            namespaceManager.AddNamespace("ram", "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100");
+
+            Assert.IsNull(document.SelectSingleNode("//ram:SpecifiedAdvancePayment", namespaceManager));
+        } // !TestAdvancePaymentIsNotWrittenOutsideExtendedProfile()
 
 
         [TestMethod]

--- a/ZUGFeRD/AdvancePayment.cs
+++ b/ZUGFeRD/AdvancePayment.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+
+namespace s2industries.ZUGFeRD
+{
+    /// <summary>
+    /// Detailangaben zu einer Vorauszahlung im Extended-Profil (BG-X-45).
+    /// </summary>
+    public class AdvancePayment
+    {
+        /// <summary>
+        /// Gezahlter Vorauszahlungsbetrag. Pflichtangabe innerhalb von BG-X-45.
+        /// </summary>
+        public decimal? PaidAmount { get; set; }
+
+        /// <summary>
+        /// Datum des Zahlungseingangs.
+        /// </summary>
+        public DateTime? FormattedReceivedDateTime { get; set; }
+
+        /// <summary>
+        /// In der Vorauszahlung enthaltene Steuern. Mindestens ein Eintrag ist erforderlich.
+        /// </summary>
+        public List<Tax> IncludedTradeTaxes { get; internal set; } = new List<Tax>();
+
+        /// <summary>
+        /// Referenz auf die zugehörige Vorauszahlungsrechnung.
+        /// </summary>
+        public InvoiceReferencedDocument InvoiceSpecifiedReferencedDocument { get; internal set; }
+
+
+        /// <summary>
+        /// Fügt eine enthaltene Steuer hinzu.
+        /// </summary>
+        /// <param name="tax">Enthaltene Steuer</param>
+        /// <returns>Hinzugefügte Steuer</returns>
+        public Tax AddIncludedTradeTax(Tax tax)
+        {
+            if (tax == null)
+            {
+                throw new ArgumentNullException(nameof(tax));
+            }
+
+            IncludedTradeTaxes.Add(tax);
+            return tax;
+        } // !AddIncludedTradeTax()
+
+
+        /// <summary>
+        /// Legt die Referenz auf die zugehörige Vorauszahlungsrechnung an oder aktualisiert sie.
+        /// </summary>
+        /// <param name="id">Rechnungsnummer</param>
+        /// <param name="issueDateTime">Rechnungsdatum</param>
+        /// <param name="typeCode">Rechnungstyp</param>
+        public void SetInvoiceReferencedDocument(string id, DateTime? issueDateTime = null, InvoiceType? typeCode = null)
+        {
+            if (InvoiceSpecifiedReferencedDocument == null)
+            {
+                InvoiceSpecifiedReferencedDocument = new InvoiceReferencedDocument();
+            }
+            InvoiceSpecifiedReferencedDocument.ID = id;
+            InvoiceSpecifiedReferencedDocument.IssueDateTime = issueDateTime;
+            InvoiceSpecifiedReferencedDocument.TypeCode = typeCode;
+        } // !SetInvoiceReferencedDocument()
+    }
+}

--- a/ZUGFeRD/AdvancePayment.cs
+++ b/ZUGFeRD/AdvancePayment.cs
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 using System;
 using System.Collections.Generic;
 

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -440,6 +440,13 @@ namespace s2industries.ZUGFeRD
         public List<PaymentTerms> PaymentTerms { get; internal set; } = new List<PaymentTerms>();
 
         /// <summary>
+        /// Detailangaben zu Vorauszahlungen im Extended-Profil.
+        ///
+        /// BG-X-45
+        /// </summary>
+        public List<AdvancePayment> AdvancePayments { get; internal set; } = new List<AdvancePayment>();
+
+        /// <summary>
         /// A group of business terms providing information about a preceding invoices.
         ///
         /// To be used in case:
@@ -1386,6 +1393,38 @@ namespace s2industries.ZUGFeRD
         {
             return this._InvoiceReferencedDocuments;
         } // !GetInvoiceReferencedDocuments()
+
+
+        /// <summary>
+        /// Fügt Detailangaben zu einer Vorauszahlung hinzu.
+        ///
+        /// BG-X-45
+        /// </summary>
+        /// <param name="paidAmount">Gezahlter Vorauszahlungsbetrag</param>
+        /// <param name="receivedDateTime">Datum des Zahlungseingangs</param>
+        /// <returns>Hinzugefügte Vorauszahlung</returns>
+        public AdvancePayment AddAdvancePayment(decimal paidAmount, DateTime? receivedDateTime = null)
+        {
+            AdvancePayment advancePayment = new AdvancePayment
+            {
+                PaidAmount = paidAmount,
+                FormattedReceivedDateTime = receivedDateTime
+            };
+            AdvancePayments.Add(advancePayment);
+            return advancePayment;
+        } // !AddAdvancePayment()
+
+
+        /// <summary>
+        /// Liefert alle Detailangaben zu Vorauszahlungen.
+        ///
+        /// BG-X-45
+        /// </summary>
+        /// <returns>Liste der Vorauszahlungen</returns>
+        public List<AdvancePayment> GetAdvancePayments()
+        {
+            return AdvancePayments;
+        } // !GetAdvancePayments()
 
 
         /// <summary>

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -484,6 +484,64 @@ namespace s2industries.ZUGFeRD
                 );
             }
 
+            // BG-X-45 ist eine eigenständige Aufschlüsselung und nicht mit BT-113 gleichzusetzen.
+            foreach (XmlNode node in doc.SelectNodes("//ram:ApplicableHeaderTradeSettlement/ram:SpecifiedAdvancePayment", nsmgr))
+            {
+                decimal? paidAmount = XmlUtils.NodeAsDecimal(node, "./ram:PaidAmount", nsmgr);
+                if (!paidAmount.HasValue)
+                {
+                    throw new MissingDataException("Advance payment paid amount is required (BG-X-45).");
+                }
+
+                AdvancePayment advancePayment = retval.AddAdvancePayment(
+                    paidAmount.Value,
+                    DataTypeReader.ReadFormattedIssueDateTime(node, "./ram:FormattedReceivedDateTime", nsmgr));
+
+                XmlNodeList includedTradeTaxNodes = node.SelectNodes("./ram:IncludedTradeTax", nsmgr);
+                if (includedTradeTaxNodes.Count == 0)
+                {
+                    throw new MissingDataException("At least one included trade tax is required for an advance payment (BG-X-45).");
+                }
+
+                foreach (XmlNode includedTradeTaxNode in includedTradeTaxNodes)
+                {
+                    TaxTypes? typeCode = EnumExtensions.StringToNullableEnum<TaxTypes>(XmlUtils.NodeAsString(includedTradeTaxNode, "./ram:TypeCode", nsmgr));
+                    TaxCategoryCodes? categoryCode = EnumExtensions.StringToNullableEnum<TaxCategoryCodes>(XmlUtils.NodeAsString(includedTradeTaxNode, "./ram:CategoryCode", nsmgr));
+                    decimal? taxAmount = XmlUtils.NodeAsDecimal(includedTradeTaxNode, "./ram:CalculatedAmount", nsmgr);
+                    if (!taxAmount.HasValue || !typeCode.HasValue || !categoryCode.HasValue)
+                    {
+                        throw new MissingDataException("Advance payment tax amount, type and category are required (BG-X-45).");
+                    }
+
+                    Tax includedTradeTax = new Tax
+                    {
+                        TaxAmount = taxAmount.Value,
+                        TypeCode = typeCode,
+                        CategoryCode = categoryCode
+                    };
+                    decimal? percent = XmlUtils.NodeAsDecimal(includedTradeTaxNode, "./ram:RateApplicablePercent", nsmgr);
+                    if (percent.HasValue)
+                    {
+                        includedTradeTax.Percent = percent.Value;
+                    }
+                    advancePayment.AddIncludedTradeTax(includedTradeTax);
+                }
+
+                XmlNode referencedDocumentNode = node.SelectSingleNode("./ram:InvoiceSpecifiedReferencedDocument", nsmgr);
+                if (referencedDocumentNode != null)
+                {
+                    string referencedDocumentId = XmlUtils.NodeAsString(referencedDocumentNode, "./ram:IssuerAssignedID", nsmgr);
+                    if (String.IsNullOrWhiteSpace(referencedDocumentId))
+                    {
+                        throw new MissingDataException("Advance payment invoice reference ID is required when a reference is specified (BG-X-45).");
+                    }
+                    advancePayment.SetInvoiceReferencedDocument(
+                        referencedDocumentId,
+                        DataTypeReader.ReadFormattedIssueDateTime(referencedDocumentNode, "./ram:FormattedIssueDateTime", nsmgr),
+                        EnumExtensions.StringToNullableEnum<InvoiceType>(XmlUtils.NodeAsString(referencedDocumentNode, "./ram:TypeCode", nsmgr)));
+                }
+            }
+
             retval.OrderDate = DataTypeReader.ReadFormattedIssueDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:FormattedIssueDateTime", nsmgr);
             retval.OrderNo = XmlUtils.NodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeAgreement/ram:BuyerOrderReferencedDocument/ram:IssuerAssignedID", nsmgr);
 

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -69,6 +69,7 @@ namespace s2industries.ZUGFeRD
             long streamPosition = stream.Position;
 
             this._Descriptor = descriptor;
+            _validateAdvancePayments();
             this._Writer = new ProfileAwareXmlTextWriter(stream, descriptor.Profile, options?.AutomaticallyCleanInvalidCharacters ?? false);
             this._Writer.SetNamespaces(_Namespaces);
 
@@ -1283,7 +1284,50 @@ namespace s2industries.ZUGFeRD
                 }
             }
 
-            // TODO: SpecifiedAdvancePayment (0..unbounded), BG-X-45
+            #region SpecifiedAdvancePayment
+            if (this._Descriptor.Profile == Profile.Extended)
+            {
+                foreach (AdvancePayment advancePayment in this._Descriptor.GetAdvancePayments())
+                {
+                    _Writer.WriteStartElement("ram", "SpecifiedAdvancePayment");
+                    _writeOptionalAmount(_Writer, "ram", "PaidAmount", advancePayment.PaidAmount);
+
+                    if (advancePayment.FormattedReceivedDateTime.HasValue)
+                    {
+                        _Writer.WriteStartElement("ram", "FormattedReceivedDateTime");
+                        _writeElementWithAttributeWithPrefix(_Writer, "qdt", "DateTimeString", "format", "102", _formatDate(advancePayment.FormattedReceivedDateTime.Value));
+                        _Writer.WriteEndElement(); // !ram:FormattedReceivedDateTime
+                    }
+
+                    foreach (Tax includedTradeTax in advancePayment.IncludedTradeTaxes)
+                    {
+                        _Writer.WriteStartElement("ram", "IncludedTradeTax");
+                        _Writer.WriteElementString("ram", "CalculatedAmount", _formatDecimal(includedTradeTax.TaxAmount));
+                        _Writer.WriteElementString("ram", "TypeCode", includedTradeTax.TypeCode.EnumToString());
+                        _Writer.WriteElementString("ram", "CategoryCode", includedTradeTax.CategoryCode.EnumToString());
+                        _Writer.WriteElementString("ram", "RateApplicablePercent", _formatDecimal(includedTradeTax.Percent));
+                        _Writer.WriteEndElement(); // !ram:IncludedTradeTax
+                    }
+
+                    InvoiceReferencedDocument referencedDocument = advancePayment.InvoiceSpecifiedReferencedDocument;
+                    if (referencedDocument != null)
+                    {
+                        _Writer.WriteStartElement("ram", "InvoiceSpecifiedReferencedDocument");
+                        _Writer.WriteElementString("ram", "IssuerAssignedID", referencedDocument.ID);
+                        _Writer.WriteOptionalElementString("ram", "TypeCode", referencedDocument.TypeCode.EnumToString());
+                        if (referencedDocument.IssueDateTime.HasValue)
+                        {
+                            _Writer.WriteStartElement("ram", "FormattedIssueDateTime");
+                            _writeElementWithAttributeWithPrefix(_Writer, "qdt", "DateTimeString", "format", "102", _formatDate(referencedDocument.IssueDateTime.Value));
+                            _Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+                        }
+                        _Writer.WriteEndElement(); // !ram:InvoiceSpecifiedReferencedDocument
+                    }
+
+                    _Writer.WriteEndElement(); // !ram:SpecifiedAdvancePayment
+                }
+            }
+            #endregion
 
             #endregion
             _Writer.WriteEndElement(); // !ram:ApplicableHeaderTradeSettlement
@@ -1299,6 +1343,39 @@ namespace s2industries.ZUGFeRD
 
             stream.Seek(streamPosition, SeekOrigin.Begin);
         } // !Save()
+
+
+        /// <summary>
+        /// Prüft die für BG-X-45 vorgeschriebenen Daten vor der Serialisierung.
+        /// </summary>
+        private void _validateAdvancePayments()
+        {
+            if (this._Descriptor.Profile != Profile.Extended || this._Descriptor.AdvancePayments == null)
+            {
+                return;
+            }
+
+            foreach (AdvancePayment advancePayment in this._Descriptor.AdvancePayments)
+            {
+                if (advancePayment == null || !advancePayment.PaidAmount.HasValue)
+                {
+                    throw new MissingDataException("Advance payment paid amount is required (BG-X-45).");
+                }
+                if (advancePayment.IncludedTradeTaxes == null || advancePayment.IncludedTradeTaxes.Count == 0)
+                {
+                    throw new MissingDataException("At least one included trade tax is required for an advance payment (BG-X-45).");
+                }
+                if (advancePayment.IncludedTradeTaxes.Any(tax => tax == null || !tax.TypeCode.HasValue || !tax.CategoryCode.HasValue))
+                {
+                    throw new MissingDataException("Advance payment tax type and category are required (BG-X-45).");
+                }
+                if (advancePayment.InvoiceSpecifiedReferencedDocument != null &&
+                    String.IsNullOrWhiteSpace(advancePayment.InvoiceSpecifiedReferencedDocument.ID))
+                {
+                    throw new MissingDataException("Advance payment invoice reference ID is required when a reference is specified (BG-X-45).");
+                }
+            }
+        } // !_validateAdvancePayments()
 
 
         private void _WriteDocumentLevelSpecifiedTradeAllowanceCharge(ProfileAwareXmlTextWriter writer, AbstractTradeAllowanceCharge tradeAllowanceCharge)


### PR DESCRIPTION
## Summary

- add an `AdvancePayment` model and `InvoiceDescriptor` APIs for BG-X-45
- read and write `SpecifiedAdvancePayment` in ZUGFeRD 2.3 CII Extended documents, including received date, included taxes, and the optional invoice reference
- validate the mandatory advance-payment fields during reading and before serialization
- keep advance-payment details out of profiles other than Extended

## Validation

- `dotnet test ZUGFeRD.Test/ZUGFeRD.Test.csproj --filter FullyQualifiedName~AdvancePayment`: 4 passed
- the round-trip test validates the generated document against the bundled Factur-X 1.07.2 Extended XSD
- `dotnet build ZUGFeRD/ZUGFeRD.csproj`: all five target frameworks built with 0 errors
