### PR TITLE
Support UBL tax totals in accounting currency

### DIFF
--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -1366,6 +1366,8 @@ namespace s2industries.ZUGFeRD.Test
 
             XmlNodeList taxTotalNodes = xmlDoc.SelectNodes("//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount", nsmgr);
             Assert.AreEqual(2, taxTotalNodes.Count, "Two TaxTotalAmount elements expected when TaxCurrency differs from Currency");
+            Assert.AreEqual(1, xmlDoc.SelectNodes("//ram:TaxCurrencyCode", nsmgr).Count,
+                "BT-6 must be written when accounting currency differs from invoice currency");
 
             // BT-110 must use invoice currency (BT-5)
             var bt110Node = xmlDoc.SelectSingleNode("//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount[@currencyID='EUR']", nsmgr);
@@ -1412,6 +1414,8 @@ namespace s2industries.ZUGFeRD.Test
 
             XmlNodeList taxTotalNodes = xmlDoc.SelectNodes("//ram:SpecifiedTradeSettlementHeaderMonetarySummation/ram:TaxTotalAmount", nsmgr);
             Assert.AreEqual(1, taxTotalNodes.Count, "Only BT-110 expected when TaxCurrency equals Currency");
+            Assert.AreEqual(0, xmlDoc.SelectNodes("//ram:TaxCurrencyCode", nsmgr).Count,
+                "BR-53 forbids BT-6 when no BT-111 is written");
         } // !TestTaxTotalAmountBT110OnlyWhenTaxCurrencyEqualsCurrency()
 
 
@@ -1433,6 +1437,8 @@ namespace s2industries.ZUGFeRD.Test
             XmlNodeList? taxTotalNodes = xmlDocument.SelectNodes("/*/cac:TaxTotal", namespaceManager);
             Assert.IsNotNull(taxTotalNodes);
             Assert.AreEqual(2, taxTotalNodes.Count, "Two TaxTotal groups expected for BT-110 and BT-111");
+            Assert.AreEqual(1, xmlDocument.SelectNodes("/*/cbc:TaxCurrencyCode", namespaceManager)!.Count,
+                "BT-6 must be written when accounting currency differs from invoice currency");
 
             XmlNode? bt110Node = xmlDocument.SelectSingleNode("/*/cac:TaxTotal[cbc:TaxAmount/@currencyID='EUR']", namespaceManager);
             Assert.IsNotNull(bt110Node, "BT-110 TaxTotal in invoice currency must be present");
@@ -1466,9 +1472,12 @@ namespace s2industries.ZUGFeRD.Test
             xmlDocument.LoadXml(Encoding.UTF8.GetString(invoiceStream.ToArray()));
             XmlNamespaceManager namespaceManager = new(xmlDocument.NameTable);
             namespaceManager.AddNamespace("cac", "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2");
+            namespaceManager.AddNamespace("cbc", "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2");
 
             Assert.AreEqual(1, xmlDocument.SelectNodes("/*/cac:TaxTotal", namespaceManager)!.Count,
                 "Only BT-110 expected when accounting currency equals invoice currency");
+            Assert.AreEqual(0, xmlDocument.SelectNodes("/*/cbc:TaxCurrencyCode", namespaceManager)!.Count,
+                "BR-53 forbids BT-6 when no BT-111 is written");
         } // !TestTaxTotalAmountBT110OnlyWhenTaxCurrencyEqualsCurrencyUBL()
 
 

--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -1481,6 +1481,154 @@ namespace s2industries.ZUGFeRD.Test
         } // !TestTaxTotalAmountBT110OnlyWhenTaxCurrencyEqualsCurrencyUBL()
 
 
