### PR TITLE
Validate invoice tax basis total

### DIFF
--- a/ZUGFeRD.Test/InvoiceValidatorTests.cs
+++ b/ZUGFeRD.Test/InvoiceValidatorTests.cs
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace s2industries.ZUGFeRD.Test
+{
+    [TestClass]
+    public class InvoiceValidatorTests
+    {
+        [TestMethod]
+        public void ValidTaxBasisAmountIsAccepted()
+        {
+            InvoiceDescriptor descriptor = new InvoiceProvider().CreateInvoice();
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void MissingTaxBasisAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = new InvoiceProvider().CreateInvoice();
+            descriptor.TaxBasisAmount = null;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("Kein TaxBasisAmount vorhanden", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void InvalidTaxBasisAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = new InvoiceProvider().CreateInvoice();
+            descriptor.TaxBasisAmount = 472m;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("taxBasisTotal", StringComparison.Ordinal)));
+        }
+    }
+}

--- a/ZUGFeRD/InvoiceValidator.cs
+++ b/ZUGFeRD/InvoiceValidator.cs
@@ -200,16 +200,19 @@ namespace s2industries.ZUGFeRD
                 retval.IsValid = false;
             }
 
-            /*
-             * @todo Richtige Validierung implementieren
-             */
-            if (Math.Abs(taxBasisTotal - taxBasisTotal) < 0.01m)
+            // The sum of VAT category taxable amounts (BT-116) must equal the invoice total amount without VAT (BT-109).
+            if (!descriptor.TaxBasisAmount.HasValue)
+            {
+                retval.Messages.Add("trade.settlement.monetarySummation.taxBasisTotal Message: Kein TaxBasisAmount vorhanden");
+                retval.IsValid = false;
+            }
+            else if (Math.Abs(taxBasisTotal - descriptor.TaxBasisAmount.Value) < 0.01m)
             {
                 retval.Messages.Add(String.Format("trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", taxBasisTotal));
             }
             else
             {
-                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[{0:0.0000}] aber tatsächliche vorhander Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", taxBasisTotal, taxBasisTotal));
+                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[{0:0.0000}] aber tatsächlicher vorhandener Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", taxBasisTotal, descriptor.TaxBasisAmount.Value));
                 retval.IsValid = false;
             }
 


### PR DESCRIPTION
## Summary

- Compare the sum of VAT category taxable amounts (BT-116) with the invoice total amount without VAT (BT-109).
- Report a missing `TaxBasisAmount` instead of silently accepting it.
- Add tests for valid, missing, and mismatching tax basis totals.
- Document the BT-109 and BT-116 relationship directly at the validation rule.

## Reason

The previous validator compared the calculated tax basis total with itself, so the check could never fail.

## Verification

- Countercheck before the fix: one valid test passed, while the missing and mismatching cases failed.
- Focused tests after the fix: 3 of 3 passed.
- Library build succeeded for `net8.0`, `net461`, `net480`, `netstandard2.0`, and `netstandard2.1` with 0 errors.