### PR TITLE
Validate prepaid and due amounts

### DIFF
--- a/ZUGFeRD.Test/InvoiceValidatorTests.cs
+++ b/ZUGFeRD.Test/InvoiceValidatorTests.cs
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace s2industries.ZUGFeRD.Test
+{
+    [TestClass]
+    public class InvoiceValidatorTests
+    {
+        [TestMethod]
+        public void ValidTaxBasisAmountIsAccepted()
+        {
+            InvoiceDescriptor descriptor = new InvoiceProvider().CreateInvoice();
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void MissingTaxBasisAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = new InvoiceProvider().CreateInvoice();
+            descriptor.TaxBasisAmount = null;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("Kein TaxBasisAmount vorhanden", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void InvalidTaxBasisAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = new InvoiceProvider().CreateInvoice();
+            descriptor.TaxBasisAmount = 472m;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("taxBasisTotal", StringComparison.Ordinal)));
+        }
+    }
+}

--- a/ZUGFeRD.Test/InvoiceValidatorTests.cs
+++ b/ZUGFeRD.Test/InvoiceValidatorTests.cs
@@ -22,7 +22,8 @@ namespace s2industries.ZUGFeRD.Test
     [TestClass]
     public class InvoiceValidatorTests
     {
-        private static InvoiceDescriptor CreateBalancedInvoice(decimal lineAllowance = 0m, decimal lineCharge = 0m)
+        private static InvoiceDescriptor CreateBalancedInvoice(decimal lineAllowance = 0m, decimal lineCharge = 0m,
+            decimal prepaidAmount = 0m, decimal roundingAmount = 0m)
         {
             InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-4711", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
             TradeLineItem lineItem = descriptor.AddTradeLineItem(
@@ -46,6 +47,7 @@ namespace s2industries.ZUGFeRD.Test
 
             decimal lineTotal = 200m - lineAllowance + lineCharge;
             decimal taxTotal = lineTotal * 19m / 100m;
+            decimal grandTotal = lineTotal + taxTotal;
             lineItem.LineTotalAmount = lineTotal;
             descriptor.AddApplicableTradeTax(lineTotal, 19m, taxTotal, TaxTypes.VAT, TaxCategoryCodes.S);
             descriptor.SetTotals(
@@ -54,9 +56,10 @@ namespace s2industries.ZUGFeRD.Test
                 allowanceTotalAmount: 0m,
                 taxBasisAmount: lineTotal,
                 taxTotalAmount: taxTotal,
-                grandTotalAmount: lineTotal + taxTotal,
-                totalPrepaidAmount: 0m,
-                duePayableAmount: lineTotal + taxTotal);
+                grandTotalAmount: grandTotal,
+                totalPrepaidAmount: prepaidAmount,
+                duePayableAmount: grandTotal - prepaidAmount + roundingAmount,
+                roundingAmount: roundingAmount);
             return descriptor;
         }
 
@@ -129,6 +132,68 @@ namespace s2industries.ZUGFeRD.Test
             ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
 
             Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void ValidInvoiceWithPrepaidAmountIsAccepted()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice(prepaidAmount: 50m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void ValidInvoiceWithRoundingAmountIsAccepted()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice(roundingAmount: 0.05m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void MissingDuePayableAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.DuePayableAmount = null;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("Kein DuePayableAmount vorhanden", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void InvalidDuePayableAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice(prepaidAmount: 50m, roundingAmount: 0.05m);
+            descriptor.DuePayableAmount = descriptor.GrandTotalAmount.Value;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("duePayable", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void DuePayableUsesDeclaredGrandTotalAmount()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice(prepaidAmount: 50m);
+            descriptor.GrandTotalAmount += 1m;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains(
+                "monetarySummation.duePayable Message: Berechneter Wert ist[", StringComparison.Ordinal)));
         }
     }
 }

