### PR TITLE
Backport receiving advice references from ZUGFeRD-for-Delphi

### DIFF
--- a/ZUGFeRD.Test/XRechnungUBLTests.cs
+++ b/ZUGFeRD.Test/XRechnungUBLTests.cs
@@ -1227,6 +1227,34 @@ namespace s2industries.ZUGFeRD.Test
 
 
         [TestMethod]
+        public void TestReceivingAdviceReferencedDocumentRoundtrip()
+        {
+            string reference = Guid.NewGuid().ToString();
+            InvoiceDescriptor descriptor = _InvoiceProvider.CreateInvoice();
+            descriptor.SetReceivingAdviceReferencedDocument(reference, DateTime.Today);
+
+            using MemoryStream stream = new MemoryStream();
+            descriptor.Save(stream, ZUGFeRDVersion.Version23, Profile.XRechnung, ZUGFeRDFormats.UBL);
+            stream.Position = 0;
+
+            XmlDocument document = new XmlDocument();
+            document.Load(stream);
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(document.NameTable);
+            Assert.IsNotNull(document.DocumentElement);
+            namespaceManager.AddNamespace("cac", document.DocumentElement.GetNamespaceOfPrefix("cac"));
+            namespaceManager.AddNamespace("cbc", document.DocumentElement.GetNamespaceOfPrefix("cbc"));
+            Assert.AreEqual(reference, document.SelectSingleNode("/*/cac:ReceiptDocumentReference/cbc:ID", namespaceManager)?.InnerText);
+            Assert.IsNull(document.SelectSingleNode("/*/cac:ReceiptDocumentReference/cbc:IssueDate", namespaceManager));
+
+            stream.Position = 0;
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(stream);
+            Assert.IsNotNull(loadedInvoice.ReceivingAdviceReferencedDocument);
+            Assert.AreEqual(reference, loadedInvoice.ReceivingAdviceReferencedDocument.ID);
+            Assert.IsNull(loadedInvoice.ReceivingAdviceReferencedDocument.IssueDateTime);
+        } // !TestReceivingAdviceReferencedDocumentRoundtrip()
+
+
+        [TestMethod]
         public void TestSampleCreditNote326()
         {
             string path = @"..\..\..\..\demodata\xRechnung\ubl-cn-br-de-17-test-557-code-326.xml";

--- a/ZUGFeRD.Test/ZUGFeRD20Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD20Tests.cs
@@ -17,12 +17,67 @@
  * under the License.
  */
 
+using System.Xml;
+
 namespace s2industries.ZUGFeRD.Test
 {
     [TestClass]
     public class ZUGFeRD20Tests : TestBase
     {
         private InvoiceProvider _InvoiceProvider = new InvoiceProvider();
+
+        [TestMethod]
+        [DataRow(Profile.Minimum, false)]
+        [DataRow(Profile.BasicWL, false)]
+        [DataRow(Profile.Basic, false)]
+        [DataRow(Profile.Comfort, true)]
+        [DataRow(Profile.Extended, true)]
+        public void TestReceivingAdviceReferencedDocumentProfileBoundaries(Profile profile, bool expected)
+        {
+            InvoiceDescriptor descriptor = _InvoiceProvider.CreateInvoice();
+            descriptor.SetReceivingAdviceReferencedDocument("RECEIPT-20", new DateTime(2026, 8, 15));
+
+            using MemoryStream stream = new MemoryStream();
+            descriptor.Save(stream, ZUGFeRDVersion.Version20, profile);
+            stream.Position = 0;
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(stream);
+            Assert.AreEqual(expected, loadedInvoice.ReceivingAdviceReferencedDocument != null);
+            if (expected)
+            {
+                DateTime? expectedDate = profile == Profile.Extended ? new DateTime(2026, 8, 15) : (DateTime?)null;
+                ReceivingAdviceReferencedDocument receivingAdvice = loadedInvoice.ReceivingAdviceReferencedDocument;
+                Assert.IsNotNull(receivingAdvice);
+                Assert.AreEqual("RECEIPT-20", receivingAdvice.ID);
+                Assert.AreEqual(expectedDate, receivingAdvice.IssueDateTime);
+            }
+        } // !TestReceivingAdviceReferencedDocumentProfileBoundaries()
+
+
+        [TestMethod]
+        public void TestReceivingAdviceReferencedDocumentOrder()
+        {
+            InvoiceDescriptor descriptor = _InvoiceProvider.CreateInvoice();
+            descriptor.SetReceivingAdviceReferencedDocument("RECEIPT-20");
+            descriptor.SetDeliveryNoteReferenceDocument("DELIVERY-20");
+
+            using MemoryStream stream = new MemoryStream();
+            descriptor.Save(stream, ZUGFeRDVersion.Version20, Profile.Extended);
+            stream.Position = 0;
+
+            XmlDocument document = new XmlDocument();
+            document.Load(stream);
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(document.NameTable);
+            namespaceManager.AddNamespace("ram", document.DocumentElement.GetNamespaceOfPrefix("ram"));
+            XmlNode? receivingAdviceNode = document.SelectSingleNode("//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument", namespaceManager);
+            XmlNode? deliveryNoteNode = document.SelectSingleNode("//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument", namespaceManager);
+
+            Assert.IsNotNull(receivingAdviceNode);
+            Assert.IsNotNull(deliveryNoteNode);
+            Assert.IsTrue(receivingAdviceNode.ParentNode.ChildNodes.Cast<XmlNode>().ToList().IndexOf(receivingAdviceNode)
+                < deliveryNoteNode.ParentNode.ChildNodes.Cast<XmlNode>().ToList().IndexOf(deliveryNoteNode));
+        } // !TestReceivingAdviceReferencedDocumentOrder()
+
 
         [TestMethod]
         public void TestLineStatusCode()

--- a/ZUGFeRD.Test/ZUGFeRD22Tests.cs
+++ b/ZUGFeRD.Test/ZUGFeRD22Tests.cs
@@ -29,6 +29,66 @@ namespace s2industries.ZUGFeRD.Test
     {
         private InvoiceProvider _InvoiceProvider = new InvoiceProvider();
 
+        [TestMethod]
+        [DataRow(Profile.Minimum, false)]
+        [DataRow(Profile.BasicWL, false)]
+        [DataRow(Profile.Basic, false)]
+        [DataRow(Profile.Comfort, true)]
+        [DataRow(Profile.Extended, true)]
+        [DataRow(Profile.XRechnung1, true)]
+        [DataRow(Profile.XRechnung, true)]
+        public void TestReceivingAdviceReferencedDocumentProfileBoundaries(Profile profile, bool expected)
+        {
+            InvoiceDescriptor descriptor = _InvoiceProvider.CreateInvoice();
+            descriptor.SetReceivingAdviceReferencedDocument("RECEIPT-23", new DateTime(2026, 8, 15));
+
+            using MemoryStream stream = new MemoryStream();
+            descriptor.Save(stream, ZUGFeRDVersion.Version23, profile);
+            stream.Position = 0;
+
+            InvoiceDescriptor loadedInvoice = InvoiceDescriptor.Load(stream);
+            Assert.AreEqual(expected, loadedInvoice.ReceivingAdviceReferencedDocument != null);
+            if (expected)
+            {
+                DateTime? expectedDate = profile == Profile.Extended ? new DateTime(2026, 8, 15) : (DateTime?)null;
+                ReceivingAdviceReferencedDocument receivingAdvice = loadedInvoice.ReceivingAdviceReferencedDocument;
+                Assert.IsNotNull(receivingAdvice);
+                Assert.AreEqual("RECEIPT-23", receivingAdvice.ID);
+                Assert.AreEqual(expectedDate, receivingAdvice.IssueDateTime);
+            }
+        } // !TestReceivingAdviceReferencedDocumentProfileBoundaries()
+
+
+        [TestMethod]
+        public void TestReceivingAdviceReferencedDocumentOrder()
+        {
+            InvoiceDescriptor descriptor = _InvoiceProvider.CreateInvoice();
+            descriptor.SetDespatchAdviceReferencedDocument("DESPATCH-23");
+            descriptor.SetReceivingAdviceReferencedDocument("RECEIPT-23");
+            descriptor.SetDeliveryNoteReferenceDocument("DELIVERY-23");
+
+            using MemoryStream stream = new MemoryStream();
+            descriptor.Save(stream, ZUGFeRDVersion.Version23, Profile.Extended);
+            stream.Position = 0;
+
+            XmlDocument document = new XmlDocument();
+            document.Load(stream);
+            XmlNamespaceManager namespaceManager = new XmlNamespaceManager(document.NameTable);
+            namespaceManager.AddNamespace("ram", document.DocumentElement.GetNamespaceOfPrefix("ram"));
+            XmlNode? despatchAdviceNode = document.SelectSingleNode("//ram:ApplicableHeaderTradeDelivery/ram:DespatchAdviceReferencedDocument", namespaceManager);
+            XmlNode? receivingAdviceNode = document.SelectSingleNode("//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument", namespaceManager);
+            XmlNode? deliveryNoteNode = document.SelectSingleNode("//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument", namespaceManager);
+
+            Assert.IsNotNull(despatchAdviceNode);
+            Assert.IsNotNull(receivingAdviceNode);
+            Assert.IsNotNull(deliveryNoteNode);
+            Assert.IsNotNull(receivingAdviceNode.ParentNode);
+            List<XmlNode> deliveryChildren = receivingAdviceNode.ParentNode.ChildNodes.Cast<XmlNode>().ToList();
+            Assert.IsTrue(deliveryChildren.IndexOf(despatchAdviceNode) < deliveryChildren.IndexOf(receivingAdviceNode));
+            Assert.IsTrue(deliveryChildren.IndexOf(receivingAdviceNode) < deliveryChildren.IndexOf(deliveryNoteNode));
+        } // !TestReceivingAdviceReferencedDocumentOrder()
+
+
 
 
         [TestMethod]

--- a/ZUGFeRD/InvoiceDescriptor.cs
+++ b/ZUGFeRD/InvoiceDescriptor.cs
@@ -74,6 +74,13 @@ namespace s2industries.ZUGFeRD
         public DespatchAdviceReferencedDocument DespatchAdviceReferencedDocument { get; internal set; } = null;
 
         /// <summary>
+        /// Detailed information about the corresponding receiving advice
+        ///
+        /// BT-15
+        /// </summary>
+        public ReceivingAdviceReferencedDocument ReceivingAdviceReferencedDocument { get; internal set; } = null;
+
+        /// <summary>
         /// Detailed information about the corresponding delivery note
         /// </summary>
         public DeliveryNoteReferencedDocument DeliveryNoteReferencedDocument { get; set; } = null;
@@ -1024,6 +1031,20 @@ namespace s2industries.ZUGFeRD
                 IssueDateTime = despatchAdviceDate
             };
         } // !SetDespatchAdviceReferencedDocument()
+
+        /// <summary>
+        /// Sets the receiving advice reference information
+        /// </summary>
+        /// <param name="receivingAdviceNo">Receiving advice number</param>
+        /// <param name="receivingAdviceDate">Receiving advice date</param>
+        public void SetReceivingAdviceReferencedDocument(string receivingAdviceNo, DateTime? receivingAdviceDate = null)
+        {
+            this.ReceivingAdviceReferencedDocument = new ReceivingAdviceReferencedDocument()
+            {
+                ID = receivingAdviceNo,
+                IssueDateTime = receivingAdviceDate
+            };
+        } // !SetReceivingAdviceReferencedDocument()
 
         /// <summary>
         /// Sets the delivery note reference information

--- a/ZUGFeRD/InvoiceDescriptor20Reader.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Reader.cs
@@ -160,6 +160,16 @@ namespace s2industries.ZUGFeRD
             retval.ShipFrom = _nodeAsParty(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:ShipFromTradeParty", nsmgr);
             retval.ActualDeliveryDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:ActualDeliverySupplyChainEvent/ram:OccurrenceDateTime/udt:DateTimeString", nsmgr);
 
+            XmlNode receivingAdviceReferencedDocumentNode = doc.DocumentElement.SelectSingleNode("//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument", nsmgr);
+            if (receivingAdviceReferencedDocumentNode != null)
+            {
+                retval.ReceivingAdviceReferencedDocument = new ReceivingAdviceReferencedDocument()
+                {
+                    ID = XmlUtils.NodeAsString(receivingAdviceReferencedDocumentNode, "ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(receivingAdviceReferencedDocumentNode, "ram:FormattedIssueDateTime", nsmgr)
+                };
+            }
+
             string deliveryNoteNo = XmlUtils.NodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:ID", nsmgr);
             DateTime? deliveryNoteDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssueDateTime/udt:DateTimeString", nsmgr);
 

--- a/ZUGFeRD/InvoiceDescriptor20Writer.cs
+++ b/ZUGFeRD/InvoiceDescriptor20Writer.cs
@@ -602,6 +602,24 @@ namespace s2industries.ZUGFeRD
                 _Writer.WriteEndElement(); // !ActualDeliverySupplyChainEvent
             }
 
+            if (this._Descriptor.ReceivingAdviceReferencedDocument != null)
+            {
+                _Writer.WriteStartElement("ram", "ReceivingAdviceReferencedDocument", PROFILE_COMFORT_EXTENDED_XRECHNUNG);
+                _Writer.WriteElementString("ram", "IssuerAssignedID", this._Descriptor.ReceivingAdviceReferencedDocument.ID);
+
+                if (this._Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.HasValue)
+                {
+                    _Writer.WriteStartElement("ram", "FormattedIssueDateTime", Profile.Extended);
+                    _Writer.WriteStartElement("qdt", "DateTimeString");
+                    _Writer.WriteAttributeString("format", "102");
+                    _Writer.WriteValue(_formatDate(this._Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.Value));
+                    _Writer.WriteEndElement(); // !qdt:DateTimeString
+                    _Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+                }
+
+                _Writer.WriteEndElement(); // !ReceivingAdviceReferencedDocument
+            }
+
             if (this._Descriptor.DeliveryNoteReferencedDocument != null)
             {
                 _Writer.WriteStartElement("ram", "DeliveryNoteReferencedDocument");

--- a/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UBLWriter.cs
@@ -200,6 +200,14 @@ namespace s2industries.ZUGFeRD
                 _Writer.WriteEndElement(); // !DespatchDocumentReference
             }
 
+            // ReceiptDocumentReference
+            if (this._Descriptor.ReceivingAdviceReferencedDocument != null)
+            {
+                _Writer.WriteStartElement("cac", "ReceiptDocumentReference", Profile.Comfort | Profile.Extended | Profile.XRechnung1 | Profile.XRechnung);
+                _Writer.WriteOptionalElementString("cbc", "ID", this._Descriptor.ReceivingAdviceReferencedDocument.ID);
+                _Writer.WriteEndElement(); // !ReceiptDocumentReference
+            }
+
             // ContractDocumentReference
             if (this._Descriptor.ContractReferencedDocument != null)
             {

--- a/ZUGFeRD/InvoiceDescriptor22UblReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor22UblReader.cs
@@ -393,6 +393,12 @@ namespace s2industries.ZUGFeRD
                 retval.SetDespatchAdviceReferencedDocument(despatchDocumentReferenceIdNode.InnerText);
             }
 
+            XmlNode receiptDocumentReferenceIdNode = baseNode.SelectSingleNode("./cac:ReceiptDocumentReference/cbc:ID", nsmgr);
+            if (receiptDocumentReferenceIdNode != null)
+            {
+                retval.SetReceivingAdviceReferencedDocument(receiptDocumentReferenceIdNode.InnerText);
+            }
+
             retval.AddTradePaymentTerms(
                 description: XmlUtils.NodeAsString(doc.DocumentElement, "//cac:PaymentTerms/cbc:Note", nsmgr),
                 dueDate: XmlUtils.NodeAsDateTime(doc.DocumentElement, "//cbc:DueDate", nsmgr)

--- a/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIReader.cs
@@ -235,6 +235,16 @@ namespace s2industries.ZUGFeRD
                 };
             }
 
+            XmlNode receivingAdviceReferencedDocumentNode = doc.DocumentElement.SelectSingleNode("//ram:ApplicableHeaderTradeDelivery/ram:ReceivingAdviceReferencedDocument", nsmgr);
+            if (receivingAdviceReferencedDocumentNode != null)
+            {
+                retval.ReceivingAdviceReferencedDocument = new ReceivingAdviceReferencedDocument()
+                {
+                    ID = XmlUtils.NodeAsString(receivingAdviceReferencedDocumentNode, "ram:IssuerAssignedID", nsmgr),
+                    IssueDateTime = DataTypeReader.ReadFormattedIssueDateTime(receivingAdviceReferencedDocumentNode, "ram:FormattedIssueDateTime", nsmgr)
+                };
+            }
+
             string deliveryNoteID = XmlUtils.NodeAsString(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:IssuerAssignedID", nsmgr);
             DateTime? deliveryNoteDate = XmlUtils.NodeAsDateTime(doc.DocumentElement, "//ram:ApplicableHeaderTradeDelivery/ram:DeliveryNoteReferencedDocument/ram:FormattedIssueDateTime/udt:DateTimeString", nsmgr);
 

--- a/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
+++ b/ZUGFeRD/InvoiceDescriptor23CIIWriter.cs
@@ -821,6 +821,26 @@ namespace s2industries.ZUGFeRD
             }
             #endregion
 
+            #region ReceivingAdviceReferencedDocument
+            if (this._Descriptor.ReceivingAdviceReferencedDocument != null)
+            {
+                _Writer.WriteStartElement("ram", "ReceivingAdviceReferencedDocument", PROFILE_COMFORT_EXTENDED_XRECHNUNG); // CII-SR-174 is a warning only
+                _Writer.WriteElementString("ram", "IssuerAssignedID", this._Descriptor.ReceivingAdviceReferencedDocument.ID);
+
+                if (this._Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.HasValue)
+                {
+                    _Writer.WriteStartElement("ram", "FormattedIssueDateTime", Profile.Extended);
+                    _Writer.WriteStartElement("qdt", "DateTimeString");
+                    _Writer.WriteAttributeString("format", "102");
+                    _Writer.WriteValue(_formatDate(this._Descriptor.ReceivingAdviceReferencedDocument.IssueDateTime.Value));
+                    _Writer.WriteEndElement(); // !qdt:DateTimeString
+                    _Writer.WriteEndElement(); // !ram:FormattedIssueDateTime
+                }
+
+                _Writer.WriteEndElement(); // !ReceivingAdviceReferencedDocument
+            }
+            #endregion
+
             #region DeliveryNoteReferencedDocument
             if (this._Descriptor.DeliveryNoteReferencedDocument != null)
             {

--- a/ZUGFeRD/ReceivingAdviceReferencedDocument.cs
+++ b/ZUGFeRD/ReceivingAdviceReferencedDocument.cs
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace s2industries.ZUGFeRD
+{
+    /// <summary>
+    /// Structure containing detailed information about the corresponding receiving advice
+    /// </summary>
+    public class ReceivingAdviceReferencedDocument : BaseReferencedDocument
+    {
+    }
+}


### PR DESCRIPTION
## Summary

This pull request backports the `ReceivingAdviceReferencedDocument` implementation developed by MGGM for the Landrix ZUGFeRD-for-Delphi library.

The corresponding Delphi implementation is available in [LandrixSoftware/ZUGFeRD-for-Delphi#104](https://github.com/LandrixSoftware/ZUGFeRD-for-Delphi/pull/104).

- add `ReceivingAdviceReferencedDocument` and the corresponding `InvoiceDescriptor` API for EN 16931 BT-15
- read and write the reference in CII 2.0 and CII 2.3
- preserve the schema-defined order between despatch advice, receiving advice, and delivery note references
- write the optional issue date only for the Extended profile
- omit the reference from profiles whose schemas do not support it
- map the reference to UBL `cac:ReceiptDocumentReference/cbc:ID`
- do not write the CII-specific issue date as UBL `cbc:IssueDate`
- add profile-boundary, XML-ordering, reader, writer, and UBL round-trip tests

The implementation follows the existing C# patterns but retains the behavior and profile boundaries established and tested in the Delphi implementation.

## Specification references

- [Peppol BIS: Despatch and receipt advice references](https://docs.peppol.eu/poacc/billing/3.0/bis/#_despatch_and_receipt_advice_references)
- [Peppol UBL syntax: ReceiptDocumentReference](https://docs.peppol.eu/poacc/billing/3.0/2022-Q4/syntax/ubl-invoice/cac-ReceiptDocumentReference/)

## Validation

- focused Receiving Advice tests: 15 passed, 0 failed, 0 skipped