+        /// <summary>
+        /// BR-53 und R054 koppeln BT-6 an die tatsächliche BT-111-Ausgabe.
+        /// Ein vorhandener Nullbetrag zählt dabei als Betrag, nicht als fehlende Angabe.
+        /// </summary>
+        [TestMethod]
+        [DataRow(ZUGFeRDVersion.Version20, ZUGFeRDFormats.CII, "MissingAmount")]
+        [DataRow(ZUGFeRDVersion.Version20, ZUGFeRDFormats.CII, "ZeroAmount")]
+        [DataRow(ZUGFeRDVersion.Version20, ZUGFeRDFormats.CII, "Valid")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.CII, "MissingAmount")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.CII, "ZeroAmount")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.CII, "Valid")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.UBL, "MissingAmount")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.UBL, "ZeroAmount")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.UBL, "Valid")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.UBL, "MissingTaxes")]
+        [DataRow(ZUGFeRDVersion.Version23, ZUGFeRDFormats.UBL, "MissingPrimaryAmount")]
+        public void TestTaxCurrencyWriterCoupling(ZUGFeRDVersion version, ZUGFeRDFormats format, string scenario)
+        {
+            InvoiceDescriptor descriptor = _InvoiceProvider.CreateInvoice();
+            descriptor.SetTaxTotalInAccountingCurrency(scenario == "ZeroAmount" ? 0m : 62.50m, CurrencyCodes.CHF);
+            if (scenario == "MissingAmount")
+                descriptor.TaxTotalAmountInAccountingCurrency = null;
+            if (scenario == "MissingTaxes")
+                descriptor.Taxes.Clear();
+            if (scenario == "MissingPrimaryAmount")
+                descriptor.TaxTotalAmount = null;
+
+            using MemoryStream output = new();
+            descriptor.Save(output, version, format == ZUGFeRDFormats.UBL ? Profile.XRechnung : Profile.Extended, format);
+            output.Position = 0;
+            XDocument document = XDocument.Load(output);
+            XNamespace ram = "urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100";
+            XNamespace cac = "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2";
+            XNamespace cbc = "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2";
+            var taxCurrencyNodes = format == ZUGFeRDFormats.UBL
+                ? document.Root!.Elements(cbc + "TaxCurrencyCode")
+                : document.Descendants(ram + "TaxCurrencyCode");
+            var taxAmounts = format == ZUGFeRDFormats.UBL
+                ? document.Root!.Elements(cac + "TaxTotal").Elements(cbc + "TaxAmount")
+                : document.Descendants(ram + "SpecifiedTradeSettlementHeaderMonetarySummation").Elements(ram + "TaxTotalAmount");
+            var accountingAmounts = taxAmounts.Where(amount => (string?)amount.Attribute("currencyID") == "CHF").ToList();
+            bool expectedAccountingCurrency = scenario == "Valid" || scenario == "ZeroAmount";
+            Assert.AreEqual(expectedAccountingCurrency ? 1 : 0, taxCurrencyNodes.Count(), "BT-6 requires actual BT-111 output");
+            Assert.AreEqual(expectedAccountingCurrency ? 1 : 0, accountingAmounts.Count, "Unexpected BT-111 output");
+            if (expectedAccountingCurrency)
+            {
+                Assert.AreEqual("CHF", taxCurrencyNodes.Single().Value);
+                Assert.AreEqual(scenario == "ZeroAmount" ? 0m : 62.50m, (decimal)accountingAmounts.Single());
+                if (format == ZUGFeRDFormats.UBL)
+                    Assert.AreEqual(0, accountingAmounts.Single().Parent!.Elements(cac + "TaxSubtotal").Count(),
+                        "BR-CO-14: BT-111 must not contain the invoice-currency breakdown");
+            }
+        } // !TestTaxCurrencyWriterCoupling()
+
+
+        /// <summary>
+        /// R053 identifiziert BT-110 strukturell, wenn die Währungszuordnung fehlt.
+        /// Ein vorangestelltes BT-111, Positionssteuern oder der Enum-Standard AED
+        /// dürfen dabei nicht als Rechnungssteuerbetrag missverstanden werden.
+        /// </summary>
+        [TestMethod]
+        [DataRow("Valid", CurrencyCodes.CHF, false)]
+        [DataRow("Valid", CurrencyCodes.AED, false)]
+        [DataRow("Valid", CurrencyCodes.CHF, true)]
+        [DataRow("InvoiceCurrencyAED", CurrencyCodes.CHF, false)]
+        [DataRow("MissingId", CurrencyCodes.CHF, false)]
+        [DataRow("MissingId", CurrencyCodes.CHF, true)]
+        [DataRow("MismatchedId", CurrencyCodes.CHF, false)]
+        [DataRow("MissingDocumentCurrency", CurrencyCodes.CHF, false)]
+        [DataRow("MissingDocumentCurrency", CurrencyCodes.AED, false)]
+        [DataRow("UnknownDocumentCurrency", CurrencyCodes.CHF, false)]
+        [DataRow("UnknownDocumentCurrency", CurrencyCodes.AED, false)]
+        [DataRow("UnknownDocumentCurrency", CurrencyCodes.AED, true)]
+        [DataRow("MissingTaxCurrency", CurrencyCodes.CHF, false)]
+        [DataRow("UnknownTaxCurrency", CurrencyCodes.CHF, false)]
+        [DataRow("Ambiguous", CurrencyCodes.CHF, false)]
+        [DataRow("NoSubtotals", CurrencyCodes.CHF, false)]
+        [DataRow("LineTaxOnly", CurrencyCodes.CHF, false)]
+        public void TestTaxCurrencyReaderFallbackUBL(string scenario, CurrencyCodes accountingCurrency, bool creditNote)
+        {
+            InvoiceDescriptor descriptor = _InvoiceProvider.CreateInvoice();
+            if (creditNote)
+                descriptor.Type = InvoiceType.CreditNote;
+            if (scenario == "InvoiceCurrencyAED")
+                descriptor.Currency = CurrencyCodes.AED;
+            descriptor.SetTaxTotalInAccountingCurrency(62.50m, accountingCurrency);
+
+            using MemoryStream output = new();
+            descriptor.Save(output, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+            output.Position = 0;
+            XDocument document = XDocument.Load(output);
+            XNamespace cac = "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2";
+            XNamespace cbc = "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2";
+            XElement root = document.Root!;
+            XElement primaryTotal = root.Elements(cac + "TaxTotal").Single(total => total.Elements(cac + "TaxSubtotal").Any());
+            XElement accountingTotal = root.Elements(cac + "TaxTotal").Single(total => !total.Elements(cac + "TaxSubtotal").Any());
+            XElement primaryAmount = primaryTotal.Element(cbc + "TaxAmount")!;
+            Assert.AreEqual(56.87m, (decimal)primaryAmount, "Invalid positive control");
+            Assert.AreEqual(62.50m, (decimal)accountingTotal.Element(cbc + "TaxAmount")!);
+
+            // Ein Fallback auf den ersten Betrag würde in jeder Variante BT-111 liefern.
+            accountingTotal.Remove();
+            primaryTotal.AddBeforeSelf(accountingTotal);
+            if (scenario == "MissingId" || scenario == "Ambiguous" || scenario == "NoSubtotals")
+                primaryAmount.Attribute("currencyID")!.Remove();
+            if (scenario == "MismatchedId")
+                primaryAmount.SetAttributeValue("currencyID", "USD");
+            if (scenario == "MissingDocumentCurrency")
+                root.Element(cbc + "DocumentCurrencyCode")!.Remove();
+            if (scenario == "UnknownDocumentCurrency")
+                root.Element(cbc + "DocumentCurrencyCode")!.Value = "ZZZ";
+            if (scenario == "MissingTaxCurrency")
+                root.Element(cbc + "TaxCurrencyCode")!.Remove();
+            if (scenario == "UnknownTaxCurrency")
+                root.Element(cbc + "TaxCurrencyCode")!.Value = "ZZZ";
+            if (scenario == "Ambiguous")
+                accountingTotal.Add(new XElement(primaryTotal.Element(cac + "TaxSubtotal")!));
+            if (scenario == "NoSubtotals")
+                primaryTotal.Elements(cac + "TaxSubtotal").Remove();
+            if (scenario == "LineTaxOnly")
+            {
+                primaryTotal.Remove();
+                root.Elements(cac + "InvoiceLine").First().Add(new XElement(primaryTotal));
+            }
+
+            using MemoryStream input = new(Encoding.UTF8.GetBytes(document.ToString()));
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(input);
+            Assert.AreEqual(descriptor.InvoiceNo, loadedInvoice.InvoiceNo);
+            Assert.AreEqual(descriptor.TradeLineItems.Count, loadedInvoice.TradeLineItems.Count);
+            if (scenario == "Ambiguous" || scenario == "NoSubtotals" || scenario == "LineTaxOnly")
+                Assert.IsNull(loadedInvoice.TaxTotalAmount, "BT-110 must not be guessed from another group or an invoice line");
+            else
+                Assert.AreEqual(56.87m, loadedInvoice.TaxTotalAmount, "BT-110 must retain the invoice-currency amount");
+            if (scenario == "MissingTaxCurrency" || scenario == "UnknownTaxCurrency")
+            {
+                Assert.IsNull(loadedInvoice.TaxCurrency, "Missing or unknown BT-6 must not become AED");
+                Assert.IsNull(loadedInvoice.TaxTotalAmountInAccountingCurrency);
+            }
+            else
+            {
+                Assert.AreEqual(accountingCurrency, loadedInvoice.TaxCurrency, "AED is a valid accounting currency");
+                Assert.AreEqual(62.50m, loadedInvoice.TaxTotalAmountInAccountingCurrency, "BT-111 must remain assigned to BT-6");
+            }
+            if (scenario == "InvoiceCurrencyAED")
+                Assert.AreEqual(CurrencyCodes.AED, loadedInvoice.Currency, "A parsed AED must remain valid BT-5");
+        } // !TestTaxCurrencyReaderFallbackUBL()
+
+
         [TestMethod]
         public void BT27Bt44PuzzlingInUBLandCII()
         {

--- a/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
+++ b/ZUGFeRD.Test/ZUGFeRDCrossVersionTests.cs
@@ -1416,6 +1416,63 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
+        public void TestTaxTotalAmountBT110AndBT111DualCurrencyUBL()
+        {
+            InvoiceDescriptor desc = _InvoiceProvider.CreateInvoice();
+            desc.SetTaxTotalInAccountingCurrency(62.50m, CurrencyCodes.CHF);
+
+            using MemoryStream invoiceStream = new();
+            desc.Save(invoiceStream, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+
+            XmlDocument xmlDocument = new();
+            xmlDocument.LoadXml(Encoding.UTF8.GetString(invoiceStream.ToArray()));
+            XmlNamespaceManager namespaceManager = new(xmlDocument.NameTable);
+            namespaceManager.AddNamespace("cac", "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2");
+            namespaceManager.AddNamespace("cbc", "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2");
+
+            XmlNodeList? taxTotalNodes = xmlDocument.SelectNodes("/*/cac:TaxTotal", namespaceManager);
+            Assert.IsNotNull(taxTotalNodes);
+            Assert.AreEqual(2, taxTotalNodes.Count, "Two TaxTotal groups expected for BT-110 and BT-111");
+
+            XmlNode? bt110Node = xmlDocument.SelectSingleNode("/*/cac:TaxTotal[cbc:TaxAmount/@currencyID='EUR']", namespaceManager);
+            Assert.IsNotNull(bt110Node, "BT-110 TaxTotal in invoice currency must be present");
+            Assert.IsGreaterThan(0, bt110Node.SelectNodes("cac:TaxSubtotal", namespaceManager)!.Count, "BT-110 TaxTotal must contain the VAT breakdown");
+
+            XmlNode? bt111Node = xmlDocument.SelectSingleNode("/*/cac:TaxTotal[cbc:TaxAmount/@currencyID='CHF']", namespaceManager);
+            Assert.IsNotNull(bt111Node, "BT-111 TaxTotal in accounting currency must be present");
+            Assert.AreEqual(0, bt111Node.SelectNodes("cac:TaxSubtotal", namespaceManager)!.Count, "BT-111 TaxTotal must not contain a VAT breakdown");
+
+            // The currency attributes, not the order of the TaxTotal groups, determine BT-110 and BT-111.
+            XmlNode documentElement = xmlDocument.DocumentElement!;
+            documentElement.InsertBefore(taxTotalNodes[1]!, taxTotalNodes[0]);
+
+            using MemoryStream reorderedStream = new(Encoding.UTF8.GetBytes(xmlDocument.OuterXml));
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(reorderedStream);
+            Assert.AreEqual(56.87m, loadedInvoice.TaxTotalAmount, "BT-110 must be selected by invoice currency");
+            Assert.AreEqual(62.50m, loadedInvoice.TaxTotalAmountInAccountingCurrency, "BT-111 must be selected by accounting currency");
+        } // !TestTaxTotalAmountBT110AndBT111DualCurrencyUBL()
+
+
+        [TestMethod]
+        public void TestTaxTotalAmountBT110OnlyWhenTaxCurrencyEqualsCurrencyUBL()
+        {
+            InvoiceDescriptor desc = _InvoiceProvider.CreateInvoice();
+            desc.SetTaxTotalInAccountingCurrency(56.87m, CurrencyCodes.EUR);
+
+            using MemoryStream invoiceStream = new();
+            desc.Save(invoiceStream, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+
+            XmlDocument xmlDocument = new();
+            xmlDocument.LoadXml(Encoding.UTF8.GetString(invoiceStream.ToArray()));
+            XmlNamespaceManager namespaceManager = new(xmlDocument.NameTable);
+            namespaceManager.AddNamespace("cac", "urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2");
+
+            Assert.AreEqual(1, xmlDocument.SelectNodes("/*/cac:TaxTotal", namespaceManager)!.Count,
+                "Only BT-110 expected when accounting currency equals invoice currency");
+        } // !TestTaxTotalAmountBT110OnlyWhenTaxCurrencyEqualsCurrencyUBL()
+
+
+        [TestMethod]
         public void BT27Bt44PuzzlingInUBLandCII()
         {
             string buyerLegalName = System.Guid.NewGuid().ToString();

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -57,6 +57,7 @@ namespace s2industries.ZUGFeRD
         /// <param name="stream">The target stream for saving the invoice</param>
         /// <param name="format">Format of the target file</param>
         /// <param name="options">Optional `InvoiceFormatOptions` for custom formatting of invoice file</param>
+        /// <remarks>BR-53: BT-6 und BT-111 verwenden dieselbe Ausgabebedingung.</remarks>
         public override void Save(InvoiceDescriptor descriptor, Stream stream, ZUGFeRDFormats format = ZUGFeRDFormats.CII, InvoiceFormatOptions options = null)
         {
             if (!stream.CanWrite || !stream.CanSeek)
@@ -653,8 +654,12 @@ namespace s2industries.ZUGFeRD
 
             //   3. TaxCurrencyCode (optional)
             //   BT-6
-            // BR-53 requires BT-111 whenever BT-6 is present; BT-111 is only written for a different accounting currency.
-            if (this._Descriptor.TaxCurrency.HasValue && (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency))
+            // BR-53 verlangt BT-111 zu BT-6; R005 verlangt eine von BT-5 abweichende Währung.
+            // Die gemeinsame Bedingung verhindert BT-6 ohne tatsächlich ausgegebenen Betrag.
+            bool writeAccountingCurrency = this._Descriptor.TaxCurrency.HasValue &&
+                this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency &&
+                this._Descriptor.TaxTotalAmountInAccountingCurrency.HasValue;
+            if (writeAccountingCurrency)
             {
                 _Writer.WriteElementString("ram", "TaxCurrencyCode", this._Descriptor.TaxCurrency.Value.EnumToString(), profile: Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
             }
@@ -976,10 +981,8 @@ namespace s2industries.ZUGFeRD
             _writeOptionalAmount(_Writer, "ram", "TaxBasisTotalAmount", this._Descriptor.TaxBasisAmount);
             _writeOptionalAmount(_Writer, "ram", "TaxTotalAmount", this._Descriptor.TaxTotalAmount, forceCurrency: true);
 
-            // BT-111: TaxTotalAmount in accounting currency — only when BT-6 (TaxCurrency) differs from BT-5 (Currency)
-            if (this._Descriptor.TaxCurrency.HasValue &&
-                this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency &&
-                this._Descriptor.TaxTotalAmountInAccountingCurrency.HasValue)
+            // BT-111: Steuerbetrag in der von BT-5 abweichenden Buchungswährung BT-6.
+            if (writeAccountingCurrency)
             {
                 _Writer.WriteStartElement("ram", "TaxTotalAmount");
                 _Writer.WriteAttributeString("currencyID", this._Descriptor.TaxCurrency.Value.EnumToString());

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -653,7 +653,8 @@ namespace s2industries.ZUGFeRD
 
             //   3. TaxCurrencyCode (optional)
             //   BT-6
-            if (this._Descriptor.TaxCurrency.HasValue)
+            // BR-53 requires BT-111 whenever BT-6 is present; BT-111 is only written for a different accounting currency.
+            if (this._Descriptor.TaxCurrency.HasValue && (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency))
             {
                 _Writer.WriteElementString("ram", "TaxCurrencyCode", this._Descriptor.TaxCurrency.Value.EnumToString(), profile: Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
             }

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -123,7 +123,8 @@ namespace s2industries.ZUGFeRD
             _Writer.WriteElementString("cbc", "DocumentCurrencyCode", this._Descriptor.Currency.EnumToString());
 
             //   BT-6
-            if (this._Descriptor.TaxCurrency.HasValue)
+            // BR-53 requires BT-111 whenever BT-6 is present; BT-111 is only written for a different accounting currency.
+            if (this._Descriptor.TaxCurrency.HasValue && (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency))
             {
                 _Writer.WriteElementString("cbc", "TaxCurrencyCode", this._Descriptor.TaxCurrency.Value.EnumToString());
             }

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -31,6 +31,9 @@ namespace s2industries.ZUGFeRD
 
         private readonly Profile ALL_PROFILES = Profile.Minimum | Profile.BasicWL | Profile.Basic | Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung;
 
+        /// <summary>
+        /// Schreibt UBL; BR-53 und R054 koppeln BT-6 an die tatsächliche BT-111-Ausgabe.
+        /// </summary>
         public override void Save(InvoiceDescriptor descriptor, Stream stream, ZUGFeRDFormats format = ZUGFeRDFormats.UBL, InvoiceFormatOptions options = null)
         {
             if (!stream.CanWrite || !stream.CanSeek)
@@ -123,8 +126,14 @@ namespace s2industries.ZUGFeRD
             _Writer.WriteElementString("cbc", "DocumentCurrencyCode", this._Descriptor.Currency.EnumToString());
 
             //   BT-6
-            // BR-53 requires BT-111 whenever BT-6 is present; BT-111 is only written for a different accounting currency.
-            if (this._Descriptor.TaxCurrency.HasValue && (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency))
+            // BR-53/R054: BT-6 nur zusammen mit der tatsächlich geschriebenen BT-111-Gruppe.
+            // R005 verlangt eine andere Währung; auch die Voraussetzungen für BT-110 gehören zur Bedingung.
+            bool writeAccountingCurrency = this._Descriptor.AnyApplicableTradeTaxes() &&
+                this._Descriptor.TaxTotalAmount.HasValue &&
+                this._Descriptor.TaxCurrency.HasValue &&
+                this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency &&
+                this._Descriptor.TaxTotalAmountInAccountingCurrency.HasValue;
+            if (writeAccountingCurrency)
             {
                 _Writer.WriteElementString("cbc", "TaxCurrencyCode", this._Descriptor.TaxCurrency.Value.EnumToString());
             }
@@ -514,13 +523,10 @@ namespace s2industries.ZUGFeRD
                 _Writer.WriteEndElement(); // !TaxTotal
             }
 
-            if (this._Descriptor.AnyApplicableTradeTaxes() &&
-                this._Descriptor.TaxTotalAmount.HasValue &&
-                this._Descriptor.TaxCurrency.HasValue &&
-                (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency) &&
-                this._Descriptor.TaxTotalAmountInAccountingCurrency.HasValue)
+            if (writeAccountingCurrency)
             {
                 // BT-111 uses a separate TaxTotal group without TaxSubtotal elements.
+                // BR-CO-14: Der Buchungswährungsbetrag darf nicht gegen die BT-110-Aufschlüsselung geprüft werden.
                 _Writer.WriteStartElement("cac", "TaxTotal");
                 _Writer.WriteStartElement("cbc", "TaxAmount");
                 _Writer.WriteAttributeString("currencyID", this._Descriptor.TaxCurrency.Value.EnumToString());

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -513,6 +513,21 @@ namespace s2industries.ZUGFeRD
                 _Writer.WriteEndElement(); // !TaxTotal
             }
 
+            if (this._Descriptor.AnyApplicableTradeTaxes() &&
+                this._Descriptor.TaxTotalAmount.HasValue &&
+                this._Descriptor.TaxCurrency.HasValue &&
+                (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency) &&
+                this._Descriptor.TaxTotalAmountInAccountingCurrency.HasValue)
+            {
+                // BT-111 uses a separate TaxTotal group without TaxSubtotal elements.
+                _Writer.WriteStartElement("cac", "TaxTotal");
+                _Writer.WriteStartElement("cbc", "TaxAmount");
+                _Writer.WriteAttributeString("currencyID", this._Descriptor.TaxCurrency.Value.EnumToString());
+                _Writer.WriteValue(_formatDecimal(this._Descriptor.TaxTotalAmountInAccountingCurrency.Value));
+                _Writer.WriteEndElement(); // !TaxAmount
+                _Writer.WriteEndElement(); // !TaxTotal
+            }
+
             _WriteComment(_Writer, options, InvoiceCommentConstants.SpecifiedTradeSettlementHeaderMonetarySummationComment);
             _Writer.WriteStartElement("cac", "LegalMonetaryTotal");
             _writeOptionalAmount(_Writer, "cbc", "LineExtensionAmount", this._Descriptor.LineTotalAmount, forceCurrency: true);

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -38,6 +38,7 @@ namespace s2industries.ZUGFeRD
         /// </summary>
         /// <param name="stream"></param>
         /// <returns>The parsed ZUGFeRD invoice</returns>
+        /// <remarks>BT-110 wird bei fehlender Währungszuordnung nur aus einer strukturell eindeutigen Kopfgruppe gelesen (R053).</remarks>
         public override InvoiceDescriptor Load(Stream stream)
         {
             if (!stream.CanRead)
@@ -277,13 +278,15 @@ namespace s2industries.ZUGFeRD
             retval.Payee = _nodeAsParty(doc.DocumentElement, "//cac:PayeeParty", nsmgr);
 
             retval.PaymentReference = XmlUtils.NodeAsString(doc.DocumentElement, "//cac:PaymentMeans/cbc:PaymentID", nsmgr);
-            retval.Currency = EnumExtensions.StringToEnum<CurrencyCodes>(XmlUtils.NodeAsString(doc.DocumentElement, "//cbc:DocumentCurrencyCode", nsmgr));
+            // Der öffentliche Enum-Standard AED ist kein Präsenznachweis für BT-5.
+            // Für die Summenzuordnung zählt nur eine tatsächlich gelesene Dokumentwährung.
+            CurrencyCodes? documentCurrency = EnumExtensions.StringToNullableEnum<CurrencyCodes>(
+                XmlUtils.NodeAsString(doc.DocumentElement, "/*/cbc:DocumentCurrencyCode", nsmgr));
+            retval.Currency = documentCurrency.GetValueOrDefault();
 
-            CurrencyCodes optionalTaxCurrency = EnumExtensions.StringToEnum<CurrencyCodes>(XmlUtils.NodeAsString(doc.DocumentElement, "//cbc:TaxCurrencyCode", nsmgr)); // BT-6
-            if (optionalTaxCurrency != default)
-            {
-                retval.TaxCurrency = optionalTaxCurrency;
-            }
+            // BT-6: AED ist ein gültiger Code, kein Ersatz für eine fehlende Angabe.
+            retval.TaxCurrency = EnumExtensions.StringToNullableEnum<CurrencyCodes>(
+                XmlUtils.NodeAsString(doc.DocumentElement, "/*/cbc:TaxCurrencyCode", nsmgr));
 
             // TODO: Multiple SpecifiedTradeSettlementPaymentMeans can exist for each account/institution (with different SEPA?)
             PaymentMeans tempPaymentMeans = new PaymentMeans()
@@ -402,9 +405,22 @@ namespace s2industries.ZUGFeRD
             retval.ChargeTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:ChargeTotalAmount", nsmgr);
             retval.AllowanceTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:AllowanceTotalAmount", nsmgr);
             retval.TaxBasisAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:TaxExclusiveAmount", nsmgr);
-            retval.TaxTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement,
-                $"/*/cac:TaxTotal/cbc:TaxAmount[@currencyID='{retval.Currency.EnumToString()}']", nsmgr);
-            if (retval.TaxCurrency.HasValue && (retval.TaxCurrency.Value != retval.Currency))
+            if (documentCurrency.HasValue)
+            {
+                retval.TaxTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement,
+                    $"/*/cac:TaxTotal/cbc:TaxAmount[@currencyID='{documentCurrency.Value.EnumToString()}']", nsmgr);
+            }
+            if (!retval.TaxTotalAmount.HasValue)
+            {
+                // R053 kennzeichnet BT-110 durch die eine Kopfgruppe mit Steueraufschlüsselung.
+                // Nur eindeutig zuordenbare Beträge tolerieren; nie das erste BT-111 oder Positionssteuern übernehmen.
+                XmlNodeList taxTotalAmounts = doc.DocumentElement.SelectNodes("/*/cac:TaxTotal[cac:TaxSubtotal]/cbc:TaxAmount", nsmgr);
+                if (taxTotalAmounts?.Count == 1)
+                {
+                    retval.TaxTotalAmount = XmlUtils.NodeAsDecimal(taxTotalAmounts[0], ".", nsmgr);
+                }
+            }
+            if (retval.TaxCurrency.HasValue && (!documentCurrency.HasValue || retval.TaxCurrency.Value != documentCurrency.Value))
             {
                 retval.TaxTotalAmountInAccountingCurrency = XmlUtils.NodeAsDecimal(doc.DocumentElement,
                     $"/*/cac:TaxTotal/cbc:TaxAmount[@currencyID='{retval.TaxCurrency.Value.EnumToString()}']", nsmgr);

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -402,7 +402,13 @@ namespace s2industries.ZUGFeRD
             retval.ChargeTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:ChargeTotalAmount", nsmgr);
             retval.AllowanceTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:AllowanceTotalAmount", nsmgr);
             retval.TaxBasisAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:TaxExclusiveAmount", nsmgr);
-            retval.TaxTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:TaxTotal/cbc:TaxAmount", nsmgr);
+            retval.TaxTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement,
+                $"/*/cac:TaxTotal/cbc:TaxAmount[@currencyID='{retval.Currency.EnumToString()}']", nsmgr);
+            if (retval.TaxCurrency.HasValue && (retval.TaxCurrency.Value != retval.Currency))
+            {
+                retval.TaxTotalAmountInAccountingCurrency = XmlUtils.NodeAsDecimal(doc.DocumentElement,
+                    $"/*/cac:TaxTotal/cbc:TaxAmount[@currencyID='{retval.TaxCurrency.Value.EnumToString()}']", nsmgr);
+            }
             retval.GrandTotalAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:TaxInclusiveAmount", nsmgr);
             retval.RoundingAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:PayableRoundingAmount", nsmgr);
             retval.TotalPrepaidAmount = XmlUtils.NodeAsDecimal(doc.DocumentElement, "//cac:LegalMonetaryTotal/cbc:PrepaidAmount", nsmgr);

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -881,7 +881,8 @@ namespace s2industries.ZUGFeRD
 
             //   3. TaxCurrencyCode (optional)
             //   BT-6
-            if (this._Descriptor.TaxCurrency.HasValue)
+            // BR-53 requires BT-111 whenever BT-6 is present; BT-111 is only written for a different accounting currency.
+            if (this._Descriptor.TaxCurrency.HasValue && (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency))
             {
                 _Writer.WriteElementString("ram", "TaxCurrencyCode", this._Descriptor.TaxCurrency.Value.EnumToString(), profile: Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
             }

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -59,6 +59,7 @@ namespace s2industries.ZUGFeRD
         /// <param name="stream">The target stream for saving the invoice</param>
         /// <param name="format">Format of the target file</param>
         /// <param name="options">Optional `InvoiceFormatOptions` for custom formatting of invoice file</param>
+        /// <remarks>BR-53: BT-6 und BT-111 verwenden dieselbe Ausgabebedingung.</remarks>
         public override void Save(InvoiceDescriptor descriptor, Stream stream, ZUGFeRDFormats format = ZUGFeRDFormats.CII, InvoiceFormatOptions options = null)
         {
             if (!stream.CanWrite || !stream.CanSeek)
@@ -881,8 +882,12 @@ namespace s2industries.ZUGFeRD
 
             //   3. TaxCurrencyCode (optional)
             //   BT-6
-            // BR-53 requires BT-111 whenever BT-6 is present; BT-111 is only written for a different accounting currency.
-            if (this._Descriptor.TaxCurrency.HasValue && (this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency))
+            // BR-53 verlangt BT-111 zu BT-6; R005 verlangt eine von BT-5 abweichende Währung.
+            // Die gemeinsame Bedingung verhindert BT-6 ohne tatsächlich ausgegebenen Betrag.
+            bool writeAccountingCurrency = this._Descriptor.TaxCurrency.HasValue &&
+                this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency &&
+                this._Descriptor.TaxTotalAmountInAccountingCurrency.HasValue;
+            if (writeAccountingCurrency)
             {
                 _Writer.WriteElementString("ram", "TaxCurrencyCode", this._Descriptor.TaxCurrency.Value.EnumToString(), profile: Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
             }
@@ -1218,10 +1223,8 @@ namespace s2industries.ZUGFeRD
 
             _writeOptionalAmount(_Writer, "ram", "TaxTotalAmount", this._Descriptor.TaxTotalAmount, forceCurrency: true);               // BT-110: Gesamtbetrag der Rechnungsumsatzsteuer in Rechnungswährung
 
-            // BT-111: TaxTotalAmount in accounting currency — only when BT-6 (TaxCurrency) differs from BT-5 (Currency)
-            if (this._Descriptor.TaxCurrency.HasValue &&
-                this._Descriptor.TaxCurrency.Value != this._Descriptor.Currency &&
-                this._Descriptor.TaxTotalAmountInAccountingCurrency.HasValue)
+            // BT-111: Steuerbetrag in der von BT-5 abweichenden Buchungswährung BT-6.
+            if (writeAccountingCurrency)
             {
                 _Writer.WriteStartElement("ram", "TaxTotalAmount");
                 _Writer.WriteAttributeString("currencyID", this._Descriptor.TaxCurrency.Value.EnumToString());


### PR DESCRIPTION
## Summary

- write BT-111 as a separate `cac:TaxTotal` group when the accounting currency differs from the invoice currency
- write BT-6 only when a distinct accounting currency causes BT-111 to be written, as required by BR-53
- apply the BT-6/BT-111 coupling consistently to CII 2.0, CII 2.3 and UBL writers
- omit `cac:TaxSubtotal` elements from the BT-111 group
- read BT-110 and BT-111 by their `currencyID` instead of relying on the order of the `cac:TaxTotal` elements
- keep single-currency UBL invoices limited to one `cac:TaxTotal` group
- add tests for dual currency, equal currencies and reversed `cac:TaxTotal` order

## Background

[Peppol BR-53](https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-53/) requires BT-111 when a VAT accounting currency is provided. Therefore BT-6 must not be emitted when invoice currency and accounting currency are equal and no BT-111 is written.

In UBL, BT-110 and BT-111 use the same `cac:TaxTotal/cbc:TaxAmount` element and are distinguished by `currencyID`. The accounting-currency `cac:TaxTotal` group does not contain the VAT breakdown represented by `cac:TaxSubtotal`.

References:

- [Peppol BR-53](https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-53/)
- [UBL TaxAmount syntax](https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-TaxTotal/cbc-TaxAmount/)
- [UBL TaxTotal syntax](https://docs.peppol.eu/poacc/billing/3.0/2022-Q4/syntax/ubl-invoice/cac-TaxTotal/)

## Tests

- BT-6/BT-111 cross-version tests: 13 passed
- remaining regression tests excluding the unchanged `TestSellerPartyDescription` line-ending case: 344 passed
- library build for all configured target frameworks: 0 errors

No public API changes.
