### PR TITLE
Validate VAT rounding per tax breakdown

### DIFF
--- a/ZUGFeRD.Test/InvoiceValidatorTests.cs
+++ b/ZUGFeRD.Test/InvoiceValidatorTests.cs
@@ -64,6 +64,22 @@ namespace s2industries.ZUGFeRD.Test
         }
 
 
+        private static void AddTaxGroup(InvoiceDescriptor descriptor, string name, decimal basisAmount,
+            decimal taxPercent, decimal taxAmount, TaxCategoryCodes categoryCode)
+        {
+            descriptor.AddTradeLineItem(
+                name: name,
+                netUnitPrice: basisAmount,
+                unitCode: QuantityCodes.H87,
+                billedQuantity: 1m,
+                lineTotalAmount: basisAmount,
+                taxType: TaxTypes.VAT,
+                categoryCode: categoryCode,
+                taxPercent: taxPercent);
+            descriptor.AddApplicableTradeTax(basisAmount, taxPercent, taxAmount, TaxTypes.VAT, categoryCode);
+        }
+
+
         [TestMethod]
         public void ValidTaxBasisAmountIsAccepted()
         {
@@ -194,6 +210,88 @@ namespace s2industries.ZUGFeRD.Test
             Assert.IsFalse(result.IsValid);
             Assert.IsTrue(result.Messages.Any(message => message.Contains(
                 "monetarySummation.duePayable Message: Berechneter Wert ist[", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void TaxAmountsAreRoundedPerTaxGroup()
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-ROUND-GROUPS", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            AddTaxGroup(descriptor, "Group 19", 0.03m, 19m, 0.01m, TaxCategoryCodes.S);
+            AddTaxGroup(descriptor, "Group 7", 0.08m, 7m, 0.01m, TaxCategoryCodes.S);
+            AddTaxGroup(descriptor, "Group 5", 0.11m, 5m, 0.01m, TaxCategoryCodes.S);
+            descriptor.SetTotals(0.22m, 0m, 0m, 0.22m, 0.03m, 0.25m, 0m, 0.25m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void UnroundedTaxAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-ROUND-INVALID", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            AddTaxGroup(descriptor, "Unrounded group", 0.03m, 19m, 0.0057m, TaxCategoryCodes.S);
+            descriptor.SetTotals(0.03m, 0m, 0m, 0.03m, 0.0057m, 0.0357m, 0m, 0.0357m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-17", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void NegativeMidpointTaxAmountIsRoundedAwayFromZero()
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-ROUND-NEGATIVE", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            AddTaxGroup(descriptor, "Negative midpoint", -0.025m, 20m, -0.01m, TaxCategoryCodes.S);
+            descriptor.SetTotals(-0.025m, 0m, 0m, -0.025m, -0.01m, -0.035m, 0m, -0.035m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void NonVatTaxDoesNotAffectVatTotals()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.AddApplicableTradeTax(200m, 5m, 10m, TaxTypes.AAA, TaxCategoryCodes.S);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void MissingTaxTypeIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.Taxes[0].TypeCode = null;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("Tax type code is required", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void TaxAmountDeviationsWithinSameRateAreReported()
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-ROUND-CATEGORY", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            AddTaxGroup(descriptor, "Standard rate", 1m, 7m, 0.08m, TaxCategoryCodes.S);
+            AddTaxGroup(descriptor, "Lower rate", 1m, 7m, 0.06m, TaxCategoryCodes.AA);
+            descriptor.SetTotals(2m, 0m, 0m, 2m, 0.14m, 2.14m, 0m, 2.14m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.AreEqual(2, result.Messages.Count(message => message.Contains("BR-CO-17", StringComparison.Ordinal)));
         }
     }
 }

--- a/ZUGFeRD/InvoiceValidator.cs
+++ b/ZUGFeRD/InvoiceValidator.cs
@@ -17,7 +17,6 @@
  * under the License.
  */
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -68,7 +67,6 @@ namespace s2industries.ZUGFeRD
             int lineCounter = 0;
 
             decimal lineTotal = 0m;
-            Dictionary<decimal, decimal> lineTotalPerTax = new Dictionary<decimal, decimal>();
             foreach (TradeLineItem item in descriptor.GetTradeLineItems())
             {
                 decimal total = decimal.Multiply(item.NetUnitPrice, item.BilledQuantity);
@@ -78,12 +76,6 @@ namespace s2industries.ZUGFeRD
                 total += item.GetSpecifiedTradeCharges().Sum(charge => charge.ActualAmount);
 
                 lineTotal += total;
-
-                if (!lineTotalPerTax.ContainsKey(item.TaxPercent))
-                {
-                    lineTotalPerTax.Add(item.TaxPercent, new decimal());
-                }
-                lineTotalPerTax[item.TaxPercent] += total;
 
                 /*
                 retval.Add(String.Format("==> {0}:", ++lineCounter));
@@ -107,11 +99,6 @@ namespace s2industries.ZUGFeRD
             {
                 retval.Messages.Add(String.Format("==> added {0:0.00} to {1:0.00}%", -charge.Amount, charge.Tax.Percent));
 
-                if (!lineTotalPerTax.ContainsKey(charge.Tax.Percent))
-                {
-                    lineTotalPerTax.Add(charge.Tax.Percent, new decimal());
-                }
-                lineTotalPerTax[charge.Tax.Percent] += charge.Amount;
                 chargeTotal += charge.Amount;
             }
 
@@ -120,11 +107,6 @@ namespace s2industries.ZUGFeRD
             {
                 retval.Messages.Add(String.Format("==> added {0:0.00} to {1:0.00}%", -allowance.Amount, allowance.Tax.Percent));
 
-                if (!lineTotalPerTax.ContainsKey(allowance.Tax.Percent))
-                {
-                    lineTotalPerTax.Add(allowance.Tax.Percent, new decimal());
-                }
-                lineTotalPerTax[allowance.Tax.Percent] -= allowance.Amount;
                 allowanceTotal += allowance.Amount;
             }
 
@@ -136,11 +118,31 @@ namespace s2industries.ZUGFeRD
             retval.Messages.Add("Calculating tax total...");
 
             decimal taxTotal = 0.0m;
-            foreach (KeyValuePair<decimal, decimal> kv in lineTotalPerTax)
+            foreach (Tax tax in descriptor.GetApplicableTradeTaxes())
             {
-                decimal taxTotalForLine = Decimal.Divide(Decimal.Multiply(kv.Value, kv.Key), 100.0m);
-                taxTotal += taxTotalForLine;
-                retval.Messages.Add(String.Format("===> {0:0.0000} x {1:0.00}% = {2:0.00}", kv.Value, kv.Key, taxTotalForLine));
+                if (!tax.TypeCode.HasValue)
+                {
+                    retval.Messages.Add("Tax type code is required for every tax breakdown");
+                    retval.IsValid = false;
+                    continue;
+                }
+                if (tax.TypeCode != TaxTypes.VAT)
+                {
+                    continue;
+                }
+
+                // BR-CO-17 requires rounding each VAT breakdown before summing the amounts to BT-110.
+                decimal expectedTaxAmount = Math.Round(tax.BasisAmount * tax.Percent / 100m, 2, MidpointRounding.AwayFromZero);
+                taxTotal += expectedTaxAmount;
+                retval.Messages.Add(String.Format("===> {0:0.0000} x {1:0.00}% = {2:0.00}", tax.BasisAmount, tax.Percent, expectedTaxAmount));
+
+                if (tax.TaxAmount != expectedTaxAmount)
+                {
+                    retval.Messages.Add(String.Format(
+                        "BR-CO-17: Berechneter Steuerbetrag ist[{0:0.0000}] aber vorhandener Steuerbetrag ist[{1:0.0000}] bei Bemessungsgrundlage[{2:0.0000}] und Steuersatz[{3:0.0000}]",
+                        expectedTaxAmount, tax.TaxAmount, tax.BasisAmount, tax.Percent));
+                    retval.IsValid = false;
+                }
             }
 
             decimal grandTotal = lineTotal - allowanceTotal + taxTotal + chargeTotal;
@@ -165,7 +167,9 @@ namespace s2industries.ZUGFeRD
                                      ));
 
 
-            decimal taxBasisTotal = descriptor.GetApplicableTradeTaxes().Sum(t => t.BasisAmount);
+            decimal taxBasisTotal = descriptor.GetApplicableTradeTaxes()
+                .Where(tax => tax.TypeCode == TaxTypes.VAT)
+                .Sum(tax => tax.BasisAmount);
             decimal allowanceTotalSummedPerTradeAllowanceCharge = descriptor.GetTradeAllowances().Sum(a => a.ActualAmount);
             decimal chargesTotalSummedPerTradeAllowanceCharge = descriptor.GetTradeCharges().Sum(c => c.ActualAmount);
 


### PR DESCRIPTION
## Summary
- validate each VAT breakdown against BR-CO-17 after rounding its calculated tax amount to two decimals
- sum the rounded VAT breakdown amounts for the invoice VAT total
- exclude additional Extended tax types from VAT totals and report a missing tax type explicitly
- cover multiple rates, equal rates in different categories, unrounded amounts, negative midpoint rounding, non-VAT taxes, and missing tax types

## Verification
- InvoiceValidatorTests: 17/17 passed on net8.0
- regression run excluding the unchanged TestSellerPartyDescription: 342/342 passed on net8.0
- multi-target library build: 0 errors; 176 existing warnings
