### PR TITLE
Backport Delphi invoice validation corrections

### DIFF
--- a/ZUGFeRD.Test/InvoiceValidatorTests.cs
+++ b/ZUGFeRD.Test/InvoiceValidatorTests.cs
@@ -80,6 +80,25 @@ namespace s2industries.ZUGFeRD.Test
         }
 
 
+        private static InvoiceDescriptor CreateInvoiceWithPriceBaseQuantity(decimal netQuantity)
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-PRICE-BASE", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            TradeLineItem lineItem = descriptor.AddTradeLineItem(
+                name: "Test item",
+                netUnitPrice: 100m,
+                unitCode: QuantityCodes.H87,
+                billedQuantity: 2m,
+                lineTotalAmount: 20m,
+                taxType: TaxTypes.VAT,
+                categoryCode: TaxCategoryCodes.S,
+                taxPercent: 19m);
+            lineItem.NetQuantity = netQuantity;
+            descriptor.AddApplicableTradeTax(20m, 19m, 3.80m, TaxTypes.VAT, TaxCategoryCodes.S);
+            descriptor.SetTotals(20m, 0m, 0m, 20m, 3.80m, 23.80m, 0m, 23.80m);
+            return descriptor;
+        }
+
+
         [TestMethod]
         public void ValidTaxBasisAmountIsAccepted()
         {
@@ -114,6 +133,86 @@ namespace s2industries.ZUGFeRD.Test
 
             Assert.IsFalse(result.IsValid);
             Assert.IsTrue(result.Messages.Any(message => message.Contains("taxBasisTotal", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void ConsistentlyWrongTaxBasisIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.Taxes[0].BasisAmount = 190m;
+            descriptor.Taxes[0].TaxAmount = 36.10m;
+            descriptor.TaxBasisAmount = 190m;
+            descriptor.TaxTotalAmount = 36.10m;
+            descriptor.GrandTotalAmount = 236.10m;
+            descriptor.DuePayableAmount = 236.10m;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-13", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void DeclaredAllowanceTotalDeviationIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.AllowanceTotalAmount = 15m;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-11", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void DeclaredChargeTotalDeviationIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.ChargeTotalAmount = 20m;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-12", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void MissingLineTotalAmountIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateBalancedInvoice();
+            descriptor.LineTotalAmount = null;
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("Kein LineTotalAmount vorhanden", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void PriceBaseQuantityIsApplied()
+        {
+            InvoiceDescriptor descriptor = CreateInvoiceWithPriceBaseQuantity(10m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+        }
+
+
+        [TestMethod]
+        public void ZeroPriceBaseQuantityIsReported()
+        {
+            InvoiceDescriptor descriptor = CreateInvoiceWithPriceBaseQuantity(0m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BT-149", StringComparison.Ordinal)));
         }
 
 
@@ -238,7 +337,50 @@ namespace s2industries.ZUGFeRD.Test
             ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
 
             Assert.IsFalse(result.IsValid);
-            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-17", StringComparison.Ordinal)));
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-DEC-20", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void TaxAmountWithinBRCO17ToleranceIsAcceptedAndLogged()
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-TOLERANCE-OK", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            AddTaxGroup(descriptor, "Standard rate", 100m, 19m, 19.50m, TaxCategoryCodes.S);
+            descriptor.SetTotals(100m, 0m, 0m, 100m, 19.50m, 119.50m, 0m, 119.50m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-17 tolerance", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void ExactFacturXBRCO17BoundaryIsAcceptedAndLogged()
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-TOLERANCE-BOUNDARY", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            AddTaxGroup(descriptor, "Standard rate", 100m, 19m, 20.00m, TaxCategoryCodes.S);
+            descriptor.SetTotals(100m, 0m, 0m, 100m, 20.00m, 120.00m, 0m, 120.00m);
+
+            // Validation is profile-independent, so preserve the inclusive Factur-X 1.08/1.09 boundary here.
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsTrue(result.IsValid, string.Join(Environment.NewLine, result.Messages));
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-17 tolerance", StringComparison.Ordinal)));
+        }
+
+
+        [TestMethod]
+        public void TaxAmountBeyondBRCO17ToleranceIsReported()
+        {
+            InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-TOLERANCE-FAIL", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
+            AddTaxGroup(descriptor, "Standard rate", 100m, 19m, 20.50m, TaxCategoryCodes.S);
+            descriptor.SetTotals(100m, 0m, 0m, 100m, 20.50m, 120.50m, 0m, 120.50m);
+
+            ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
+
+            Assert.IsFalse(result.IsValid);
+            Assert.IsTrue(result.Messages.Any(message => message.Contains("BR-CO-17:", StringComparison.Ordinal)));
         }
 
 
@@ -284,9 +426,9 @@ namespace s2industries.ZUGFeRD.Test
         public void TaxAmountDeviationsWithinSameRateAreReported()
         {
             InvoiceDescriptor descriptor = InvoiceDescriptor.CreateInvoice("RE-ROUND-CATEGORY", new DateTime(2026, 1, 15), CurrencyCodes.EUR);
-            AddTaxGroup(descriptor, "Standard rate", 1m, 7m, 0.08m, TaxCategoryCodes.S);
-            AddTaxGroup(descriptor, "Lower rate", 1m, 7m, 0.06m, TaxCategoryCodes.AA);
-            descriptor.SetTotals(2m, 0m, 0m, 2m, 0.14m, 2.14m, 0m, 2.14m);
+            AddTaxGroup(descriptor, "Standard rate", 100m, 7m, 9.00m, TaxCategoryCodes.S);
+            AddTaxGroup(descriptor, "Lower rate", 100m, 7m, 5.00m, TaxCategoryCodes.AA);
+            descriptor.SetTotals(200m, 0m, 0m, 200m, 14.00m, 214.00m, 0m, 214.00m);
 
             ValidationResult result = InvoiceValidator.Validate(descriptor, ZUGFeRDVersion.Version23);
 

--- a/ZUGFeRD/InvoiceValidator.cs
+++ b/ZUGFeRD/InvoiceValidator.cs
@@ -71,6 +71,20 @@ namespace s2industries.ZUGFeRD
             {
                 decimal total = decimal.Multiply(item.NetUnitPrice, item.BilledQuantity);
 
+                // BT-146 is stated per price base quantity BT-149; an absent base quantity means 1.
+                if (item.NetQuantity.HasValue)
+                {
+                    if (item.NetQuantity.Value > 0m)
+                    {
+                        total /= item.NetQuantity.Value;
+                    }
+                    else
+                    {
+                        retval.Messages.Add(String.Format("BT-149: Price base quantity for line item [{0}] must be greater than 0", item.Name));
+                        retval.IsValid = false;
+                    }
+                }
+
                 // BT-131 includes BG-28 line charges and excludes BG-27 line allowances.
                 total -= item.GetSpecifiedTradeAllowances().Sum(allowance => allowance.ActualAmount);
                 total += item.GetSpecifiedTradeCharges().Sum(charge => charge.ActualAmount);
@@ -97,17 +111,17 @@ namespace s2industries.ZUGFeRD
             decimal chargeTotal = 0.0m;
             foreach (TradeCharge charge in descriptor.GetTradeCharges())
             {
-                retval.Messages.Add(String.Format("==> added {0:0.00} to {1:0.00}%", -charge.Amount, charge.Tax.Percent));
+                retval.Messages.Add(String.Format("==> added {0:0.00} to {1:0.00}%", charge.ActualAmount, charge.Tax.Percent));
 
-                chargeTotal += charge.Amount;
+                chargeTotal += charge.ActualAmount;
             }
 
             decimal allowanceTotal = 0.0m;
             foreach (TradeAllowance allowance in descriptor.GetTradeAllowances())
             {
-                retval.Messages.Add(String.Format("==> added {0:0.00} to {1:0.00}%", -allowance.Amount, allowance.Tax.Percent));
+                retval.Messages.Add(String.Format("==> subtracted {0:0.00} from {1:0.00}%", allowance.ActualAmount, allowance.Tax.Percent));
 
-                allowanceTotal += allowance.Amount;
+                allowanceTotal += allowance.ActualAmount;
             }
 
             retval.Messages.Add("Adding tax amounts from invoice service charge...");
@@ -131,19 +145,42 @@ namespace s2industries.ZUGFeRD
                     continue;
                 }
 
-                // BR-CO-17 requires rounding each VAT breakdown before summing the amounts to BT-110.
+                // BR-CO-17 recalculates and rounds each VAT breakdown independently.
                 decimal expectedTaxAmount = Math.Round(tax.BasisAmount * tax.Percent / 100m, 2, MidpointRounding.AwayFromZero);
-                taxTotal += expectedTaxAmount;
+                // BR-CO-14 derives BT-110 from declared BT-117 values, including tolerated BR-CO-17 deviations.
+                taxTotal += tax.TaxAmount;
                 retval.Messages.Add(String.Format("===> {0:0.0000} x {1:0.00}% = {2:0.00}", tax.BasisAmount, tax.Percent, expectedTaxAmount));
 
-                if (tax.TaxAmount != expectedTaxAmount)
+                // BR-DEC-20 limits BT-117 to two decimal places.
+                if (tax.TaxAmount != Math.Round(tax.TaxAmount, 2, MidpointRounding.AwayFromZero))
+                {
+                    retval.Messages.Add(String.Format(
+                        "BR-DEC-20: Declared tax amount [{0:0.0000}] has more than two decimal places",
+                        tax.TaxAmount));
+                    retval.IsValid = false;
+                }
+
+                // This validator is generally profile and output-format independent. Factur-X 1.08/1.09
+                // FX-SCH-A-000052 accepts the inclusive 1.00 boundary, while current CEN/Peppol
+                // BR-CO-17 uses a strict < 1 boundary. Preserve the inclusive Factur-X behavior used by Delphi.
+                decimal taxDeviation = tax.TaxAmount - expectedTaxAmount;
+                if (Math.Abs(taxDeviation) > 1m)
                 {
                     retval.Messages.Add(String.Format(
                         "BR-CO-17: Berechneter Steuerbetrag ist[{0:0.0000}] aber vorhandener Steuerbetrag ist[{1:0.0000}] bei Bemessungsgrundlage[{2:0.0000}] und Steuersatz[{3:0.0000}]",
                         expectedTaxAmount, tax.TaxAmount, tax.BasisAmount, tax.Percent));
                     retval.IsValid = false;
                 }
+                else if (taxDeviation != 0m)
+                {
+                    retval.Messages.Add(String.Format(
+                        "Note: Declared tax amount [{0:0.0000}] deviates by [{1:0.0000}] from [{2:0.0000}] but remains within the inclusive BR-CO-17 tolerance of one currency unit",
+                        tax.TaxAmount, taxDeviation, expectedTaxAmount));
+                }
             }
+
+            // BR-CO-14 rounds the sum of declared BT-117 values to two decimal places.
+            taxTotal = Math.Round(taxTotal, 2, MidpointRounding.AwayFromZero);
 
             decimal grandTotal = lineTotal - allowanceTotal + taxTotal + chargeTotal;
             decimal prepaid = descriptor.TotalPrepaidAmount.GetValueOrDefault();
@@ -170,8 +207,8 @@ namespace s2industries.ZUGFeRD
             decimal taxBasisTotal = descriptor.GetApplicableTradeTaxes()
                 .Where(tax => tax.TypeCode == TaxTypes.VAT)
                 .Sum(tax => tax.BasisAmount);
-            decimal allowanceTotalSummedPerTradeAllowanceCharge = descriptor.GetTradeAllowances().Sum(a => a.ActualAmount);
-            decimal chargesTotalSummedPerTradeAllowanceCharge = descriptor.GetTradeCharges().Sum(c => c.ActualAmount);
+            decimal declaredAllowanceTotal = descriptor.AllowanceTotalAmount.GetValueOrDefault();
+            decimal declaredChargeTotal = descriptor.ChargeTotalAmount.GetValueOrDefault();
 
             if (!descriptor.TaxTotalAmount.HasValue)
             {
@@ -188,7 +225,12 @@ namespace s2industries.ZUGFeRD
                 retval.IsValid = false;
             }
 
-            if (Math.Abs(lineTotal - descriptor.LineTotalAmount.Value) < 0.01m)
+            if (!descriptor.LineTotalAmount.HasValue)
+            {
+                retval.Messages.Add("trade.settlement.monetarySummation.lineTotal Message: Kein LineTotalAmount vorhanden");
+                retval.IsValid = false;
+            }
+            else if (Math.Abs(lineTotal - descriptor.LineTotalAmount.Value) < 0.01m)
             {
                 retval.Messages.Add(String.Format("trade.settlement.monetarySummation.lineTotal Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", lineTotal));
             }
@@ -248,24 +290,41 @@ namespace s2industries.ZUGFeRD
                 retval.IsValid = false;
             }
 
-            if (Math.Abs(allowanceTotalSummedPerTradeAllowanceCharge - allowanceTotal) < 0.01m)
+            // BR-CO-11/12 compare declared BT-107/108 with the sums of individual document allowances/charges.
+            // Optional declared totals are treated as zero when absent.
+            if (Math.Abs(allowanceTotal - declaredAllowanceTotal) < 0.01m)
             {
-                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.allowanceTotal  Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", allowanceTotalSummedPerTradeAllowanceCharge));
+                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.allowanceTotal  Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", declaredAllowanceTotal));
             }
             else
             {
-                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.allowanceTotal  Message: Berechneter Wert ist[{0:0.0000}] aber tatsächliche vorhander Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", allowanceTotalSummedPerTradeAllowanceCharge, allowanceTotal));
+                retval.Messages.Add(String.Format("BR-CO-11: trade.settlement.monetarySummation.allowanceTotal Message: Berechneter Wert ist[{0:0.0000}] aber tatsächlich vorhandener Wert ist[{1:0.0000}]", allowanceTotal, declaredAllowanceTotal));
                 retval.IsValid = false;
             }
 
-            if (Math.Abs(chargesTotalSummedPerTradeAllowanceCharge - chargeTotal) < 0.01m)
+            if (Math.Abs(chargeTotal - declaredChargeTotal) < 0.01m)
             {
-                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.chargeTotal  Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", chargesTotalSummedPerTradeAllowanceCharge));
+                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.chargeTotal  Message: Berechneter Wert ist wie vorhanden:[{0:0.0000}]", declaredChargeTotal));
             }
             else
             {
-                retval.Messages.Add(String.Format("trade.settlement.monetarySummation.chargeTotal  Message: Berechneter Wert ist[{0:0.0000}] aber tatsächliche vorhander Wert ist[{1:0.0000}] | Actual value: {1:0.0000})", chargesTotalSummedPerTradeAllowanceCharge, chargeTotal));
+                retval.Messages.Add(String.Format("BR-CO-12: trade.settlement.monetarySummation.chargeTotal Message: Berechneter Wert ist[{0:0.0000}] aber tatsächlich vorhandener Wert ist[{1:0.0000}]", chargeTotal, declaredChargeTotal));
                 retval.IsValid = false;
+            }
+
+            // BR-CO-13 requires BT-109 = BT-106 - BT-107 + BT-108.
+            if (descriptor.LineTotalAmount.HasValue && descriptor.TaxBasisAmount.HasValue)
+            {
+                decimal expectedTaxBasis = descriptor.LineTotalAmount.Value - declaredAllowanceTotal + declaredChargeTotal;
+                if (Math.Abs(expectedTaxBasis - descriptor.TaxBasisAmount.Value) < 0.01m)
+                {
+                    retval.Messages.Add(String.Format("BR-CO-13: Tax basis from BT-106 - BT-107 + BT-108 matches [{0:0.0000}]", expectedTaxBasis));
+                }
+                else
+                {
+                    retval.Messages.Add(String.Format("BR-CO-13: Tax basis from BT-106 - BT-107 + BT-108 is [{0:0.0000}] but declared BT-109 is [{1:0.0000}]", expectedTaxBasis, descriptor.TaxBasisAmount.Value));
+                    retval.IsValid = false;
+                }
             }
 
             // version-specific validation


### PR DESCRIPTION
## Summary

This pull request backports invoice validation corrections from the Landrix/MGGM Delphi implementation:

- apply BT-149 price base quantity when validating line net amounts
- report a missing BT-106 instead of throwing while validating monetary totals
- validate declared allowance and charge totals according to BR-CO-11 and BR-CO-12
- validate the tax basis according to BR-CO-13
- calculate BR-CO-14 from the declared VAT category tax amounts
- validate the two-decimal limit from BR-DEC-20
- validate BR-CO-17 per VAT breakdown so opposing deviations cannot cancel each other
- use the inclusive Factur-X 1.08/1.09 tolerance boundary and document the difference from current CEN/Peppol rules

The Documentation Sweep changes from the Delphi repository are intentionally outside the scope of this pull request.

## Background

The validation behavior is based on changes developed in [LandrixSoftware/ZUGFeRD-for-Delphi](https://github.com/LandrixSoftware/ZUGFeRD-for-Delphi) and reviewed for the corresponding EN16931 rules before being ported to C#.

Factur-X 1.08/1.09 rule `FX-SCH-A-000052` accepts an inclusive deviation of 1.00. Current CEN and Peppol BR-CO-17 expressions use strict bounds. The generic validator keeps the Factur-X boundary consistently with the Delphi implementation and documents this decision in the source.

References:

- [CEN EN16931 CII schematron](https://github.com/ConnectingEurope/eInvoicing-EN16931/blob/master/cii/schematron/CII/EN16931-CII-model.sch)
- [Peppol BR-CO-17](https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-CO-17/)

## Tests

- `InvoiceValidatorTests`: 26 passed
- remaining regression tests excluding the unchanged `TestSellerPartyDescription` line-ending case: 351 passed
- library build: 0 errors

No public API changes.
