### PR TITLE
Enforce BR-Z-10 in the UBL writer

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -346,6 +346,33 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
+        [DataRow(ZUGFeRDVersion.Version20, ZUGFeRDFormats.CII, Profile.Extended)]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.CII, Profile.Extended)]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.UBL, Profile.XRechnung)]
+        public void TestVATBreakdownExemptionReasons(ZUGFeRDVersion version, ZUGFeRDFormats format, Profile profile)
+        {
+            InvoiceDescriptor descriptor = this._InvoiceProvider.CreateInvoice();
+            descriptor.AddApplicableTradeTax(10m, 0m, 0m, TaxTypes.VAT, TaxCategoryCodes.Z,
+                exemptionReasonCode: TaxExemptionReasonCodes.VATEX_EU_132, exemptionReason: "Zero rated reason");
+            descriptor.AddApplicableTradeTax(20m, 0m, 0m, TaxTypes.VAT, TaxCategoryCodes.E,
+                exemptionReasonCode: TaxExemptionReasonCodes.VATEX_EU_132, exemptionReason: "Exempt reason");
+
+            MemoryStream stream = new MemoryStream();
+            descriptor.Save(stream, version, profile, format);
+            stream.Seek(0, SeekOrigin.Begin);
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(stream);
+            Tax zeroRatedTax = loadedInvoice.Taxes.Single(tax => tax.CategoryCode == TaxCategoryCodes.Z);
+            Tax exemptTax = loadedInvoice.Taxes.Single(tax => tax.CategoryCode == TaxCategoryCodes.E);
+
+            Assert.AreEqual(String.Empty, zeroRatedTax.ExemptionReason);
+            Assert.IsNull(zeroRatedTax.ExemptionReasonCode);
+            Assert.AreEqual("Exempt reason", exemptTax.ExemptionReason);
+            Assert.AreEqual(TaxExemptionReasonCodes.VATEX_EU_132, exemptTax.ExemptionReasonCode);
+        } // !TestVATBreakdownExemptionReasons()
+
+
+        [TestMethod]
         [DataRow(ZUGFeRDVersion.Version1)]
         [DataRow(ZUGFeRDVersion.Version20)]
         [DataRow(ZUGFeRDVersion.Version23)]

--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -365,8 +365,10 @@ namespace s2industries.ZUGFeRD.Test
             Tax zeroRatedTax = loadedInvoice.Taxes.Single(tax => tax.CategoryCode == TaxCategoryCodes.Z);
             Tax exemptTax = loadedInvoice.Taxes.Single(tax => tax.CategoryCode == TaxCategoryCodes.E);
 
+            Assert.AreEqual(TaxTypes.VAT, zeroRatedTax.TypeCode);
             Assert.AreEqual(String.Empty, zeroRatedTax.ExemptionReason);
             Assert.IsNull(zeroRatedTax.ExemptionReasonCode);
+            Assert.AreEqual(TaxTypes.VAT, exemptTax.TypeCode);
             Assert.AreEqual("Exempt reason", exemptTax.ExemptionReason);
             Assert.AreEqual(TaxExemptionReasonCodes.VATEX_EU_132, exemptTax.ExemptionReasonCode);
         } // !TestVATBreakdownExemptionReasons()

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -1156,7 +1156,7 @@ namespace s2industries.ZUGFeRD
 
                 writer.WriteElementString("ram", "TypeCode", tax.TypeCode.EnumToString());
 
-                // no exemption reason for tax category Z (reverse charge) according to BR-Z-10
+                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
                 if (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z))
                 {
                     writer.WriteOptionalElementString("ram", "ExemptionReason", tax.ExemptionReason);
@@ -1184,7 +1184,7 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram", "CategoryCode", tax.CategoryCode.EnumToString());
                 }
 
-                // no exemption reason for tax category Z (reverse charge) according to BR-Z-10
+                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
                 if (tax.ExemptionReasonCode.HasValue &&
                     (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z)))
                 {

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -1156,7 +1156,7 @@ namespace s2industries.ZUGFeRD
 
                 writer.WriteElementString("ram", "TypeCode", tax.TypeCode.EnumToString());
 
-                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
+                // BR-Z-10 omits the CII 2.0 exemption reason text for zero-rated VAT breakdowns.
                 if (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z))
                 {
                     writer.WriteOptionalElementString("ram", "ExemptionReason", tax.ExemptionReason);
@@ -1184,7 +1184,7 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram", "CategoryCode", tax.CategoryCode.EnumToString());
                 }
 