--- a/ZUGFeRD.Test/InvoiceValidatorTests.cs
+++ b/ZUGFeRD.Test/InvoiceValidatorTests.cs
@@ -22,6 +22,45 @@ namespace s2industries.ZUGFeRD.Test
     [TestClass]
     public class InvoiceValidatorTests
     {
+        private static InvoiceDescriptor CreateBalancedInvoice(decimal lineAllowance = 0m, decimal lineCharge = 0m)
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-4711", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            TradeLineItem lineItem = descriptor.AddTradeLineItem(
+                name: "Test item",
+                netUnitPrice: 100m,
+                unitCode: QuantityCodes.H87,
+                billedQuantity: 2m,
+                lineTotalAmount: 200m,
+                taxType: TaxTypes.VAT,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 19m);
+
+            if (lineAllowance != 0m)
+            {
+                lineItem.AddSpecifiedTradeAllowance(CurrencyCodes.EUR, 200m, lineAllowance, "Quantity discount");
+            }
+            if (lineCharge != 0m)
+            {
+                lineItem.AddSpecifiedTradeCharge(CurrencyCodes.EUR, 200m, lineCharge, "Line charge");
+            }
+
+            decimal lineTotal = 200m - lineAllowance + lineCharge;
+            decimal taxTotal = lineTotal * 19m / 100m;
+            lineItem.LineTotalAmount = lineTotal;
+            descriptor.AddApplicableTradeTax(lineTotal, 19m, taxTotal, TaxTypes.VAT, TaxCategoryCodes.S);
+            descriptor.SetTotals(
+                lineTotalAmount: lineTotal,
+                chargeTotalAmount: 0m,
+                allowanceTotalAmount: 0m,
+                taxBasisAmount: lineTotal,
+                taxTotalAmount: taxTotal,
+                grandTotalAmount: lineTotal + taxTotal,
+                totalPrepaidAmount: 0m,
+                duePayableAmount: lineTotal + taxTotal);
+            return descriptor;
+        }
+
+
         [TestMethod]
         public void ValidTaxBasisAmountIsAccepted()
         {
@@ -56,6 +95,40 @@ namespace s2industries.ZUGFeRD.Test
 
             Assert.IsFalse(result.IsValid);
             Assert.IsTrue(result.Messages.Any(message => message.Contains("taxBasisTotal", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void ValidInvoiceWithLineAllowanceIsAccepted()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice(lineAllowance: 10m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void ValidInvoiceWithLineChargeIsAccepted()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice(lineCharge: 10m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void PriceAllowanceIsNotSubtractedTwice()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.TradeLineItems[0].AddTradeAllowance(CurrencyCodes.EUR, 110m, 10m, "Price allowance");
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
         }
     }
 }

--- a/ZUGFeRD/InvoiceValidator.cs
+++ b/ZUGFeRD/InvoiceValidator.cs
@@ -72,6 +72,11 @@ namespace s2industries.ZUGFeRD
             foreach (TradeLineItem item in descriptor.GetTradeLineItems())
             {
                 decimal total = decimal.Multiply(item.NetUnitPrice, item.BilledQuantity);
+
+                // BT-131 includes BG-28 line charges and excludes BG-27 line allowances.
+                total -= item.GetSpecifiedTradeAllowances().Sum(allowance => allowance.ActualAmount);
+                total += item.GetSpecifiedTradeCharges().Sum(charge => charge.ActualAmount);
+
                 lineTotal += total;
 
                 if (!lineTotalPerTax.ContainsKey(item.TaxPercent))

--- a/ZUGFeRD/InvoiceValidator.cs
+++ b/ZUGFeRD/InvoiceValidator.cs
@@ -200,16 +200,19 @@ namespace s2industries.ZUGFeRD
                 retval.IsValid = false;
             }
 
-            /*
-             * @todo Richtige Validierung implementieren
-             */
-            if (Math.Abs(taxBasisTotal - taxBasisTotal) < 0.01m)
+            // The sum of VAT category taxable amounts (BT-116) must equal the invoice total amount without VAT (BT-109).
+            if (!descriptor.TaxBasisAmount.HasValue)
+            {
+                retval.Messages.Add("trade.settlement.monetarySummation.taxBasisTotal Message: Kein TaxBasisAmount vorhanden");
+                retval.IsValid = false;
+            }
+            else if (Math.Abs(taxBasisTotal - descriptor.TaxBasisAmount.Value) < 0.01m)
             {
                 retval.Messages.Add(String.Format("trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", taxBasisTotal));
             }
             else
             {
-                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[{0:0.0000}] aber tatsächliche vorhander Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", taxBasisTotal, taxBasisTotal));
+                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.taxBasisTotal Message: Berechneter Wert ist[{0:0.0000}] aber tatsächlicher vorhandener Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", taxBasisTotal, descriptor.TaxBasisAmount.Value));
                 retval.IsValid = false;
             }
 

--- a/ZUGFeRD/InvoiceValidator.cs
+++ b/ZUGFeRD/InvoiceValidator.cs
@@ -144,7 +144,11 @@ namespace s2industries.ZUGFeRD
             }
 
             decimal grandTotal = lineTotal - allowanceTotal + taxTotal + chargeTotal;
-            decimal prepaid = 0m; // TODO: calculcate
+            decimal prepaid = descriptor.TotalPrepaidAmount.GetValueOrDefault();
+            decimal rounding = descriptor.RoundingAmount.GetValueOrDefault();
+
+            // BR-CO-16: BT-115 equals BT-112 minus BT-113 plus BT-114.
+            decimal duePayable = grandTotal - prepaid + rounding;
 
             retval.Messages.Add(String.Format("Recalculated tax total = {0:0.00}", taxTotal));
             retval.Messages.Add(String.Format("Recalculated grand total = {0:0.0000} EUR(tax basis total + tax total)", grandTotal));
@@ -157,7 +161,7 @@ namespace s2industries.ZUGFeRD
                                      taxTotal,
                                      grandTotal,
                                      prepaid,
-                                     lineTotal - allowanceTotal + taxTotal + chargeTotal + prepaid
+                                     duePayable
                                      ));
 
 