-                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
+                // BR-Z-10 omits the CII 2.0 exemption reason code for zero-rated VAT breakdowns.
                 if (tax.ExemptionReasonCode.HasValue &&
                     (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z)))
                 {

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -1145,6 +1145,7 @@ namespace s2industries.ZUGFeRD
 
         private void _writeOptionalTaxes(ProfileAwareXmlTextWriter writer, InvoiceFormatOptions options)
         {
+            // BR-Z-10 omits exemption reason text and code from zero-rated CII 2.0 VAT breakdowns.
             foreach (Tax tax in this._Descriptor.GetApplicableTradeTaxes())
             {
                 _WriteComment(writer, options, InvoiceCommentConstants.ApplicableTradeTaxComment);
@@ -1156,7 +1157,6 @@ namespace s2industries.ZUGFeRD
 
                 writer.WriteElementString("ram", "TypeCode", tax.TypeCode.EnumToString());
 
-                // BR-Z-10 omits the CII 2.0 exemption reason text for zero-rated VAT breakdowns.
                 if (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z))
                 {
                     writer.WriteOptionalElementString("ram", "ExemptionReason", tax.ExemptionReason);
@@ -1184,7 +1184,6 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram", "CategoryCode", tax.CategoryCode.EnumToString());
                 }
 
-                // BR-Z-10 omits the CII 2.0 exemption reason code for zero-rated VAT breakdowns.
                 if (tax.ExemptionReasonCode.HasValue &&
                     (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z)))
                 {

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -497,11 +497,15 @@ namespace s2industries.ZUGFeRD
                         _Writer.WriteElementString("cbc", "Percent", _formatDecimal(tax.Percent));
                     }
 
-                    if (tax.ExemptionReasonCode.HasValue)
+                    // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
+                    if (!tax.CategoryCode.HasValue || tax.CategoryCode.Value != TaxCategoryCodes.Z)
                     {
-                        _Writer.WriteElementString("cbc", "TaxExemptionReasonCode", tax.ExemptionReasonCode.Value.EnumToString());
+                        if (tax.ExemptionReasonCode.HasValue)
+                        {
+                            _Writer.WriteElementString("cbc", "TaxExemptionReasonCode", tax.ExemptionReasonCode.Value.EnumToString());
+                        }
+                        _Writer.WriteOptionalElementString("cbc", "TaxExemptionReason", tax.ExemptionReason);
                     }
-                    _Writer.WriteOptionalElementString("cbc", "TaxExemptionReason", tax.ExemptionReason);
                     _Writer.WriteStartElement("cac", "TaxScheme");
                     _Writer.WriteElementString("cbc", "ID", tax.TypeCode.EnumToString());
                     _Writer.WriteEndElement(); // !TaxScheme

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1711,6 +1711,7 @@ namespace s2industries.ZUGFeRD
 
         private void _writeOptionalTaxes(ProfileAwareXmlTextWriter writer, InvoiceFormatOptions options)
         {
+            // BR-Z-10 omits exemption reason text and code from zero-rated CII 2.3 VAT breakdowns.
             this._Descriptor.GetApplicableTradeTaxes()?.ForEach(tax =>
             {
                 _WriteComment(writer, options, InvoiceCommentConstants.ApplicableTradeTaxComment);
@@ -1722,7 +1723,6 @@ namespace s2industries.ZUGFeRD
 
                 writer.WriteElementString("ram", "TypeCode", tax.TypeCode.EnumToString());
 
-                // BR-Z-10 omits the CII 2.3 exemption reason text for zero-rated VAT breakdowns.
                 if (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z))
                 {
                     writer.WriteOptionalElementString("ram", "ExemptionReason", tax.ExemptionReason);
@@ -1750,7 +1750,6 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram", "CategoryCode", tax.CategoryCode.EnumToString());
                 }
 
-                // BR-Z-10 omits the CII 2.3 exemption reason code for zero-rated VAT breakdowns.
                 if (tax.ExemptionReasonCode.HasValue &&
                     (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z)))
                 {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1722,7 +1722,7 @@ namespace s2industries.ZUGFeRD
 
                 writer.WriteElementString("ram", "TypeCode", tax.TypeCode.EnumToString());
 
-                // no exemption reason for tax category Z (reverse charge) according to BR-Z-10
+                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
                 if (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z))
                 {
                     writer.WriteOptionalElementString("ram", "ExemptionReason", tax.ExemptionReason);
@@ -1750,7 +1750,7 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram", "CategoryCode", tax.CategoryCode.EnumToString());
                 }
 
-                // no exemption reason for tax category Z (reverse charge) according to BR-Z-10
+                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
                 if (tax.ExemptionReasonCode.HasValue &&
                     (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z)))
                 {

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -1722,7 +1722,7 @@ namespace s2industries.ZUGFeRD
 
                 writer.WriteElementString("ram", "TypeCode", tax.TypeCode.EnumToString());
 
-                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
+                // BR-Z-10 omits the CII 2.3 exemption reason text for zero-rated VAT breakdowns.
                 if (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z))
                 {
                     writer.WriteOptionalElementString("ram", "ExemptionReason", tax.ExemptionReason);
@@ -1750,7 +1750,7 @@ namespace s2industries.ZUGFeRD
                     writer.WriteElementString("ram", "CategoryCode", tax.CategoryCode.EnumToString());
                 }
 
-                // BR-Z-10: zero-rated VAT breakdowns must not include exemption reasons.
+                // BR-Z-10 omits the CII 2.3 exemption reason code for zero-rated VAT breakdowns.
                 if (tax.ExemptionReasonCode.HasValue &&
                     (!tax.CategoryCode.HasValue || (tax.CategoryCode.Value != TaxCategoryCodes.Z)))
                 {


### PR DESCRIPTION
## Summary

- suppress `TaxExemptionReason` and `TaxExemptionReasonCode` for zero-rated VAT breakdowns in the UBL writer
- add cross-version coverage for CII 2.0, CII 2.3, and UBL
- preserve both exemption fields for VAT category `E` as a negative control
- correct CII comments that described category `Z` as reverse charge

## Specification

BR-Z-10 requires a VAT breakdown with category code `Z` to omit VAT exemption reason text (BT-120) and code (BT-121):
https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-Z-10/

## Verification

- targeted BR-Z-10 tests: 3 passed, 0 failed
- regression tests excluding the unchanged `TestSellerPartyDescription`: 345 passed, 0 failed
- multi-target library build: 0 errors