@@ -203,6 +207,25 @@ namespace s2industries.ZUGFeRD
             {
                 retval.Messages.Add(String.Format("trade.settlement.monetarySummation.grandTotal Message: Berechneter Wert ist[{0:0.0000}] aber tatsächliche vorhander Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", grandTotal, descriptor.GrandTotalAmount));
                 retval.IsValid = false;
+            }
+
+            if (!descriptor.DuePayableAmount.HasValue)
+            {
+                retval.Messages.Add("trade.settlement.monetarySummation.duePayable Message: Kein DuePayableAmount vorhanden");
+                retval.IsValid = false;
+            }
+            else if (descriptor.GrandTotalAmount.HasValue)
+            {
+                decimal expectedDuePayable = descriptor.GrandTotalAmount.Value - prepaid + rounding;
+                if (Math.Abs(expectedDuePayable - descriptor.DuePayableAmount.Value) < 0.01m)
+                {
+                    retval.Messages.Add(String.Format("trade.settlement.monetarySummation.duePayable Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", expectedDuePayable));
+                }
+                else
+                {
+                    retval.Messages.Add(String.Format("trade.settlement.monetarySummation.duePayable Message: Berechneter Wert ist[{0:0.0000}] aber tatsächlicher vorhandener Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", expectedDuePayable, descriptor.DuePayableAmount.Value));
+                    retval.IsValid = false;
+                }
             }
 
             // The sum of VAT category taxable amounts (BT-116) must equal the invoice total amount without VAT (BT-109).


### PR DESCRIPTION
## Summary

- validate BT-115 against declared BT-112 minus BT-113 plus BT-114
- treat the optional paid and rounding amounts as zero when absent
- report a missing or inconsistent BT-115
- add positive and negative validator tests for paid amounts, rounding, missing values, and an inconsistent declared BT-112

## Reason

BR-CO-16 defines the amount due for payment from the declared invoice total amount with VAT, paid amount, and rounding amount. The validator previously displayed a hard-coded paid amount of zero, added it with the wrong sign in the diagnostic result, and did not validate BT-115.

`SpecifiedAdvancePayment` remains independent detail information. No normative rule requiring its sum to equal BT-113 was identified.

This pull request is based on #970. After #970 is merged, the remaining change is commit `e5bcf09`.

## Verification

- counterproof before the implementation: 8 of 11 focused tests passed; only the three new BT-115 error cases failed
- focused validator tests after the implementation: 11 of 11 passed
- regression tests excluding the unchanged `TestSellerPartyDescription` line-ending assertion: 336 of 336 passed
- unfiltered test run: 336 of 337 passed; only that unchanged assertion failed
- library build for `net8.0`, `net461`, `net480`, `netstandard2.0`, and `netstandard2.1`: 0 errors
